### PR TITLE
Add two-windings transformer icon

### DIFF
--- a/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -80,9 +80,10 @@ public class NetworkGraphBuilder implements GraphBuilder {
             if (vlNode1.isEmpty() || vlNode2.isEmpty()) {
                 throw new PowsyblException("Cannot add line, voltage level unknown");
             }
+            double nominalV = vlNode1.get().getNominalV();
             graph.addEdge(vlNode1.get(), vlNode2.get(),
-                    new BranchEdge(idProvider.createId(line), line.getId(), line.getNameOrId(),
-                            line.getTerminal1().isConnected(), line.getTerminal2().isConnected()));
+                    new LineEdge(idProvider.createId(line), line.getId(), line.getNameOrId(),
+                            line.getTerminal1().isConnected(), line.getTerminal2().isConnected(), nominalV));
         }
 
         @Override
@@ -91,13 +92,16 @@ public class NetworkGraphBuilder implements GraphBuilder {
             if (graph.containsEdge(twt.getId())) {
                 return;
             }
-            Optional<VoltageLevelNode> vlNode1 = graph.getVoltageLevelNode(twt.getTerminal1().getVoltageLevel().getId());
-            Optional<VoltageLevelNode> vlNode2 = graph.getVoltageLevelNode(twt.getTerminal2().getVoltageLevel().getId());
+            VoltageLevel vl1 = twt.getTerminal1().getVoltageLevel();
+            VoltageLevel vl2 = twt.getTerminal2().getVoltageLevel();
+            Optional<VoltageLevelNode> vlNode1 = graph.getVoltageLevelNode(vl1.getId());
+            Optional<VoltageLevelNode> vlNode2 = graph.getVoltageLevelNode(vl2.getId());
             if (vlNode1.isEmpty() || vlNode2.isEmpty()) {
                 throw new PowsyblException("Cannot add line, one voltage level unknown");
             }
-            BranchEdge edge = new BranchEdge(idProvider.createId(twt), twt.getId(), twt.getNameOrId(),
-                    twt.getTerminal1().isConnected(), twt.getTerminal2().isConnected());
+            AbstractBranchEdge edge = new TwoWtEdge(idProvider.createId(twt), twt.getId(), twt.getNameOrId(),
+                    twt.getTerminal1().isConnected(), twt.getTerminal2().isConnected(),
+                    vl1.getNominalV(), vl2.getNominalV());
             graph.addEdge(vlNode1.get(), vlNode2.get(), edge);
         }
 
@@ -117,9 +121,9 @@ public class NetworkGraphBuilder implements GraphBuilder {
             String twtId = twt.getId();
             String twtName = twt.getNameOrId();
             TransformerNode tn = new TransformerNode(idProvider.createId(twt), twtId, twtName);
-            graph.addEdge(vlNode1.get(), tn, new TransformerEdge(idProvider.createId(twt.getLeg1()), twtId + LEG1_SUFFIX, twtName, twt.getLeg1().getTerminal().isConnected()));
-            graph.addEdge(vlNode2.get(), tn, new TransformerEdge(idProvider.createId(twt.getLeg2()), twtId + LEG2_SUFFIX, twtName, twt.getLeg2().getTerminal().isConnected()));
-            graph.addEdge(vlNode3.get(), tn, new TransformerEdge(idProvider.createId(twt.getLeg3()), twtId + LEG3_SUFFIX, twtName, twt.getLeg3().getTerminal().isConnected()));
+            graph.addEdge(vlNode1.get(), tn, new ThreeWtEdge(idProvider.createId(twt.getLeg1()), twtId + LEG1_SUFFIX, twtName, twt.getLeg1().getTerminal().isConnected()));
+            graph.addEdge(vlNode2.get(), tn, new ThreeWtEdge(idProvider.createId(twt.getLeg2()), twtId + LEG2_SUFFIX, twtName, twt.getLeg2().getTerminal().isConnected()));
+            graph.addEdge(vlNode3.get(), tn, new ThreeWtEdge(idProvider.createId(twt.getLeg3()), twtId + LEG3_SUFFIX, twtName, twt.getLeg3().getTerminal().isConnected()));
         }
     }
 }

--- a/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
@@ -9,11 +9,11 @@ package com.powsybl.nad.model;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class BranchEdge extends AbstractEdge {
+public abstract class AbstractBranchEdge extends AbstractEdge {
     private final boolean side1Connected;
     private final boolean side2Connected;
 
-    public BranchEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected) {
+    public AbstractBranchEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected) {
         super(diagramId, equipmentId, nameOrId);
         this.side1Connected = side1Connected;
         this.side2Connected = side2Connected;

--- a/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
@@ -13,7 +13,7 @@ public abstract class AbstractBranchEdge extends AbstractEdge {
     private final boolean side1Connected;
     private final boolean side2Connected;
 
-    public AbstractBranchEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected) {
+    protected AbstractBranchEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected) {
         super(diagramId, equipmentId, nameOrId);
         this.side1Connected = side1Connected;
         this.side2Connected = side2Connected;

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -59,6 +59,10 @@ public class Graph {
         return edges.values().stream();
     }
 
+    public Collection<Edge> getEdges() {
+        return Collections.unmodifiableCollection(edges.values());
+    }
+
     public Stream<Edge> getNonMultiEdgesStream() {
         return edges.values().stream()
                 .filter(e -> jgrapht.getAllEdges(jgrapht.getEdgeSource(e), jgrapht.getEdgeTarget(e)).size() == 1);

--- a/src/main/java/com/powsybl/nad/model/LineEdge.java
+++ b/src/main/java/com/powsybl/nad/model/LineEdge.java
@@ -1,0 +1,15 @@
+package com.powsybl.nad.model;
+
+public class LineEdge extends AbstractBranchEdge {
+
+    private final double nominalV;
+
+    public LineEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected, double nominalV) {
+        super(diagramId, equipmentId, nameOrId, side1Connected, side2Connected);
+        this.nominalV = nominalV;
+    }
+
+    public double getNominalV() {
+        return nominalV;
+    }
+}

--- a/src/main/java/com/powsybl/nad/model/Point.java
+++ b/src/main/java/com/powsybl/nad/model/Point.java
@@ -62,4 +62,10 @@ public class Point {
     public void setX(double x) {
         this.x = x;
     }
+
+    public Point atDistance(double dist, Point direction) {
+        double r = dist / distance(direction);
+        return new Point(x + r * (direction.x - x),
+                y + r * (direction.y - y));
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
+++ b/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
@@ -9,10 +9,10 @@ package com.powsybl.nad.model;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class TransformerEdge extends AbstractEdge {
+public class ThreeWtEdge extends AbstractEdge {
     private final boolean connected;
 
-    public TransformerEdge(String diagramId, String transformerId, String transformerName, boolean connected) {
+    public ThreeWtEdge(String diagramId, String transformerId, String transformerName, boolean connected) {
         super(diagramId, transformerId, transformerName);
         this.connected = connected;
     }

--- a/src/main/java/com/powsybl/nad/model/TwoWtEdge.java
+++ b/src/main/java/com/powsybl/nad/model/TwoWtEdge.java
@@ -1,0 +1,26 @@
+package com.powsybl.nad.model;
+
+public class TwoWtEdge extends AbstractBranchEdge {
+
+    private final double nominalV1;
+    private final double nominalV2;
+
+    public TwoWtEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected,
+                     double nominalV1, double nominalV2) {
+        super(diagramId, equipmentId, nameOrId, side1Connected, side2Connected);
+        this.nominalV1 = nominalV1;
+        this.nominalV2 = nominalV2;
+    }
+
+    public double getNominalV1() {
+        return nominalV1;
+    }
+
+    public double getNominalV2() {
+        return nominalV2;
+    }
+
+    public double getNominalV(Side side) {
+        return side == Side.ONE ? nominalV1 : nominalV2;
+    }
+}

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -90,14 +90,14 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     @Override
     public List<String> getSideEdgeStyleClasses(Edge edge, Edge.Side side) {
         Objects.requireNonNull(side);
+        List<String> result = new ArrayList<>();
         if (edge instanceof AbstractBranchEdge && !((AbstractBranchEdge) edge).isConnected(side)) {
-            return Collections.singletonList(DISCONNECTED_SIDE_EDGE_CLASS);
+            result.add(DISCONNECTED_SIDE_EDGE_CLASS);
         }
         if (edge instanceof TwoWtEdge) {
-            return getBaseVoltageStyle(((TwoWtEdge) edge).getNominalV(side))
-                    .map(Collections::singletonList).orElse(Collections.emptyList());
+            getBaseVoltageStyle(((TwoWtEdge) edge).getNominalV(side)).ifPresent(result::add);
         }
-        return Collections.emptyList();
+        return result;
     }
 
     private Optional<String> getBaseVoltageStyle(double nominalV) {

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -7,20 +7,14 @@
 package com.powsybl.nad.svg;
 
 import com.powsybl.commons.config.BaseVoltagesConfig;
-import com.powsybl.nad.model.BranchEdge;
-import com.powsybl.nad.model.Edge;
-import com.powsybl.nad.model.Node;
-import com.powsybl.nad.model.VoltageLevelNode;
+import com.powsybl.nad.model.*;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -69,8 +63,7 @@ public abstract class AbstractStyleProvider implements StyleProvider {
         List<String> styles = new ArrayList<>();
         if (node instanceof VoltageLevelNode) {
             double nominalV = ((VoltageLevelNode) node).getNominalV();
-            baseVoltagesConfig.getBaseVoltageName(nominalV, baseVoltagesConfig.getDefaultProfile())
-                    .ifPresent(styles::add);
+            getBaseVoltageStyle(nominalV).ifPresent(styles::add);
         }
         return styles;
     }
@@ -86,11 +79,29 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
-    public List<String> getSideEdgeStyleClasses(Edge edge, Edge.Side side) {
-        Objects.requireNonNull(side);
-        if (edge instanceof BranchEdge && !((BranchEdge) edge).isConnected(side)) {
-            return Collections.singletonList(DISCONNECTED_SIDE_EDGE_CLASS);
+    public List<String> getEdgeStyleClasses(Edge edge) {
+        if (edge instanceof LineEdge) {
+            return getBaseVoltageStyle(((LineEdge) edge).getNominalV())
+                    .map(Collections::singletonList).orElse(Collections.emptyList());
         }
         return Collections.emptyList();
     }
+
+    @Override
+    public List<String> getSideEdgeStyleClasses(Edge edge, Edge.Side side) {
+        Objects.requireNonNull(side);
+        if (edge instanceof AbstractBranchEdge && !((AbstractBranchEdge) edge).isConnected(side)) {
+            return Collections.singletonList(DISCONNECTED_SIDE_EDGE_CLASS);
+        }
+        if (edge instanceof TwoWtEdge) {
+            return getBaseVoltageStyle(((TwoWtEdge) edge).getNominalV(side))
+                    .map(Collections::singletonList).orElse(Collections.emptyList());
+        }
+        return Collections.emptyList();
+    }
+
+    private Optional<String> getBaseVoltageStyle(double nominalV) {
+        return baseVoltagesConfig.getBaseVoltageName(nominalV, baseVoltagesConfig.getDefaultProfile());
+    }
+
 }

--- a/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
@@ -7,7 +7,6 @@
 package com.powsybl.nad.svg;
 
 import com.powsybl.commons.config.BaseVoltagesConfig;
-import com.powsybl.nad.model.Edge;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,11 +27,6 @@ public class DefaultStyleProvider extends AbstractStyleProvider {
     @Override
     public List<String> getCssFilenames() {
         return Collections.singletonList("defaultStyle.css");
-    }
-
-    @Override
-    public List<String> getEdgeStyleClasses(Edge edge) {
-        return Collections.emptyList();
     }
 
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -45,6 +45,7 @@ public class SvgWriter {
     private static final String TITLE_ATTRIBUTE = "title";
     private static final String CLASS_ATTRIBUTE = "class";
     private static final String TRANSFORM_ATTRIBUTE = "transform";
+    public static final String CIRCLE_RADIUS_ATTRIBUTE = "r";
     private static final double CIRCLE_RADIUS = 0.6;
     private static final double TRANSFORMER_CIRCLE_RADIUS = 0.2;
 
@@ -127,19 +128,19 @@ public class SvgWriter {
                 .collect(Collectors.joining(" "));
         writer.writeAttribute("points", lineFormatted1);
         if (edge instanceof TwoWtEdge) {
-            drawTransformer(writer, (TwoWtEdge) edge, half);
+            drawTransformer(writer, half);
         }
         writer.writeEndElement();
     }
 
-    private void drawTransformer(XMLStreamWriter writer, TwoWtEdge edge, List<Point> half) throws XMLStreamException {
+    private void drawTransformer(XMLStreamWriter writer, List<Point> half) throws XMLStreamException {
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
         Point point1 = half.get(half.size() - 1); // point in the middle
         Point point2 = half.get(half.size() - 2); // point before
         Point circleCenter = point1.atDistance(TRANSFORMER_CIRCLE_RADIUS / 2, point2);
         writer.writeAttribute("cx", getFormattedValue(circleCenter.getX()));
         writer.writeAttribute("cy", getFormattedValue(circleCenter.getY()));
-        writer.writeAttribute("r", getFormattedValue(TRANSFORMER_CIRCLE_RADIUS));
+        writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(TRANSFORMER_CIRCLE_RADIUS));
     }
 
     private void drawNodes(Graph graph, XMLStreamWriter writer) throws XMLStreamException {
@@ -161,7 +162,7 @@ public class SvgWriter {
         writer.writeAttribute(ID_ATTRIBUTE, vlNode.getDiagramId());
         writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ", styleProvider.getNodeStyleClasses(vlNode)));
         insertName(writer, vlNode::getName);
-        writer.writeAttribute("r", getFormattedValue(CIRCLE_RADIUS));
+        writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(CIRCLE_RADIUS));
     }
 
     private void writeNbBuses(XMLStreamWriter writer, VoltageLevelNode vlNode) throws XMLStreamException {

--- a/src/main/resources/defaultStyle.css
+++ b/src/main/resources/defaultStyle.css
@@ -1,11 +1,12 @@
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}

--- a/src/test/java/com/powsybl/nad/SvgWriterTest.java
+++ b/src/test/java/com/powsybl/nad/SvgWriterTest.java
@@ -56,6 +56,7 @@ class SvgWriterTest extends AbstractTest {
     void testDisconnection() {
         Network network = IeeeCdfNetworkFactory.create14();
         network.getLine("L3-4-1").getTerminal1().disconnect();
+        network.getTwoWindingsTransformer("T4-7-1").getTerminal1().disconnect();
         assertEquals(toString("/IEEE_14_bus_disconnection.svg"), generateSvgString(network, "/IEEE_14_bus_disconnection.svg"));
     }
 

--- a/src/test/java/com/powsybl/nad/SvgWriterTest.java
+++ b/src/test/java/com/powsybl/nad/SvgWriterTest.java
@@ -53,6 +53,13 @@ class SvgWriterTest extends AbstractTest {
     }
 
     @Test
+    void testDisconnection() {
+        Network network = IeeeCdfNetworkFactory.create14();
+        network.getLine("L3-4-1").getTerminal1().disconnect();
+        assertEquals(toString("/IEEE_14_bus_disconnection.svg"), generateSvgString(network, "/IEEE_14_bus_disconnection.svg"));
+    }
+
+    @Test
     void testIEEE24() {
         Network network = NetworkXml.read(getClass().getResourceAsStream("/IEEE_24_bus.xiidm"));
         assertEquals(toString("/IEEE_24_bus.svg"), generateSvgString(network, "/IEEE_24_bus.svg"));

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -1,763 +1,1526 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="725.76" viewBox="-27.41 -26.21 56.44 51.20" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
     <g class="nad-edges">
-        <g id="236" title="L1-2-1">
-            <polyline points="27.03,10.72 26.59,9.59"/>
-            <polyline points="26.15,8.45 26.59,9.59"/>
+        <g id="236" class="nad-vl120to180" title="L1-2-1">
+            <g>
+                <polyline points="27.03,10.72 26.59,9.59"/>
+            </g>
+            <g>
+                <polyline points="26.15,8.45 26.59,9.59"/>
+            </g>
         </g>
-        <g id="237" title="L1-3-1">
-            <polyline points="27.03,10.72 25.45,10.47"/>
-            <polyline points="23.87,10.22 25.45,10.47"/>
+        <g id="237" class="nad-vl120to180" title="L1-3-1">
+            <g>
+                <polyline points="27.03,10.72 25.45,10.47"/>
+            </g>
+            <g>
+                <polyline points="23.87,10.22 25.45,10.47"/>
+            </g>
         </g>
-        <g id="238" title="L2-12-1">
-            <polyline points="26.15,8.45 24.53,8.51"/>
-            <polyline points="22.90,8.56 24.53,8.51"/>
+        <g id="238" class="nad-vl120to180" title="L2-12-1">
+            <g>
+                <polyline points="26.15,8.45 24.53,8.51"/>
+            </g>
+            <g>
+                <polyline points="22.90,8.56 24.53,8.51"/>
+            </g>
         </g>
-        <g id="239" title="L3-5-1">
-            <polyline points="23.87,10.22 22.06,10.56"/>
-            <polyline points="20.26,10.90 22.06,10.56"/>
+        <g id="239" class="nad-vl120to180" title="L3-5-1">
+            <g>
+                <polyline points="23.87,10.22 22.06,10.56"/>
+            </g>
+            <g>
+                <polyline points="20.26,10.90 22.06,10.56"/>
+            </g>
         </g>
-        <g id="240" title="L3-12-1">
-            <polyline points="23.87,10.22 23.38,9.39"/>
-            <polyline points="22.90,8.56 23.38,9.39"/>
+        <g id="240" class="nad-vl120to180" title="L3-12-1">
+            <g>
+                <polyline points="23.87,10.22 23.38,9.39"/>
+            </g>
+            <g>
+                <polyline points="22.90,8.56 23.38,9.39"/>
+            </g>
         </g>
-        <g id="241" title="L4-5-1">
-            <polyline points="22.56,13.16 21.41,12.03"/>
-            <polyline points="20.26,10.90 21.41,12.03"/>
+        <g id="241" class="nad-vl120to180" title="L4-5-1">
+            <g>
+                <polyline points="22.56,13.16 21.41,12.03"/>
+            </g>
+            <g>
+                <polyline points="20.26,10.90 21.41,12.03"/>
+            </g>
         </g>
-        <g id="242" title="L4-11-1">
-            <polyline points="22.56,13.16 21.23,12.85"/>
-            <polyline points="19.91,12.54 21.23,12.85"/>
+        <g id="242" class="nad-vl120to180" title="L4-11-1">
+            <g>
+                <polyline points="22.56,13.16 21.23,12.85"/>
+            </g>
+            <g>
+                <polyline points="19.91,12.54 21.23,12.85"/>
+            </g>
         </g>
-        <g id="243" title="L5-6-1">
-            <polyline points="20.26,10.90 20.61,8.56"/>
-            <polyline points="20.96,6.22 20.61,8.56"/>
+        <g id="243" class="nad-vl120to180" title="L5-6-1">
+            <g>
+                <polyline points="20.26,10.90 20.61,8.56"/>
+            </g>
+            <g>
+                <polyline points="20.96,6.22 20.61,8.56"/>
+            </g>
         </g>
         <g id="244" title="T8-5-1">
-            <polyline points="15.05,11.34 17.65,11.12"/>
-            <polyline points="20.26,10.90 17.65,11.12"/>
+            <g class="nad-vl120to180">
+                <polyline points="15.05,11.34 17.65,11.12"/>
+                <circle cx="17.55" cy="11.13" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="20.26,10.90 17.65,11.12"/>
+                <circle cx="17.75" cy="11.11" r="0.20"/>
+            </g>
         </g>
-        <g id="245" title="L5-11-1">
-            <polyline points="20.26,10.90 20.08,11.72"/>
-            <polyline points="19.91,12.54 20.08,11.72"/>
+        <g id="245" class="nad-vl120to180" title="L5-11-1">
+            <g>
+                <polyline points="20.26,10.90 20.08,11.72"/>
+            </g>
+            <g>
+                <polyline points="19.91,12.54 20.08,11.72"/>
+            </g>
         </g>
-        <g id="246" title="L6-7-1">
-            <polyline points="20.96,6.22 21.87,5.57"/>
-            <polyline points="22.79,4.92 21.87,5.57"/>
+        <g id="246" class="nad-vl120to180" title="L6-7-1">
+            <g>
+                <polyline points="20.96,6.22 21.87,5.57"/>
+            </g>
+            <g>
+                <polyline points="22.79,4.92 21.87,5.57"/>
+            </g>
         </g>
-        <g id="247" title="L7-12-1">
-            <polyline points="22.79,4.92 22.84,6.74"/>
-            <polyline points="22.90,8.56 22.84,6.74"/>
+        <g id="247" class="nad-vl120to180" title="L7-12-1">
+            <g>
+                <polyline points="22.79,4.92 22.84,6.74"/>
+            </g>
+            <g>
+                <polyline points="22.90,8.56 22.84,6.74"/>
+            </g>
         </g>
-        <g id="248" title="L8-9-1">
-            <polyline points="15.05,11.34 15.08,13.64"/>
-            <polyline points="15.12,15.94 15.08,13.64"/>
+        <g id="248" class="nad-vl120to180" title="L8-9-1">
+            <g>
+                <polyline points="15.05,11.34 15.08,13.64"/>
+            </g>
+            <g>
+                <polyline points="15.12,15.94 15.08,13.64"/>
+            </g>
         </g>
-        <g id="249" title="L8-30-1">
-            <polyline points="15.05,11.34 12.97,9.22"/>
-            <polyline points="10.89,7.10 12.97,9.22"/>
+        <g id="249" class="nad-vl120to180" title="L8-30-1">
+            <g>
+                <polyline points="15.05,11.34 12.97,9.22"/>
+            </g>
+            <g>
+                <polyline points="10.89,7.10 12.97,9.22"/>
+            </g>
         </g>
-        <g id="250" title="L9-10-1">
-            <polyline points="15.12,15.94 15.29,17.46"/>
-            <polyline points="15.46,18.97 15.29,17.46"/>
+        <g id="250" class="nad-vl120to180" title="L9-10-1">
+            <g>
+                <polyline points="15.12,15.94 15.29,17.46"/>
+            </g>
+            <g>
+                <polyline points="15.46,18.97 15.29,17.46"/>
+            </g>
         </g>
-        <g id="251" title="L11-12-1">
-            <polyline points="19.91,12.54 21.41,10.55"/>
-            <polyline points="22.90,8.56 21.41,10.55"/>
+        <g id="251" class="nad-vl120to180" title="L11-12-1">
+            <g>
+                <polyline points="19.91,12.54 21.41,10.55"/>
+            </g>
+            <g>
+                <polyline points="22.90,8.56 21.41,10.55"/>
+            </g>
         </g>
-        <g id="252" title="L11-13-1">
-            <polyline points="19.91,12.54 18.68,12.43"/>
-            <polyline points="17.46,12.32 18.68,12.43"/>
+        <g id="252" class="nad-vl120to180" title="L11-13-1">
+            <g>
+                <polyline points="19.91,12.54 18.68,12.43"/>
+            </g>
+            <g>
+                <polyline points="17.46,12.32 18.68,12.43"/>
+            </g>
         </g>
-        <g id="253" title="L12-14-1">
-            <polyline points="22.90,8.56 20.32,8.68"/>
-            <polyline points="17.73,8.79 20.32,8.68"/>
+        <g id="253" class="nad-vl120to180" title="L12-14-1">
+            <g>
+                <polyline points="22.90,8.56 20.32,8.68"/>
+            </g>
+            <g>
+                <polyline points="17.73,8.79 20.32,8.68"/>
+            </g>
         </g>
-        <g id="254" title="L12-16-1">
-            <polyline points="22.90,8.56 20.76,6.97"/>
-            <polyline points="18.62,5.39 20.76,6.97"/>
+        <g id="254" class="nad-vl120to180" title="L12-16-1">
+            <g>
+                <polyline points="22.90,8.56 20.76,6.97"/>
+            </g>
+            <g>
+                <polyline points="18.62,5.39 20.76,6.97"/>
+            </g>
         </g>
-        <g id="255" title="L12-117-1">
-            <polyline points="22.90,8.56 24.32,6.98"/>
-            <polyline points="25.75,5.39 24.32,6.98"/>
+        <g id="255" class="nad-vl120to180" title="L12-117-1">
+            <g>
+                <polyline points="22.90,8.56 24.32,6.98"/>
+            </g>
+            <g>
+                <polyline points="25.75,5.39 24.32,6.98"/>
+            </g>
         </g>
-        <g id="256" title="L13-15-1">
-            <polyline points="17.46,12.32 15.55,10.97"/>
-            <polyline points="13.64,9.63 15.55,10.97"/>
+        <g id="256" class="nad-vl120to180" title="L13-15-1">
+            <g>
+                <polyline points="17.46,12.32 15.55,10.97"/>
+            </g>
+            <g>
+                <polyline points="13.64,9.63 15.55,10.97"/>
+            </g>
         </g>
-        <g id="257" title="L14-15-1">
-            <polyline points="17.73,8.79 15.69,9.21"/>
-            <polyline points="13.64,9.63 15.69,9.21"/>
+        <g id="257" class="nad-vl120to180" title="L14-15-1">
+            <g>
+                <polyline points="17.73,8.79 15.69,9.21"/>
+            </g>
+            <g>
+                <polyline points="13.64,9.63 15.69,9.21"/>
+            </g>
         </g>
-        <g id="258" title="L15-17-1">
-            <polyline points="13.64,9.63 14.14,7.15"/>
-            <polyline points="14.65,4.68 14.14,7.15"/>
+        <g id="258" class="nad-vl120to180" title="L15-17-1">
+            <g>
+                <polyline points="13.64,9.63 14.14,7.15"/>
+            </g>
+            <g>
+                <polyline points="14.65,4.68 14.14,7.15"/>
+            </g>
         </g>
-        <g id="259" title="L15-19-1">
-            <polyline points="13.64,9.63 11.63,9.46"/>
-            <polyline points="9.62,9.30 11.63,9.46"/>
+        <g id="259" class="nad-vl120to180" title="L15-19-1">
+            <g>
+                <polyline points="13.64,9.63 11.63,9.46"/>
+            </g>
+            <g>
+                <polyline points="9.62,9.30 11.63,9.46"/>
+            </g>
         </g>
-        <g id="260" title="L15-33-1">
-            <polyline points="13.64,9.63 11.54,11.17"/>
-            <polyline points="9.43,12.71 11.54,11.17"/>
+        <g id="260" class="nad-vl120to180" title="L15-33-1">
+            <g>
+                <polyline points="13.64,9.63 11.54,11.17"/>
+            </g>
+            <g>
+                <polyline points="9.43,12.71 11.54,11.17"/>
+            </g>
         </g>
-        <g id="261" title="L16-17-1">
-            <polyline points="18.62,5.39 16.63,5.03"/>
-            <polyline points="14.65,4.68 16.63,5.03"/>
+        <g id="261" class="nad-vl120to180" title="L16-17-1">
+            <g>
+                <polyline points="18.62,5.39 16.63,5.03"/>
+            </g>
+            <g>
+                <polyline points="14.65,4.68 16.63,5.03"/>
+            </g>
         </g>
-        <g id="262" title="L17-18-1">
-            <polyline points="14.65,4.68 13.57,5.79"/>
-            <polyline points="12.49,6.90 13.57,5.79"/>
+        <g id="262" class="nad-vl120to180" title="L17-18-1">
+            <g>
+                <polyline points="14.65,4.68 13.57,5.79"/>
+            </g>
+            <g>
+                <polyline points="12.49,6.90 13.57,5.79"/>
+            </g>
         </g>
         <g id="263" title="T30-17-1">
-            <polyline points="10.89,7.10 12.77,5.89"/>
-            <polyline points="14.65,4.68 12.77,5.89"/>
+            <g class="nad-vl120to180">
+                <polyline points="10.89,7.10 12.77,5.89"/>
+                <circle cx="12.68" cy="5.95" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="14.65,4.68 12.77,5.89"/>
+                <circle cx="12.85" cy="5.84" r="0.20"/>
+            </g>
         </g>
-        <g id="264" title="L17-31-1">
-            <polyline points="14.65,4.68 15.77,2.06"/>
-            <polyline points="16.89,-0.57 15.77,2.06"/>
+        <g id="264" class="nad-vl120to180" title="L17-31-1">
+            <g>
+                <polyline points="14.65,4.68 15.77,2.06"/>
+            </g>
+            <g>
+                <polyline points="16.89,-0.57 15.77,2.06"/>
+            </g>
         </g>
-        <g id="265" title="L17-113-1">
-            <polyline points="14.65,4.68 14.67,2.74"/>
-            <polyline points="14.70,0.80 14.67,2.74"/>
+        <g id="265" class="nad-vl120to180" title="L17-113-1">
+            <g>
+                <polyline points="14.65,4.68 14.67,2.74"/>
+            </g>
+            <g>
+                <polyline points="14.70,0.80 14.67,2.74"/>
+            </g>
         </g>
-        <g id="266" title="L18-19-1">
-            <polyline points="12.49,6.90 11.05,8.10"/>
-            <polyline points="9.62,9.30 11.05,8.10"/>
+        <g id="266" class="nad-vl120to180" title="L18-19-1">
+            <g>
+                <polyline points="12.49,6.90 11.05,8.10"/>
+            </g>
+            <g>
+                <polyline points="9.62,9.30 11.05,8.10"/>
+            </g>
         </g>
-        <g id="267" title="L19-20-1">
-            <polyline points="9.62,9.30 8.51,7.71"/>
-            <polyline points="7.39,6.12 8.51,7.71"/>
+        <g id="267" class="nad-vl120to180" title="L19-20-1">
+            <g>
+                <polyline points="9.62,9.30 8.51,7.71"/>
+            </g>
+            <g>
+                <polyline points="7.39,6.12 8.51,7.71"/>
+            </g>
         </g>
-        <g id="268" title="L19-34-1">
-            <polyline points="9.62,9.30 7.99,10.97"/>
-            <polyline points="6.37,12.65 7.99,10.97"/>
+        <g id="268" class="nad-vl120to180" title="L19-34-1">
+            <g>
+                <polyline points="9.62,9.30 7.99,10.97"/>
+            </g>
+            <g>
+                <polyline points="6.37,12.65 7.99,10.97"/>
+            </g>
         </g>
-        <g id="269" title="L20-21-1">
-            <polyline points="7.39,6.12 7.21,4.46"/>
-            <polyline points="7.02,2.80 7.21,4.46"/>
+        <g id="269" class="nad-vl120to180" title="L20-21-1">
+            <g>
+                <polyline points="7.39,6.12 7.21,4.46"/>
+            </g>
+            <g>
+                <polyline points="7.02,2.80 7.21,4.46"/>
+            </g>
         </g>
-        <g id="270" title="L21-22-1">
-            <polyline points="7.02,2.80 7.56,1.24"/>
-            <polyline points="8.09,-0.32 7.56,1.24"/>
+        <g id="270" class="nad-vl120to180" title="L21-22-1">
+            <g>
+                <polyline points="7.02,2.80 7.56,1.24"/>
+            </g>
+            <g>
+                <polyline points="8.09,-0.32 7.56,1.24"/>
+            </g>
         </g>
-        <g id="271" title="L22-23-1">
-            <polyline points="8.09,-0.32 8.92,-1.67"/>
-            <polyline points="9.74,-3.02 8.92,-1.67"/>
+        <g id="271" class="nad-vl120to180" title="L22-23-1">
+            <g>
+                <polyline points="8.09,-0.32 8.92,-1.67"/>
+            </g>
+            <g>
+                <polyline points="9.74,-3.02 8.92,-1.67"/>
+            </g>
         </g>
-        <g id="272" title="L23-24-1">
-            <polyline points="9.74,-3.02 7.58,-3.33"/>
-            <polyline points="5.43,-3.64 7.58,-3.33"/>
+        <g id="272" class="nad-vl120to180" title="L23-24-1">
+            <g>
+                <polyline points="9.74,-3.02 7.58,-3.33"/>
+            </g>
+            <g>
+                <polyline points="5.43,-3.64 7.58,-3.33"/>
+            </g>
         </g>
-        <g id="273" title="L23-25-1">
-            <polyline points="9.74,-3.02 10.98,-2.53"/>
-            <polyline points="12.21,-2.05 10.98,-2.53"/>
+        <g id="273" class="nad-vl120to180" title="L23-25-1">
+            <g>
+                <polyline points="9.74,-3.02 10.98,-2.53"/>
+            </g>
+            <g>
+                <polyline points="12.21,-2.05 10.98,-2.53"/>
+            </g>
         </g>
-        <g id="274" title="L23-32-1">
-            <polyline points="9.74,-3.02 12.00,-3.11"/>
-            <polyline points="14.25,-3.21 12.00,-3.11"/>
+        <g id="274" class="nad-vl120to180" title="L23-32-1">
+            <g>
+                <polyline points="9.74,-3.02 12.00,-3.11"/>
+            </g>
+            <g>
+                <polyline points="14.25,-3.21 12.00,-3.11"/>
+            </g>
         </g>
-        <g id="275" title="L24-70-1">
-            <polyline points="5.43,-3.64 2.78,-3.25"/>
-            <polyline points="0.13,-2.86 2.78,-3.25"/>
+        <g id="275" class="nad-vl120to180" title="L24-70-1">
+            <g>
+                <polyline points="5.43,-3.64 2.78,-3.25"/>
+            </g>
+            <g>
+                <polyline points="0.13,-2.86 2.78,-3.25"/>
+            </g>
         </g>
-        <g id="276" title="L24-72-1">
-            <polyline points="5.43,-3.64 5.39,-5.00"/>
-            <polyline points="5.34,-6.36 5.39,-5.00"/>
+        <g id="276" class="nad-vl120to180" title="L24-72-1">
+            <g>
+                <polyline points="5.43,-3.64 5.39,-5.00"/>
+            </g>
+            <g>
+                <polyline points="5.34,-6.36 5.39,-5.00"/>
+            </g>
         </g>
         <g id="277" title="T26-25-1">
-            <polyline points="11.13,2.34 11.67,0.15"/>
-            <polyline points="12.21,-2.05 11.67,0.15"/>
+            <g class="nad-vl120to180">
+                <polyline points="11.13,2.34 11.67,0.15"/>
+                <circle cx="11.65" cy="0.24" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="12.21,-2.05 11.67,0.15"/>
+                <circle cx="11.70" cy="0.05" r="0.20"/>
+            </g>
         </g>
-        <g id="278" title="L25-27-1">
-            <polyline points="12.21,-2.05 13.94,-3.69"/>
-            <polyline points="15.67,-5.34 13.94,-3.69"/>
+        <g id="278" class="nad-vl120to180" title="L25-27-1">
+            <g>
+                <polyline points="12.21,-2.05 13.94,-3.69"/>
+            </g>
+            <g>
+                <polyline points="15.67,-5.34 13.94,-3.69"/>
+            </g>
         </g>
-        <g id="279" title="L26-30-1">
-            <polyline points="11.13,2.34 11.01,4.72"/>
-            <polyline points="10.89,7.10 11.01,4.72"/>
+        <g id="279" class="nad-vl120to180" title="L26-30-1">
+            <g>
+                <polyline points="11.13,2.34 11.01,4.72"/>
+            </g>
+            <g>
+                <polyline points="10.89,7.10 11.01,4.72"/>
+            </g>
         </g>
-        <g id="280" title="L27-28-1">
-            <polyline points="15.67,-5.34 17.27,-5.62"/>
-            <polyline points="18.87,-5.91 17.27,-5.62"/>
+        <g id="280" class="nad-vl120to180" title="L27-28-1">
+            <g>
+                <polyline points="15.67,-5.34 17.27,-5.62"/>
+            </g>
+            <g>
+                <polyline points="18.87,-5.91 17.27,-5.62"/>
+            </g>
         </g>
-        <g id="281" title="L27-32-1">
-            <polyline points="15.67,-5.34 14.96,-4.27"/>
-            <polyline points="14.25,-3.21 14.96,-4.27"/>
+        <g id="281" class="nad-vl120to180" title="L27-32-1">
+            <g>
+                <polyline points="15.67,-5.34 14.96,-4.27"/>
+            </g>
+            <g>
+                <polyline points="14.25,-3.21 14.96,-4.27"/>
+            </g>
         </g>
-        <g id="282" title="L27-115-1">
-            <polyline points="15.67,-5.34 15.65,-6.96"/>
-            <polyline points="15.63,-8.59 15.65,-6.96"/>
+        <g id="282" class="nad-vl120to180" title="L27-115-1">
+            <g>
+                <polyline points="15.67,-5.34 15.65,-6.96"/>
+            </g>
+            <g>
+                <polyline points="15.63,-8.59 15.65,-6.96"/>
+            </g>
         </g>
-        <g id="283" title="L28-29-1">
-            <polyline points="18.87,-5.91 19.14,-4.57"/>
-            <polyline points="19.41,-3.24 19.14,-4.57"/>
+        <g id="283" class="nad-vl120to180" title="L28-29-1">
+            <g>
+                <polyline points="18.87,-5.91 19.14,-4.57"/>
+            </g>
+            <g>
+                <polyline points="19.41,-3.24 19.14,-4.57"/>
+            </g>
         </g>
-        <g id="284" title="L29-31-1">
-            <polyline points="19.41,-3.24 18.15,-1.90"/>
-            <polyline points="16.89,-0.57 18.15,-1.90"/>
+        <g id="284" class="nad-vl120to180" title="L29-31-1">
+            <g>
+                <polyline points="19.41,-3.24 18.15,-1.90"/>
+            </g>
+            <g>
+                <polyline points="16.89,-0.57 18.15,-1.90"/>
+            </g>
         </g>
-        <g id="285" title="L30-38-1">
-            <polyline points="10.89,7.10 8.05,8.78"/>
-            <polyline points="5.22,10.46 8.05,8.78"/>
+        <g id="285" class="nad-vl120to180" title="L30-38-1">
+            <g>
+                <polyline points="10.89,7.10 8.05,8.78"/>
+            </g>
+            <g>
+                <polyline points="5.22,10.46 8.05,8.78"/>
+            </g>
         </g>
-        <g id="286" title="L31-32-1">
-            <polyline points="16.89,-0.57 15.57,-1.89"/>
-            <polyline points="14.25,-3.21 15.57,-1.89"/>
+        <g id="286" class="nad-vl120to180" title="L31-32-1">
+            <g>
+                <polyline points="16.89,-0.57 15.57,-1.89"/>
+            </g>
+            <g>
+                <polyline points="14.25,-3.21 15.57,-1.89"/>
+            </g>
         </g>
-        <g id="287" title="L32-113-1">
-            <polyline points="14.25,-3.21 14.48,-1.20"/>
-            <polyline points="14.70,0.80 14.48,-1.20"/>
+        <g id="287" class="nad-vl120to180" title="L32-113-1">
+            <g>
+                <polyline points="14.25,-3.21 14.48,-1.20"/>
+            </g>
+            <g>
+                <polyline points="14.70,0.80 14.48,-1.20"/>
+            </g>
         </g>
-        <g id="288" title="L32-114-1">
-            <polyline points="14.25,-3.21 14.01,-5.13"/>
-            <polyline points="13.77,-7.06 14.01,-5.13"/>
+        <g id="288" class="nad-vl120to180" title="L32-114-1">
+            <g>
+                <polyline points="14.25,-3.21 14.01,-5.13"/>
+            </g>
+            <g>
+                <polyline points="13.77,-7.06 14.01,-5.13"/>
+            </g>
         </g>
-        <g id="289" title="L33-37-1">
-            <polyline points="9.43,12.71 7.10,13.65"/>
-            <polyline points="4.76,14.59 7.10,13.65"/>
+        <g id="289" class="nad-vl120to180" title="L33-37-1">
+            <g>
+                <polyline points="9.43,12.71 7.10,13.65"/>
+            </g>
+            <g>
+                <polyline points="4.76,14.59 7.10,13.65"/>
+            </g>
         </g>
-        <g id="290" title="L34-36-1">
-            <polyline points="6.37,12.65 6.93,14.26"/>
-            <polyline points="7.48,15.88 6.93,14.26"/>
+        <g id="290" class="nad-vl120to180" title="L34-36-1">
+            <g>
+                <polyline points="6.37,12.65 6.93,14.26"/>
+            </g>
+            <g>
+                <polyline points="7.48,15.88 6.93,14.26"/>
+            </g>
         </g>
-        <g id="291" title="L34-37-1">
-            <polyline points="6.37,12.65 5.57,13.62"/>
-            <polyline points="4.76,14.59 5.57,13.62"/>
+        <g id="291" class="nad-vl120to180" title="L34-37-1">
+            <g>
+                <polyline points="6.37,12.65 5.57,13.62"/>
+            </g>
+            <g>
+                <polyline points="4.76,14.59 5.57,13.62"/>
+            </g>
         </g>
-        <g id="292" title="L34-43-1">
-            <polyline points="6.37,12.65 4.13,11.98"/>
-            <polyline points="1.89,11.30 4.13,11.98"/>
+        <g id="292" class="nad-vl120to180" title="L34-43-1">
+            <g>
+                <polyline points="6.37,12.65 4.13,11.98"/>
+            </g>
+            <g>
+                <polyline points="1.89,11.30 4.13,11.98"/>
+            </g>
         </g>
-        <g id="293" title="L35-36-1">
-            <polyline points="5.77,17.43 6.63,16.65"/>
-            <polyline points="7.48,15.88 6.63,16.65"/>
+        <g id="293" class="nad-vl120to180" title="L35-36-1">
+            <g>
+                <polyline points="5.77,17.43 6.63,16.65"/>
+            </g>
+            <g>
+                <polyline points="7.48,15.88 6.63,16.65"/>
+            </g>
         </g>
-        <g id="294" title="L35-37-1">
-            <polyline points="5.77,17.43 5.27,16.01"/>
-            <polyline points="4.76,14.59 5.27,16.01"/>
+        <g id="294" class="nad-vl120to180" title="L35-37-1">
+            <g>
+                <polyline points="5.77,17.43 5.27,16.01"/>
+            </g>
+            <g>
+                <polyline points="4.76,14.59 5.27,16.01"/>
+            </g>
         </g>
         <g id="295" title="T38-37-1">
-            <polyline points="5.22,10.46 4.99,12.52"/>
-            <polyline points="4.76,14.59 4.99,12.52"/>
+            <g class="nad-vl120to180">
+                <polyline points="5.22,10.46 4.99,12.52"/>
+                <circle cx="5.00" cy="12.42" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="4.76,14.59 4.99,12.52"/>
+                <circle cx="4.98" cy="12.62" r="0.20"/>
+            </g>
         </g>
-        <g id="296" title="L37-39-1">
-            <polyline points="4.76,14.59 3.57,15.75"/>
-            <polyline points="2.38,16.92 3.57,15.75"/>
+        <g id="296" class="nad-vl120to180" title="L37-39-1">
+            <g>
+                <polyline points="4.76,14.59 3.57,15.75"/>
+            </g>
+            <g>
+                <polyline points="2.38,16.92 3.57,15.75"/>
+            </g>
         </g>
-        <g id="297" title="L37-40-1">
-            <polyline points="4.76,14.59 2.44,14.93"/>
-            <polyline points="0.12,15.27 2.44,14.93"/>
+        <g id="297" class="nad-vl120to180" title="L37-40-1">
+            <g>
+                <polyline points="4.76,14.59 2.44,14.93"/>
+            </g>
+            <g>
+                <polyline points="0.12,15.27 2.44,14.93"/>
+            </g>
         </g>
-        <g id="298" title="L38-65-1">
-            <polyline points="5.22,10.46 0.24,9.77"/>
-            <polyline points="-4.73,9.08 0.24,9.77"/>
+        <g id="298" class="nad-vl120to180" title="L38-65-1">
+            <g>
+                <polyline points="5.22,10.46 0.24,9.77"/>
+            </g>
+            <g>
+                <polyline points="-4.73,9.08 0.24,9.77"/>
+            </g>
         </g>
-        <g id="299" title="L39-40-1">
-            <polyline points="2.38,16.92 1.25,16.10"/>
-            <polyline points="0.12,15.27 1.25,16.10"/>
+        <g id="299" class="nad-vl120to180" title="L39-40-1">
+            <g>
+                <polyline points="2.38,16.92 1.25,16.10"/>
+            </g>
+            <g>
+                <polyline points="0.12,15.27 1.25,16.10"/>
+            </g>
         </g>
-        <g id="300" title="L40-41-1">
-            <polyline points="0.12,15.27 -1.22,15.55"/>
-            <polyline points="-2.56,15.82 -1.22,15.55"/>
+        <g id="300" class="nad-vl120to180" title="L40-41-1">
+            <g>
+                <polyline points="0.12,15.27 -1.22,15.55"/>
+            </g>
+            <g>
+                <polyline points="-2.56,15.82 -1.22,15.55"/>
+            </g>
         </g>
-        <g id="301" title="L40-42-1">
-            <polyline points="0.12,15.27 -1.97,14.40"/>
-            <polyline points="-4.05,13.53 -1.97,14.40"/>
+        <g id="301" class="nad-vl120to180" title="L40-42-1">
+            <g>
+                <polyline points="0.12,15.27 -1.97,14.40"/>
+            </g>
+            <g>
+                <polyline points="-4.05,13.53 -1.97,14.40"/>
+            </g>
         </g>
-        <g id="302" title="L41-42-1">
-            <polyline points="-2.56,15.82 -3.31,14.67"/>
-            <polyline points="-4.05,13.53 -3.31,14.67"/>
+        <g id="302" class="nad-vl120to180" title="L41-42-1">
+            <g>
+                <polyline points="-2.56,15.82 -3.31,14.67"/>
+            </g>
+            <g>
+                <polyline points="-4.05,13.53 -3.31,14.67"/>
+            </g>
         </g>
-        <g id="303" title="L42-49-1">
-            <polyline points="-4.05,13.53 -4.02,12.73 -5.77,9.45"/>
-            <polyline points="-8.20,5.75 -7.52,6.18 -5.77,9.45"/>
+        <g id="303" class="nad-vl120to180" title="L42-49-1">
+            <g>
+                <polyline points="-4.05,13.53 -4.02,12.73 -5.77,9.45"/>
+            </g>
+            <g>
+                <polyline points="-8.20,5.75 -7.52,6.18 -5.77,9.45"/>
+            </g>
         </g>
-        <g id="304" title="L42-49-2">
-            <polyline points="-4.05,13.53 -4.73,13.11 -6.48,9.83"/>
-            <polyline points="-8.20,5.75 -8.23,6.55 -6.48,9.83"/>
+        <g id="304" class="nad-vl120to180" title="L42-49-2">
+            <g>
+                <polyline points="-4.05,13.53 -4.73,13.11 -6.48,9.83"/>
+            </g>
+            <g>
+                <polyline points="-8.20,5.75 -8.23,6.55 -6.48,9.83"/>
+            </g>
         </g>
-        <g id="305" title="L43-44-1">
-            <polyline points="1.89,11.30 -0.49,9.35"/>
-            <polyline points="-2.88,7.40 -0.49,9.35"/>
+        <g id="305" class="nad-vl120to180" title="L43-44-1">
+            <g>
+                <polyline points="1.89,11.30 -0.49,9.35"/>
+            </g>
+            <g>
+                <polyline points="-2.88,7.40 -0.49,9.35"/>
+            </g>
         </g>
-        <g id="306" title="L44-45-1">
-            <polyline points="-2.88,7.40 -4.60,6.71"/>
-            <polyline points="-6.32,6.02 -4.60,6.71"/>
+        <g id="306" class="nad-vl120to180" title="L44-45-1">
+            <g>
+                <polyline points="-2.88,7.40 -4.60,6.71"/>
+            </g>
+            <g>
+                <polyline points="-6.32,6.02 -4.60,6.71"/>
+            </g>
         </g>
-        <g id="307" title="L45-46-1">
-            <polyline points="-6.32,6.02 -6.34,6.68"/>
-            <polyline points="-6.37,7.34 -6.34,6.68"/>
+        <g id="307" class="nad-vl120to180" title="L45-46-1">
+            <g>
+                <polyline points="-6.32,6.02 -6.34,6.68"/>
+            </g>
+            <g>
+                <polyline points="-6.37,7.34 -6.34,6.68"/>
+            </g>
         </g>
-        <g id="308" title="L45-49-1">
-            <polyline points="-6.32,6.02 -7.26,5.88"/>
-            <polyline points="-8.20,5.75 -7.26,5.88"/>
+        <g id="308" class="nad-vl120to180" title="L45-49-1">
+            <g>
+                <polyline points="-6.32,6.02 -7.26,5.88"/>
+            </g>
+            <g>
+                <polyline points="-8.20,5.75 -7.26,5.88"/>
+            </g>
         </g>
-        <g id="309" title="L46-47-1">
-            <polyline points="-6.37,7.34 -5.51,6.12"/>
-            <polyline points="-4.66,4.90 -5.51,6.12"/>
+        <g id="309" class="nad-vl120to180" title="L46-47-1">
+            <g>
+                <polyline points="-6.37,7.34 -5.51,6.12"/>
+            </g>
+            <g>
+                <polyline points="-4.66,4.90 -5.51,6.12"/>
+            </g>
         </g>
-        <g id="310" title="L46-48-1">
-            <polyline points="-6.37,7.34 -9.06,10.29"/>
-            <polyline points="-11.75,13.24 -9.06,10.29"/>
+        <g id="310" class="nad-vl120to180" title="L46-48-1">
+            <g>
+                <polyline points="-6.37,7.34 -9.06,10.29"/>
+            </g>
+            <g>
+                <polyline points="-11.75,13.24 -9.06,10.29"/>
+            </g>
         </g>
-        <g id="311" title="L47-49-1">
-            <polyline points="-4.66,4.90 -6.43,5.33"/>
-            <polyline points="-8.20,5.75 -6.43,5.33"/>
+        <g id="311" class="nad-vl120to180" title="L47-49-1">
+            <g>
+                <polyline points="-4.66,4.90 -6.43,5.33"/>
+            </g>
+            <g>
+                <polyline points="-8.20,5.75 -6.43,5.33"/>
+            </g>
         </g>
-        <g id="312" title="L47-69-1">
-            <polyline points="-4.66,4.90 -8.40,-1.00"/>
-            <polyline points="-12.14,-6.89 -8.40,-1.00"/>
+        <g id="312" class="nad-vl120to180" title="L47-69-1">
+            <g>
+                <polyline points="-4.66,4.90 -8.40,-1.00"/>
+            </g>
+            <g>
+                <polyline points="-12.14,-6.89 -8.40,-1.00"/>
+            </g>
         </g>
-        <g id="313" title="L48-49-1">
-            <polyline points="-11.75,13.24 -9.98,9.50"/>
-            <polyline points="-8.20,5.75 -9.98,9.50"/>
+        <g id="313" class="nad-vl120to180" title="L48-49-1">
+            <g>
+                <polyline points="-11.75,13.24 -9.98,9.50"/>
+            </g>
+            <g>
+                <polyline points="-8.20,5.75 -9.98,9.50"/>
+            </g>
         </g>
-        <g id="314" title="L49-50-1">
-            <polyline points="-8.20,5.75 -9.82,2.86"/>
-            <polyline points="-11.45,-0.04 -9.82,2.86"/>
+        <g id="314" class="nad-vl120to180" title="L49-50-1">
+            <g>
+                <polyline points="-8.20,5.75 -9.82,2.86"/>
+            </g>
+            <g>
+                <polyline points="-11.45,-0.04 -9.82,2.86"/>
+            </g>
         </g>
-        <g id="315" title="L49-51-1">
-            <polyline points="-8.20,5.75 -10.81,5.92"/>
-            <polyline points="-13.42,6.08 -10.81,5.92"/>
+        <g id="315" class="nad-vl120to180" title="L49-51-1">
+            <g>
+                <polyline points="-8.20,5.75 -10.81,5.92"/>
+            </g>
+            <g>
+                <polyline points="-13.42,6.08 -10.81,5.92"/>
+            </g>
         </g>
-        <g id="316" title="L49-54-1">
-            <polyline points="-8.20,5.75 -8.38,6.53 -6.94,11.09"/>
-            <polyline points="-4.92,16.19 -5.51,15.65 -6.94,11.09"/>
+        <g id="316" class="nad-vl120to180" title="L49-54-1">
+            <g>
+                <polyline points="-8.20,5.75 -8.38,6.53 -6.94,11.09"/>
+            </g>
+            <g>
+                <polyline points="-4.92,16.19 -5.51,15.65 -6.94,11.09"/>
+            </g>
         </g>
-        <g id="317" title="L49-54-2">
-            <polyline points="-8.20,5.75 -7.61,6.29 -6.18,10.85"/>
-            <polyline points="-4.92,16.19 -4.74,15.41 -6.18,10.85"/>
+        <g id="317" class="nad-vl120to180" title="L49-54-2">
+            <g>
+                <polyline points="-8.20,5.75 -7.61,6.29 -6.18,10.85"/>
+            </g>
+            <g>
+                <polyline points="-4.92,16.19 -4.74,15.41 -6.18,10.85"/>
+            </g>
         </g>
-        <g id="318" title="L49-66-1">
-            <polyline points="-8.20,5.75 -8.95,5.47 -11.57,5.89"/>
-            <polyline points="-14.81,6.82 -14.19,6.32 -11.57,5.89"/>
+        <g id="318" class="nad-vl120to180" title="L49-66-1">
+            <g>
+                <polyline points="-8.20,5.75 -8.95,5.47 -11.57,5.89"/>
+            </g>
+            <g>
+                <polyline points="-14.81,6.82 -14.19,6.32 -11.57,5.89"/>
+            </g>
         </g>
-        <g id="319" title="L49-66-2">
-            <polyline points="-8.20,5.75 -8.82,6.26 -11.44,6.68"/>
-            <polyline points="-14.81,6.82 -14.06,7.10 -11.44,6.68"/>
+        <g id="319" class="nad-vl120to180" title="L49-66-2">
+            <g>
+                <polyline points="-8.20,5.75 -8.82,6.26 -11.44,6.68"/>
+            </g>
+            <g>
+                <polyline points="-14.81,6.82 -14.06,7.10 -11.44,6.68"/>
+            </g>
         </g>
-        <g id="320" title="L49-69-1">
-            <polyline points="-8.20,5.75 -10.17,-0.57"/>
-            <polyline points="-12.14,-6.89 -10.17,-0.57"/>
+        <g id="320" class="nad-vl120to180" title="L49-69-1">
+            <g>
+                <polyline points="-8.20,5.75 -10.17,-0.57"/>
+            </g>
+            <g>
+                <polyline points="-12.14,-6.89 -10.17,-0.57"/>
+            </g>
         </g>
-        <g id="321" title="L50-57-1">
-            <polyline points="-11.45,-0.04 -12.79,2.74"/>
-            <polyline points="-14.14,5.51 -12.79,2.74"/>
+        <g id="321" class="nad-vl120to180" title="L50-57-1">
+            <g>
+                <polyline points="-11.45,-0.04 -12.79,2.74"/>
+            </g>
+            <g>
+                <polyline points="-14.14,5.51 -12.79,2.74"/>
+            </g>
         </g>
-        <g id="322" title="L51-52-1">
-            <polyline points="-13.42,6.08 -15.24,6.64"/>
-            <polyline points="-17.07,7.21 -15.24,6.64"/>
+        <g id="322" class="nad-vl120to180" title="L51-52-1">
+            <g>
+                <polyline points="-13.42,6.08 -15.24,6.64"/>
+            </g>
+            <g>
+                <polyline points="-17.07,7.21 -15.24,6.64"/>
+            </g>
         </g>
-        <g id="323" title="L51-58-1">
-            <polyline points="-13.42,6.08 -13.50,7.10"/>
-            <polyline points="-13.58,8.12 -13.50,7.10"/>
+        <g id="323" class="nad-vl120to180" title="L51-58-1">
+            <g>
+                <polyline points="-13.42,6.08 -13.50,7.10"/>
+            </g>
+            <g>
+                <polyline points="-13.58,8.12 -13.50,7.10"/>
+            </g>
         </g>
-        <g id="324" title="L52-53-1">
-            <polyline points="-17.07,7.21 -16.66,8.33"/>
-            <polyline points="-16.25,9.46 -16.66,8.33"/>
+        <g id="324" class="nad-vl120to180" title="L52-53-1">
+            <g>
+                <polyline points="-17.07,7.21 -16.66,8.33"/>
+            </g>
+            <g>
+                <polyline points="-16.25,9.46 -16.66,8.33"/>
+            </g>
         </g>
-        <g id="325" title="L53-54-1">
-            <polyline points="-16.25,9.46 -10.58,12.83"/>
-            <polyline points="-4.92,16.19 -10.58,12.83"/>
+        <g id="325" class="nad-vl120to180" title="L53-54-1">
+            <g>
+                <polyline points="-16.25,9.46 -10.58,12.83"/>
+            </g>
+            <g>
+                <polyline points="-4.92,16.19 -10.58,12.83"/>
+            </g>
         </g>
-        <g id="326" title="L54-55-1">
-            <polyline points="-4.92,16.19 -5.95,16.33"/>
-            <polyline points="-6.98,16.47 -5.95,16.33"/>
+        <g id="326" class="nad-vl120to180" title="L54-55-1">
+            <g>
+                <polyline points="-4.92,16.19 -5.95,16.33"/>
+            </g>
+            <g>
+                <polyline points="-6.98,16.47 -5.95,16.33"/>
+            </g>
         </g>
-        <g id="327" title="L54-56-1">
-            <polyline points="-4.92,16.19 -7.21,15.92"/>
-            <polyline points="-9.51,15.65 -7.21,15.92"/>
+        <g id="327" class="nad-vl120to180" title="L54-56-1">
+            <g>
+                <polyline points="-4.92,16.19 -7.21,15.92"/>
+            </g>
+            <g>
+                <polyline points="-9.51,15.65 -7.21,15.92"/>
+            </g>
         </g>
-        <g id="328" title="L54-59-1">
-            <polyline points="-4.92,16.19 -7.73,15.42"/>
-            <polyline points="-10.53,14.64 -7.73,15.42"/>
+        <g id="328" class="nad-vl120to180" title="L54-59-1">
+            <g>
+                <polyline points="-4.92,16.19 -7.73,15.42"/>
+            </g>
+            <g>
+                <polyline points="-10.53,14.64 -7.73,15.42"/>
+            </g>
         </g>
-        <g id="329" title="L55-56-1">
-            <polyline points="-6.98,16.47 -8.25,16.06"/>
-            <polyline points="-9.51,15.65 -8.25,16.06"/>
+        <g id="329" class="nad-vl120to180" title="L55-56-1">
+            <g>
+                <polyline points="-6.98,16.47 -8.25,16.06"/>
+            </g>
+            <g>
+                <polyline points="-9.51,15.65 -8.25,16.06"/>
+            </g>
         </g>
-        <g id="330" title="L55-59-1">
-            <polyline points="-6.98,16.47 -8.76,15.56"/>
-            <polyline points="-10.53,14.64 -8.76,15.56"/>
+        <g id="330" class="nad-vl120to180" title="L55-59-1">
+            <g>
+                <polyline points="-6.98,16.47 -8.76,15.56"/>
+            </g>
+            <g>
+                <polyline points="-10.53,14.64 -8.76,15.56"/>
+            </g>
         </g>
-        <g id="331" title="L56-57-1">
-            <polyline points="-9.51,15.65 -11.82,10.58"/>
-            <polyline points="-14.14,5.51 -11.82,10.58"/>
+        <g id="331" class="nad-vl120to180" title="L56-57-1">
+            <g>
+                <polyline points="-9.51,15.65 -11.82,10.58"/>
+            </g>
+            <g>
+                <polyline points="-14.14,5.51 -11.82,10.58"/>
+            </g>
         </g>
-        <g id="332" title="L56-58-1">
-            <polyline points="-9.51,15.65 -11.54,11.89"/>
-            <polyline points="-13.58,8.12 -11.54,11.89"/>
+        <g id="332" class="nad-vl120to180" title="L56-58-1">
+            <g>
+                <polyline points="-9.51,15.65 -11.54,11.89"/>
+            </g>
+            <g>
+                <polyline points="-13.58,8.12 -11.54,11.89"/>
+            </g>
         </g>
-        <g id="333" title="L56-59-1">
-            <polyline points="-9.51,15.65 -9.72,14.88 -9.74,14.86"/>
-            <polyline points="-10.53,14.64 -9.76,14.84 -9.74,14.86"/>
+        <g id="333" class="nad-vl120to180" title="L56-59-1">
+            <g>
+                <polyline points="-9.51,15.65 -9.72,14.88 -9.74,14.86"/>
+            </g>
+            <g>
+                <polyline points="-10.53,14.64 -9.76,14.84 -9.74,14.86"/>
+            </g>
         </g>
-        <g id="334" title="L56-59-2">
-            <polyline points="-9.51,15.65 -10.28,15.45 -10.30,15.43"/>
-            <polyline points="-10.53,14.64 -10.32,15.41 -10.30,15.43"/>
+        <g id="334" class="nad-vl120to180" title="L56-59-2">
+            <g>
+                <polyline points="-9.51,15.65 -10.28,15.45 -10.30,15.43"/>
+            </g>
+            <g>
+                <polyline points="-10.53,14.64 -10.32,15.41 -10.30,15.43"/>
+            </g>
         </g>
-        <g id="335" title="L59-60-1">
-            <polyline points="-10.53,14.64 -8.77,16.63"/>
-            <polyline points="-7.01,18.61 -8.77,16.63"/>
+        <g id="335" class="nad-vl120to180" title="L59-60-1">
+            <g>
+                <polyline points="-10.53,14.64 -8.77,16.63"/>
+            </g>
+            <g>
+                <polyline points="-7.01,18.61 -8.77,16.63"/>
+            </g>
         </g>
-        <g id="336" title="L59-61-1">
-            <polyline points="-10.53,14.64 -12.48,14.29"/>
-            <polyline points="-14.43,13.95 -12.48,14.29"/>
+        <g id="336" class="nad-vl120to180" title="L59-61-1">
+            <g>
+                <polyline points="-10.53,14.64 -12.48,14.29"/>
+            </g>
+            <g>
+                <polyline points="-14.43,13.95 -12.48,14.29"/>
+            </g>
         </g>
         <g id="337" title="T63-59-1">
-            <polyline points="-3.93,22.99 -7.23,18.82"/>
-            <polyline points="-10.53,14.64 -7.23,18.82"/>
+            <g class="nad-vl120to180">
+                <polyline points="-3.93,22.99 -7.23,18.82"/>
+                <circle cx="-7.17" cy="18.90" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-10.53,14.64 -7.23,18.82"/>
+                <circle cx="-7.30" cy="18.74" r="0.20"/>
+            </g>
         </g>
-        <g id="338" title="L60-61-1">
-            <polyline points="-7.01,18.61 -10.72,16.28"/>
-            <polyline points="-14.43,13.95 -10.72,16.28"/>
+        <g id="338" class="nad-vl120to180" title="L60-61-1">
+            <g>
+                <polyline points="-7.01,18.61 -10.72,16.28"/>
+            </g>
+            <g>
+                <polyline points="-14.43,13.95 -10.72,16.28"/>
+            </g>
         </g>
-        <g id="339" title="L60-62-1">
-            <polyline points="-7.01,18.61 -15.53,10.81"/>
-            <polyline points="-24.05,3.01 -15.53,10.81"/>
+        <g id="339" class="nad-vl120to180" title="L60-62-1">
+            <g>
+                <polyline points="-7.01,18.61 -15.53,10.81"/>
+            </g>
+            <g>
+                <polyline points="-24.05,3.01 -15.53,10.81"/>
+            </g>
         </g>
-        <g id="340" title="L61-62-1">
-            <polyline points="-14.43,13.95 -19.24,8.48"/>
-            <polyline points="-24.05,3.01 -19.24,8.48"/>
+        <g id="340" class="nad-vl120to180" title="L61-62-1">
+            <g>
+                <polyline points="-14.43,13.95 -19.24,8.48"/>
+            </g>
+            <g>
+                <polyline points="-24.05,3.01 -19.24,8.48"/>
+            </g>
         </g>
         <g id="341" title="T64-61-1">
-            <polyline points="-9.38,15.01 -11.90,14.48"/>
-            <polyline points="-14.43,13.95 -11.90,14.48"/>
+            <g class="nad-vl120to180">
+                <polyline points="-9.38,15.01 -11.90,14.48"/>
+                <circle cx="-11.80" cy="14.50" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-14.43,13.95 -11.90,14.48"/>
+                <circle cx="-12.00" cy="14.46" r="0.20"/>
+            </g>
         </g>
-        <g id="342" title="L62-66-1">
-            <polyline points="-24.05,3.01 -19.43,4.92"/>
-            <polyline points="-14.81,6.82 -19.43,4.92"/>
+        <g id="342" class="nad-vl120to180" title="L62-66-1">
+            <g>
+                <polyline points="-24.05,3.01 -19.43,4.92"/>
+            </g>
+            <g>
+                <polyline points="-14.81,6.82 -19.43,4.92"/>
+            </g>
         </g>
-        <g id="343" title="L62-67-1">
-            <polyline points="-24.05,3.01 -21.48,5.85"/>
-            <polyline points="-18.92,8.69 -21.48,5.85"/>
+        <g id="343" class="nad-vl120to180" title="L62-67-1">
+            <g>
+                <polyline points="-24.05,3.01 -21.48,5.85"/>
+            </g>
+            <g>
+                <polyline points="-18.92,8.69 -21.48,5.85"/>
+            </g>
         </g>
-        <g id="344" title="L63-64-1">
-            <polyline points="-3.93,22.99 -6.66,19.00"/>
-            <polyline points="-9.38,15.01 -6.66,19.00"/>
+        <g id="344" class="nad-vl120to180" title="L63-64-1">
+            <g>
+                <polyline points="-3.93,22.99 -6.66,19.00"/>
+            </g>
+            <g>
+                <polyline points="-9.38,15.01 -6.66,19.00"/>
+            </g>
         </g>
-        <g id="345" title="L64-65-1">
-            <polyline points="-9.38,15.01 -7.06,12.05"/>
-            <polyline points="-4.73,9.08 -7.06,12.05"/>
+        <g id="345" class="nad-vl120to180" title="L64-65-1">
+            <g>
+                <polyline points="-9.38,15.01 -7.06,12.05"/>
+            </g>
+            <g>
+                <polyline points="-4.73,9.08 -7.06,12.05"/>
+            </g>
         </g>
         <g id="346" title="T65-66-1">
-            <polyline points="-4.73,9.08 -9.77,7.95"/>
-            <polyline points="-14.81,6.82 -9.77,7.95"/>
+            <g class="nad-vl120to180">
+                <polyline points="-4.73,9.08 -9.77,7.95"/>
+                <circle cx="-9.67" cy="7.97" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-14.81,6.82 -9.77,7.95"/>
+                <circle cx="-9.87" cy="7.93" r="0.20"/>
+            </g>
         </g>
-        <g id="347" title="L65-68-1">
-            <polyline points="-4.73,9.08 -1.61,9.61"/>
-            <polyline points="1.51,10.13 -1.61,9.61"/>
+        <g id="347" class="nad-vl120to180" title="L65-68-1">
+            <g>
+                <polyline points="-4.73,9.08 -1.61,9.61"/>
+            </g>
+            <g>
+                <polyline points="1.51,10.13 -1.61,9.61"/>
+            </g>
         </g>
-        <g id="348" title="L66-67-1">
-            <polyline points="-14.81,6.82 -16.86,7.76"/>
-            <polyline points="-18.92,8.69 -16.86,7.76"/>
+        <g id="348" class="nad-vl120to180" title="L66-67-1">
+            <g>
+                <polyline points="-14.81,6.82 -16.86,7.76"/>
+            </g>
+            <g>
+                <polyline points="-18.92,8.69 -16.86,7.76"/>
+            </g>
         </g>
         <g id="349" title="T68-69-1">
-            <polyline points="1.51,10.13 -5.32,1.62"/>
-            <polyline points="-12.14,-6.89 -5.32,1.62"/>
+            <g class="nad-vl120to180">
+                <polyline points="1.51,10.13 -5.32,1.62"/>
+                <circle cx="-5.25" cy="1.70" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-12.14,-6.89 -5.32,1.62"/>
+                <circle cx="-5.38" cy="1.54" r="0.20"/>
+            </g>
         </g>
-        <g id="350" title="L68-81-1">
-            <polyline points="1.51,10.13 -2.14,1.62"/>
-            <polyline points="-5.79,-6.89 -2.14,1.62"/>
+        <g id="350" class="nad-vl120to180" title="L68-81-1">
+            <g>
+                <polyline points="1.51,10.13 -2.14,1.62"/>
+            </g>
+            <g>
+                <polyline points="-5.79,-6.89 -2.14,1.62"/>
+            </g>
         </g>
-        <g id="351" title="L68-116-1">
-            <polyline points="1.51,10.13 -4.07,4.98"/>
-            <polyline points="-9.66,-0.16 -4.07,4.98"/>
+        <g id="351" class="nad-vl120to180" title="L68-116-1">
+            <g>
+                <polyline points="1.51,10.13 -4.07,4.98"/>
+            </g>
+            <g>
+                <polyline points="-9.66,-0.16 -4.07,4.98"/>
+            </g>
         </g>
-        <g id="352" title="L69-70-1">
-            <polyline points="-12.14,-6.89 -6.00,-4.88"/>
-            <polyline points="0.13,-2.86 -6.00,-4.88"/>
+        <g id="352" class="nad-vl120to180" title="L69-70-1">
+            <g>
+                <polyline points="-12.14,-6.89 -6.00,-4.88"/>
+            </g>
+            <g>
+                <polyline points="0.13,-2.86 -6.00,-4.88"/>
+            </g>
         </g>
-        <g id="353" title="L69-75-1">
-            <polyline points="-12.14,-6.89 -7.53,-4.48"/>
-            <polyline points="-2.92,-2.06 -7.53,-4.48"/>
+        <g id="353" class="nad-vl120to180" title="L69-75-1">
+            <g>
+                <polyline points="-12.14,-6.89 -7.53,-4.48"/>
+            </g>
+            <g>
+                <polyline points="-2.92,-2.06 -7.53,-4.48"/>
+            </g>
         </g>
-        <g id="354" title="L69-77-1">
-            <polyline points="-12.14,-6.89 -9.74,-5.63"/>
-            <polyline points="-7.34,-4.37 -9.74,-5.63"/>
+        <g id="354" class="nad-vl120to180" title="L69-77-1">
+            <g>
+                <polyline points="-12.14,-6.89 -9.74,-5.63"/>
+            </g>
+            <g>
+                <polyline points="-7.34,-4.37 -9.74,-5.63"/>
+            </g>
         </g>
-        <g id="355" title="L70-71-1">
-            <polyline points="0.13,-2.86 1.50,-4.59"/>
-            <polyline points="2.87,-6.32 1.50,-4.59"/>
+        <g id="355" class="nad-vl120to180" title="L70-71-1">
+            <g>
+                <polyline points="0.13,-2.86 1.50,-4.59"/>
+            </g>
+            <g>
+                <polyline points="2.87,-6.32 1.50,-4.59"/>
+            </g>
         </g>
-        <g id="356" title="L70-74-1">
-            <polyline points="0.13,-2.86 -0.36,-1.91"/>
-            <polyline points="-0.85,-0.96 -0.36,-1.91"/>
+        <g id="356" class="nad-vl120to180" title="L70-74-1">
+            <g>
+                <polyline points="0.13,-2.86 -0.36,-1.91"/>
+            </g>
+            <g>
+                <polyline points="-0.85,-0.96 -0.36,-1.91"/>
+            </g>
         </g>
-        <g id="357" title="L70-75-1">
-            <polyline points="0.13,-2.86 -1.40,-2.46"/>
-            <polyline points="-2.92,-2.06 -1.40,-2.46"/>
+        <g id="357" class="nad-vl120to180" title="L70-75-1">
+            <g>
+                <polyline points="0.13,-2.86 -1.40,-2.46"/>
+            </g>
+            <g>
+                <polyline points="-2.92,-2.06 -1.40,-2.46"/>
+            </g>
         </g>
-        <g id="358" title="L71-72-1">
-            <polyline points="2.87,-6.32 4.11,-6.34"/>
-            <polyline points="5.34,-6.36 4.11,-6.34"/>
+        <g id="358" class="nad-vl120to180" title="L71-72-1">
+            <g>
+                <polyline points="2.87,-6.32 4.11,-6.34"/>
+            </g>
+            <g>
+                <polyline points="5.34,-6.36 4.11,-6.34"/>
+            </g>
         </g>
-        <g id="359" title="L71-73-1">
-            <polyline points="2.87,-6.32 3.23,-7.85"/>
-            <polyline points="3.59,-9.39 3.23,-7.85"/>
+        <g id="359" class="nad-vl120to180" title="L71-73-1">
+            <g>
+                <polyline points="2.87,-6.32 3.23,-7.85"/>
+            </g>
+            <g>
+                <polyline points="3.59,-9.39 3.23,-7.85"/>
+            </g>
         </g>
-        <g id="360" title="L74-75-1">
-            <polyline points="-0.85,-0.96 -1.89,-1.51"/>
-            <polyline points="-2.92,-2.06 -1.89,-1.51"/>
+        <g id="360" class="nad-vl120to180" title="L74-75-1">
+            <g>
+                <polyline points="-0.85,-0.96 -1.89,-1.51"/>
+            </g>
+            <g>
+                <polyline points="-2.92,-2.06 -1.89,-1.51"/>
+            </g>
         </g>
-        <g id="361" title="L75-77-1">
-            <polyline points="-2.92,-2.06 -5.13,-3.22"/>
-            <polyline points="-7.34,-4.37 -5.13,-3.22"/>
+        <g id="361" class="nad-vl120to180" title="L75-77-1">
+            <g>
+                <polyline points="-2.92,-2.06 -5.13,-3.22"/>
+            </g>
+            <g>
+                <polyline points="-7.34,-4.37 -5.13,-3.22"/>
+            </g>
         </g>
-        <g id="362" title="L75-118-1">
-            <polyline points="-2.92,-2.06 -2.59,-3.61"/>
-            <polyline points="-2.25,-5.16 -2.59,-3.61"/>
+        <g id="362" class="nad-vl120to180" title="L75-118-1">
+            <g>
+                <polyline points="-2.92,-2.06 -2.59,-3.61"/>
+            </g>
+            <g>
+                <polyline points="-2.25,-5.16 -2.59,-3.61"/>
+            </g>
         </g>
-        <g id="363" title="L76-77-1">
-            <polyline points="-4.13,-2.99 -5.73,-3.68"/>
-            <polyline points="-7.34,-4.37 -5.73,-3.68"/>
+        <g id="363" class="nad-vl120to180" title="L76-77-1">
+            <g>
+                <polyline points="-4.13,-2.99 -5.73,-3.68"/>
+            </g>
+            <g>
+                <polyline points="-7.34,-4.37 -5.73,-3.68"/>
+            </g>
         </g>
-        <g id="364" title="L76-118-1">
-            <polyline points="-4.13,-2.99 -3.19,-4.08"/>
-            <polyline points="-2.25,-5.16 -3.19,-4.08"/>
+        <g id="364" class="nad-vl120to180" title="L76-118-1">
+            <g>
+                <polyline points="-4.13,-2.99 -3.19,-4.08"/>
+            </g>
+            <g>
+                <polyline points="-2.25,-5.16 -3.19,-4.08"/>
+            </g>
         </g>
-        <g id="365" title="L77-78-1">
-            <polyline points="-7.34,-4.37 -8.72,-4.84"/>
-            <polyline points="-10.09,-5.31 -8.72,-4.84"/>
+        <g id="365" class="nad-vl120to180" title="L77-78-1">
+            <g>
+                <polyline points="-7.34,-4.37 -8.72,-4.84"/>
+            </g>
+            <g>
+                <polyline points="-10.09,-5.31 -8.72,-4.84"/>
+            </g>
         </g>
-        <g id="366" title="L77-80-1">
-            <polyline points="-7.34,-4.37 -7.02,-5.10 -7.25,-7.05"/>
-            <polyline points="-7.95,-9.65 -7.48,-9.00 -7.25,-7.05"/>
+        <g id="366" class="nad-vl120to180" title="L77-80-1">
+            <g>
+                <polyline points="-7.34,-4.37 -7.02,-5.10 -7.25,-7.05"/>
+            </g>
+            <g>
+                <polyline points="-7.95,-9.65 -7.48,-9.00 -7.25,-7.05"/>
+            </g>
         </g>
-        <g id="367" title="L77-80-2">
-            <polyline points="-7.34,-4.37 -7.82,-5.01 -8.04,-6.96"/>
-            <polyline points="-7.95,-9.65 -8.27,-8.91 -8.04,-6.96"/>
+        <g id="367" class="nad-vl120to180" title="L77-80-2">
+            <g>
+                <polyline points="-7.34,-4.37 -7.82,-5.01 -8.04,-6.96"/>
+            </g>
+            <g>
+                <polyline points="-7.95,-9.65 -8.27,-8.91 -8.04,-6.96"/>
+            </g>
         </g>
-        <g id="368" title="L77-82-1">
-            <polyline points="-7.34,-4.37 -9.94,-6.22"/>
-            <polyline points="-12.54,-8.08 -9.94,-6.22"/>
+        <g id="368" class="nad-vl120to180" title="L77-82-1">
+            <g>
+                <polyline points="-7.34,-4.37 -9.94,-6.22"/>
+            </g>
+            <g>
+                <polyline points="-12.54,-8.08 -9.94,-6.22"/>
+            </g>
         </g>
-        <g id="369" title="L78-79-1">
-            <polyline points="-10.09,-5.31 -10.65,-5.40"/>
-            <polyline points="-11.22,-5.48 -10.65,-5.40"/>
+        <g id="369" class="nad-vl120to180" title="L78-79-1">
+            <g>
+                <polyline points="-10.09,-5.31 -10.65,-5.40"/>
+            </g>
+            <g>
+                <polyline points="-11.22,-5.48 -10.65,-5.40"/>
+            </g>
         </g>
-        <g id="370" title="L79-80-1">
-            <polyline points="-11.22,-5.48 -9.58,-7.56"/>
-            <polyline points="-7.95,-9.65 -9.58,-7.56"/>
+        <g id="370" class="nad-vl120to180" title="L79-80-1">
+            <g>
+                <polyline points="-11.22,-5.48 -9.58,-7.56"/>
+            </g>
+            <g>
+                <polyline points="-7.95,-9.65 -9.58,-7.56"/>
+            </g>
         </g>
         <g id="371" title="T81-80-1">
-            <polyline points="-5.79,-6.89 -6.87,-8.27"/>
-            <polyline points="-7.95,-9.65 -6.87,-8.27"/>
+            <g class="nad-vl120to180">
+                <polyline points="-5.79,-6.89 -6.87,-8.27"/>
+                <circle cx="-6.81" cy="-8.19" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-7.95,-9.65 -6.87,-8.27"/>
+                <circle cx="-6.93" cy="-8.35" r="0.20"/>
+            </g>
         </g>
-        <g id="372" title="L80-96-1">
-            <polyline points="-7.95,-9.65 -9.84,-11.21"/>
-            <polyline points="-11.72,-12.77 -9.84,-11.21"/>
+        <g id="372" class="nad-vl120to180" title="L80-96-1">
+            <g>
+                <polyline points="-7.95,-9.65 -9.84,-11.21"/>
+            </g>
+            <g>
+                <polyline points="-11.72,-12.77 -9.84,-11.21"/>
+            </g>
         </g>
-        <g id="373" title="L80-97-1">
-            <polyline points="-7.95,-9.65 -8.63,-10.15"/>
-            <polyline points="-9.30,-10.66 -8.63,-10.15"/>
+        <g id="373" class="nad-vl120to180" title="L80-97-1">
+            <g>
+                <polyline points="-7.95,-9.65 -8.63,-10.15"/>
+            </g>
+            <g>
+                <polyline points="-9.30,-10.66 -8.63,-10.15"/>
+            </g>
         </g>
-        <g id="374" title="L80-98-1">
-            <polyline points="-7.95,-9.65 -7.04,-11.26"/>
-            <polyline points="-6.13,-12.88 -7.04,-11.26"/>
+        <g id="374" class="nad-vl120to180" title="L80-98-1">
+            <g>
+                <polyline points="-7.95,-9.65 -7.04,-11.26"/>
+            </g>
+            <g>
+                <polyline points="-6.13,-12.88 -7.04,-11.26"/>
+            </g>
         </g>
-        <g id="375" title="L80-99-1">
-            <polyline points="-7.95,-9.65 -7.22,-11.99"/>
-            <polyline points="-6.49,-14.34 -7.22,-11.99"/>
+        <g id="375" class="nad-vl120to180" title="L80-99-1">
+            <g>
+                <polyline points="-7.95,-9.65 -7.22,-11.99"/>
+            </g>
+            <g>
+                <polyline points="-6.49,-14.34 -7.22,-11.99"/>
+            </g>
         </g>
-        <g id="376" title="L82-83-1">
-            <polyline points="-12.54,-8.08 -14.74,-8.70"/>
-            <polyline points="-16.93,-9.33 -14.74,-8.70"/>
+        <g id="376" class="nad-vl120to180" title="L82-83-1">
+            <g>
+                <polyline points="-12.54,-8.08 -14.74,-8.70"/>
+            </g>
+            <g>
+                <polyline points="-16.93,-9.33 -14.74,-8.70"/>
+            </g>
         </g>
-        <g id="377" title="L82-96-1">
-            <polyline points="-12.54,-8.08 -12.13,-10.42"/>
-            <polyline points="-11.72,-12.77 -12.13,-10.42"/>
+        <g id="377" class="nad-vl120to180" title="L82-96-1">
+            <g>
+                <polyline points="-12.54,-8.08 -12.13,-10.42"/>
+            </g>
+            <g>
+                <polyline points="-11.72,-12.77 -12.13,-10.42"/>
+            </g>
         </g>
-        <g id="378" title="L83-84-1">
-            <polyline points="-16.93,-9.33 -18.38,-9.13"/>
-            <polyline points="-19.82,-8.93 -18.38,-9.13"/>
+        <g id="378" class="nad-vl120to180" title="L83-84-1">
+            <g>
+                <polyline points="-16.93,-9.33 -18.38,-9.13"/>
+            </g>
+            <g>
+                <polyline points="-19.82,-8.93 -18.38,-9.13"/>
+            </g>
         </g>
-        <g id="379" title="L83-85-1">
-            <polyline points="-16.93,-9.33 -18.09,-10.36"/>
-            <polyline points="-19.24,-11.39 -18.09,-10.36"/>
+        <g id="379" class="nad-vl120to180" title="L83-85-1">
+            <g>
+                <polyline points="-16.93,-9.33 -18.09,-10.36"/>
+            </g>
+            <g>
+                <polyline points="-19.24,-11.39 -18.09,-10.36"/>
+            </g>
         </g>
-        <g id="380" title="L84-85-1">
-            <polyline points="-19.82,-8.93 -19.53,-10.16"/>
-            <polyline points="-19.24,-11.39 -19.53,-10.16"/>
+        <g id="380" class="nad-vl120to180" title="L84-85-1">
+            <g>
+                <polyline points="-19.82,-8.93 -19.53,-10.16"/>
+            </g>
+            <g>
+                <polyline points="-19.24,-11.39 -19.53,-10.16"/>
+            </g>
         </g>
-        <g id="381" title="L85-86-1">
-            <polyline points="-19.24,-11.39 -21.06,-11.02"/>
-            <polyline points="-22.87,-10.65 -21.06,-11.02"/>
+        <g id="381" class="nad-vl120to180" title="L85-86-1">
+            <g>
+                <polyline points="-19.24,-11.39 -21.06,-11.02"/>
+            </g>
+            <g>
+                <polyline points="-22.87,-10.65 -21.06,-11.02"/>
+            </g>
         </g>
-        <g id="382" title="L85-88-1">
-            <polyline points="-19.24,-11.39 -19.21,-12.77"/>
-            <polyline points="-19.17,-14.14 -19.21,-12.77"/>
+        <g id="382" class="nad-vl120to180" title="L85-88-1">
+            <g>
+                <polyline points="-19.24,-11.39 -19.21,-12.77"/>
+            </g>
+            <g>
+                <polyline points="-19.17,-14.14 -19.21,-12.77"/>
+            </g>
         </g>
-        <g id="383" title="L85-89-1">
-            <polyline points="-19.24,-11.39 -17.85,-12.81"/>
-            <polyline points="-16.45,-14.23 -17.85,-12.81"/>
+        <g id="383" class="nad-vl120to180" title="L85-89-1">
+            <g>
+                <polyline points="-19.24,-11.39 -17.85,-12.81"/>
+            </g>
+            <g>
+                <polyline points="-16.45,-14.23 -17.85,-12.81"/>
+            </g>
         </g>
-        <g id="384" title="L86-87-1">
-            <polyline points="-22.87,-10.65 -24.14,-10.13"/>
-            <polyline points="-25.41,-9.61 -24.14,-10.13"/>
+        <g id="384" class="nad-vl120to180" title="L86-87-1">
+            <g>
+                <polyline points="-22.87,-10.65 -24.14,-10.13"/>
+            </g>
+            <g>
+                <polyline points="-25.41,-9.61 -24.14,-10.13"/>
+            </g>
         </g>
-        <g id="385" title="L88-89-1">
-            <polyline points="-19.17,-14.14 -17.81,-14.19"/>
-            <polyline points="-16.45,-14.23 -17.81,-14.19"/>
+        <g id="385" class="nad-vl120to180" title="L88-89-1">
+            <g>
+                <polyline points="-19.17,-14.14 -17.81,-14.19"/>
+            </g>
+            <g>
+                <polyline points="-16.45,-14.23 -17.81,-14.19"/>
+            </g>
         </g>
-        <g id="386" title="L89-90-1">
-            <polyline points="-16.45,-14.23 -16.12,-14.96 -16.22,-15.92"/>
-            <polyline points="-16.78,-17.52 -16.31,-16.87 -16.22,-15.92"/>
+        <g id="386" class="nad-vl120to180" title="L89-90-1">
+            <g>
+                <polyline points="-16.45,-14.23 -16.12,-14.96 -16.22,-15.92"/>
+            </g>
+            <g>
+                <polyline points="-16.78,-17.52 -16.31,-16.87 -16.22,-15.92"/>
+            </g>
         </g>
-        <g id="387" title="L89-90-2">
-            <polyline points="-16.45,-14.23 -16.92,-14.88 -17.01,-15.83"/>
-            <polyline points="-16.78,-17.52 -17.11,-16.79 -17.01,-15.83"/>
+        <g id="387" class="nad-vl120to180" title="L89-90-2">
+            <g>
+                <polyline points="-16.45,-14.23 -16.92,-14.88 -17.01,-15.83"/>
+            </g>
+            <g>
+                <polyline points="-16.78,-17.52 -17.11,-16.79 -17.01,-15.83"/>
+            </g>
         </g>
-        <g id="388" title="L89-92-1">
-            <polyline points="-16.45,-14.23 -15.85,-14.77 -14.98,-17.41"/>
-            <polyline points="-14.28,-20.83 -14.11,-20.05 -14.98,-17.41"/>
+        <g id="388" class="nad-vl120to180" title="L89-92-1">
+            <g>
+                <polyline points="-16.45,-14.23 -15.85,-14.77 -14.98,-17.41"/>
+            </g>
+            <g>
+                <polyline points="-14.28,-20.83 -14.11,-20.05 -14.98,-17.41"/>
+            </g>
         </g>
-        <g id="389" title="L89-92-2">
-            <polyline points="-16.45,-14.23 -16.61,-15.02 -15.74,-17.66"/>
-            <polyline points="-14.28,-20.83 -14.87,-20.30 -15.74,-17.66"/>
+        <g id="389" class="nad-vl120to180" title="L89-92-2">
+            <g>
+                <polyline points="-16.45,-14.23 -16.61,-15.02 -15.74,-17.66"/>
+            </g>
+            <g>
+                <polyline points="-14.28,-20.83 -14.87,-20.30 -15.74,-17.66"/>
+            </g>
         </g>
-        <g id="390" title="L90-91-1">
-            <polyline points="-16.78,-17.52 -15.15,-17.36"/>
-            <polyline points="-13.52,-17.20 -15.15,-17.36"/>
+        <g id="390" class="nad-vl120to180" title="L90-91-1">
+            <g>
+                <polyline points="-16.78,-17.52 -15.15,-17.36"/>
+            </g>
+            <g>
+                <polyline points="-13.52,-17.20 -15.15,-17.36"/>
+            </g>
         </g>
-        <g id="391" title="L91-92-1">
-            <polyline points="-13.52,-17.20 -13.90,-19.01"/>
-            <polyline points="-14.28,-20.83 -13.90,-19.01"/>
+        <g id="391" class="nad-vl120to180" title="L91-92-1">
+            <g>
+                <polyline points="-13.52,-17.20 -13.90,-19.01"/>
+            </g>
+            <g>
+                <polyline points="-14.28,-20.83 -13.90,-19.01"/>
+            </g>
         </g>
-        <g id="392" title="L92-93-1">
-            <polyline points="-14.28,-20.83 -11.53,-19.14"/>
-            <polyline points="-8.78,-17.46 -11.53,-19.14"/>
+        <g id="392" class="nad-vl120to180" title="L92-93-1">
+            <g>
+                <polyline points="-14.28,-20.83 -11.53,-19.14"/>
+            </g>
+            <g>
+                <polyline points="-8.78,-17.46 -11.53,-19.14"/>
+            </g>
         </g>
-        <g id="393" title="L92-94-1">
-            <polyline points="-14.28,-20.83 -11.47,-16.43"/>
-            <polyline points="-8.67,-12.03 -11.47,-16.43"/>
+        <g id="393" class="nad-vl120to180" title="L92-94-1">
+            <g>
+                <polyline points="-14.28,-20.83 -11.47,-16.43"/>
+            </g>
+            <g>
+                <polyline points="-8.67,-12.03 -11.47,-16.43"/>
+            </g>
         </g>
-        <g id="394" title="L92-100-1">
-            <polyline points="-14.28,-20.83 -10.04,-19.66"/>
-            <polyline points="-5.81,-18.48 -10.04,-19.66"/>
+        <g id="394" class="nad-vl120to180" title="L92-100-1">
+            <g>
+                <polyline points="-14.28,-20.83 -10.04,-19.66"/>
+            </g>
+            <g>
+                <polyline points="-5.81,-18.48 -10.04,-19.66"/>
+            </g>
         </g>
-        <g id="395" title="L92-102-1">
-            <polyline points="-14.28,-20.83 -12.41,-19.94"/>
-            <polyline points="-10.54,-19.05 -12.41,-19.94"/>
+        <g id="395" class="nad-vl120to180" title="L92-102-1">
+            <g>
+                <polyline points="-14.28,-20.83 -12.41,-19.94"/>
+            </g>
+            <g>
+                <polyline points="-10.54,-19.05 -12.41,-19.94"/>
+            </g>
         </g>
-        <g id="396" title="L93-94-1">
-            <polyline points="-8.78,-17.46 -8.73,-14.74"/>
-            <polyline points="-8.67,-12.03 -8.73,-14.74"/>
+        <g id="396" class="nad-vl120to180" title="L93-94-1">
+            <g>
+                <polyline points="-8.78,-17.46 -8.73,-14.74"/>
+            </g>
+            <g>
+                <polyline points="-8.67,-12.03 -8.73,-14.74"/>
+            </g>
         </g>
-        <g id="397" title="L94-95-1">
-            <polyline points="-8.67,-12.03 -11.44,-13.73"/>
-            <polyline points="-14.22,-15.43 -11.44,-13.73"/>
+        <g id="397" class="nad-vl120to180" title="L94-95-1">
+            <g>
+                <polyline points="-8.67,-12.03 -11.44,-13.73"/>
+            </g>
+            <g>
+                <polyline points="-14.22,-15.43 -11.44,-13.73"/>
+            </g>
         </g>
-        <g id="398" title="L94-96-1">
-            <polyline points="-8.67,-12.03 -10.20,-12.40"/>
-            <polyline points="-11.72,-12.77 -10.20,-12.40"/>
+        <g id="398" class="nad-vl120to180" title="L94-96-1">
+            <g>
+                <polyline points="-8.67,-12.03 -10.20,-12.40"/>
+            </g>
+            <g>
+                <polyline points="-11.72,-12.77 -10.20,-12.40"/>
+            </g>
         </g>
-        <g id="399" title="L94-100-1">
-            <polyline points="-8.67,-12.03 -7.24,-15.25"/>
-            <polyline points="-5.81,-18.48 -7.24,-15.25"/>
+        <g id="399" class="nad-vl120to180" title="L94-100-1">
+            <g>
+                <polyline points="-8.67,-12.03 -7.24,-15.25"/>
+            </g>
+            <g>
+                <polyline points="-5.81,-18.48 -7.24,-15.25"/>
+            </g>
         </g>
-        <g id="400" title="L95-96-1">
-            <polyline points="-14.22,-15.43 -12.97,-14.10"/>
-            <polyline points="-11.72,-12.77 -12.97,-14.10"/>
+        <g id="400" class="nad-vl120to180" title="L95-96-1">
+            <g>
+                <polyline points="-14.22,-15.43 -12.97,-14.10"/>
+            </g>
+            <g>
+                <polyline points="-11.72,-12.77 -12.97,-14.10"/>
+            </g>
         </g>
-        <g id="401" title="L96-97-1">
-            <polyline points="-11.72,-12.77 -10.51,-11.71"/>
-            <polyline points="-9.30,-10.66 -10.51,-11.71"/>
+        <g id="401" class="nad-vl120to180" title="L96-97-1">
+            <g>
+                <polyline points="-11.72,-12.77 -10.51,-11.71"/>
+            </g>
+            <g>
+                <polyline points="-9.30,-10.66 -10.51,-11.71"/>
+            </g>
         </g>
-        <g id="402" title="L98-100-1">
-            <polyline points="-6.13,-12.88 -5.97,-15.68"/>
-            <polyline points="-5.81,-18.48 -5.97,-15.68"/>
+        <g id="402" class="nad-vl120to180" title="L98-100-1">
+            <g>
+                <polyline points="-6.13,-12.88 -5.97,-15.68"/>
+            </g>
+            <g>
+                <polyline points="-5.81,-18.48 -5.97,-15.68"/>
+            </g>
         </g>
-        <g id="403" title="L99-100-1">
-            <polyline points="-6.49,-14.34 -6.15,-16.41"/>
-            <polyline points="-5.81,-18.48 -6.15,-16.41"/>
+        <g id="403" class="nad-vl120to180" title="L99-100-1">
+            <g>
+                <polyline points="-6.49,-14.34 -6.15,-16.41"/>
+            </g>
+            <g>
+                <polyline points="-5.81,-18.48 -6.15,-16.41"/>
+            </g>
         </g>
-        <g id="404" title="L100-101-1">
-            <polyline points="-5.81,-18.48 -7.20,-19.41"/>
-            <polyline points="-8.59,-20.33 -7.20,-19.41"/>
+        <g id="404" class="nad-vl120to180" title="L100-101-1">
+            <g>
+                <polyline points="-5.81,-18.48 -7.20,-19.41"/>
+            </g>
+            <g>
+                <polyline points="-8.59,-20.33 -7.20,-19.41"/>
+            </g>
         </g>
-        <g id="405" title="L100-103-1">
-            <polyline points="-5.81,-18.48 -3.51,-19.00"/>
-            <polyline points="-1.20,-19.52 -3.51,-19.00"/>
+        <g id="405" class="nad-vl120to180" title="L100-103-1">
+            <g>
+                <polyline points="-5.81,-18.48 -3.51,-19.00"/>
+            </g>
+            <g>
+                <polyline points="-1.20,-19.52 -3.51,-19.00"/>
+            </g>
         </g>
-        <g id="406" title="L100-104-1">
-            <polyline points="-5.81,-18.48 -4.63,-18.74"/>
-            <polyline points="-3.45,-19.00 -4.63,-18.74"/>
+        <g id="406" class="nad-vl120to180" title="L100-104-1">
+            <g>
+                <polyline points="-5.81,-18.48 -4.63,-18.74"/>
+            </g>
+            <g>
+                <polyline points="-3.45,-19.00 -4.63,-18.74"/>
+            </g>
         </g>
-        <g id="407" title="L100-106-1">
-            <polyline points="-5.81,-18.48 -5.50,-19.93"/>
-            <polyline points="-5.18,-21.38 -5.50,-19.93"/>
+        <g id="407" class="nad-vl120to180" title="L100-106-1">
+            <g>
+                <polyline points="-5.81,-18.48 -5.50,-19.93"/>
+            </g>
+            <g>
+                <polyline points="-5.18,-21.38 -5.50,-19.93"/>
+            </g>
         </g>
-        <g id="408" title="L101-102-1">
-            <polyline points="-8.59,-20.33 -9.57,-19.69"/>
-            <polyline points="-10.54,-19.05 -9.57,-19.69"/>
+        <g id="408" class="nad-vl120to180" title="L101-102-1">
+            <g>
+                <polyline points="-8.59,-20.33 -9.57,-19.69"/>
+            </g>
+            <g>
+                <polyline points="-10.54,-19.05 -9.57,-19.69"/>
+            </g>
         </g>
-        <g id="409" title="L103-104-1">
-            <polyline points="-1.20,-19.52 -2.32,-19.26"/>
-            <polyline points="-3.45,-19.00 -2.32,-19.26"/>
+        <g id="409" class="nad-vl120to180" title="L103-104-1">
+            <g>
+                <polyline points="-1.20,-19.52 -2.32,-19.26"/>
+            </g>
+            <g>
+                <polyline points="-3.45,-19.00 -2.32,-19.26"/>
+            </g>
         </g>
-        <g id="410" title="L103-105-1">
-            <polyline points="-1.20,-19.52 -1.70,-20.88"/>
-            <polyline points="-2.20,-22.23 -1.70,-20.88"/>
+        <g id="410" class="nad-vl120to180" title="L103-105-1">
+            <g>
+                <polyline points="-1.20,-19.52 -1.70,-20.88"/>
+            </g>
+            <g>
+                <polyline points="-2.20,-22.23 -1.70,-20.88"/>
+            </g>
         </g>
-        <g id="411" title="L103-110-1">
-            <polyline points="-1.20,-19.52 1.09,-20.27"/>
-            <polyline points="3.38,-21.02 1.09,-20.27"/>
+        <g id="411" class="nad-vl120to180" title="L103-110-1">
+            <g>
+                <polyline points="-1.20,-19.52 1.09,-20.27"/>
+            </g>
+            <g>
+                <polyline points="3.38,-21.02 1.09,-20.27"/>
+            </g>
         </g>
-        <g id="412" title="L104-105-1">
-            <polyline points="-3.45,-19.00 -2.83,-20.62"/>
-            <polyline points="-2.20,-22.23 -2.83,-20.62"/>
+        <g id="412" class="nad-vl120to180" title="L104-105-1">
+            <g>
+                <polyline points="-3.45,-19.00 -2.83,-20.62"/>
+            </g>
+            <g>
+                <polyline points="-2.20,-22.23 -2.83,-20.62"/>
+            </g>
         </g>
-        <g id="413" title="L105-106-1">
-            <polyline points="-2.20,-22.23 -3.69,-21.81"/>
-            <polyline points="-5.18,-21.38 -3.69,-21.81"/>
+        <g id="413" class="nad-vl120to180" title="L105-106-1">
+            <g>
+                <polyline points="-2.20,-22.23 -3.69,-21.81"/>
+            </g>
+            <g>
+                <polyline points="-5.18,-21.38 -3.69,-21.81"/>
+            </g>
         </g>
-        <g id="414" title="L105-107-1">
-            <polyline points="-2.20,-22.23 -3.13,-23.17"/>
-            <polyline points="-4.06,-24.10 -3.13,-23.17"/>
+        <g id="414" class="nad-vl120to180" title="L105-107-1">
+            <g>
+                <polyline points="-2.20,-22.23 -3.13,-23.17"/>
+            </g>
+            <g>
+                <polyline points="-4.06,-24.10 -3.13,-23.17"/>
+            </g>
         </g>
-        <g id="415" title="L105-108-1">
-            <polyline points="-2.20,-22.23 -1.02,-23.22"/>
-            <polyline points="0.17,-24.21 -1.02,-23.22"/>
+        <g id="415" class="nad-vl120to180" title="L105-108-1">
+            <g>
+                <polyline points="-2.20,-22.23 -1.02,-23.22"/>
+            </g>
+            <g>
+                <polyline points="0.17,-24.21 -1.02,-23.22"/>
+            </g>
         </g>
-        <g id="416" title="L106-107-1">
-            <polyline points="-5.18,-21.38 -4.62,-22.74"/>
-            <polyline points="-4.06,-24.10 -4.62,-22.74"/>
+        <g id="416" class="nad-vl120to180" title="L106-107-1">
+            <g>
+                <polyline points="-5.18,-21.38 -4.62,-22.74"/>
+            </g>
+            <g>
+                <polyline points="-4.06,-24.10 -4.62,-22.74"/>
+            </g>
         </g>
-        <g id="417" title="L108-109-1">
-            <polyline points="0.17,-24.21 1.45,-24.01"/>
-            <polyline points="2.74,-23.81 1.45,-24.01"/>
+        <g id="417" class="nad-vl120to180" title="L108-109-1">
+            <g>
+                <polyline points="0.17,-24.21 1.45,-24.01"/>
+            </g>
+            <g>
+                <polyline points="2.74,-23.81 1.45,-24.01"/>
+            </g>
         </g>
-        <g id="418" title="L109-110-1">
-            <polyline points="2.74,-23.81 3.06,-22.42"/>
-            <polyline points="3.38,-21.02 3.06,-22.42"/>
+        <g id="418" class="nad-vl120to180" title="L109-110-1">
+            <g>
+                <polyline points="2.74,-23.81 3.06,-22.42"/>
+            </g>
+            <g>
+                <polyline points="3.38,-21.02 3.06,-22.42"/>
+            </g>
         </g>
-        <g id="419" title="L110-111-1">
-            <polyline points="3.38,-21.02 4.79,-21.67"/>
-            <polyline points="6.20,-22.32 4.79,-21.67"/>
+        <g id="419" class="nad-vl120to180" title="L110-111-1">
+            <g>
+                <polyline points="3.38,-21.02 4.79,-21.67"/>
+            </g>
+            <g>
+                <polyline points="6.20,-22.32 4.79,-21.67"/>
+            </g>
         </g>
-        <g id="420" title="L110-112-1">
-            <polyline points="3.38,-21.02 4.51,-20.09"/>
-            <polyline points="5.64,-19.15 4.51,-20.09"/>
+        <g id="420" class="nad-vl120to180" title="L110-112-1">
+            <g>
+                <polyline points="3.38,-21.02 4.51,-20.09"/>
+            </g>
+            <g>
+                <polyline points="5.64,-19.15 4.51,-20.09"/>
+            </g>
         </g>
-        <g id="421" title="L114-115-1">
-            <polyline points="13.77,-7.06 14.70,-7.82"/>
-            <polyline points="15.63,-8.59 14.70,-7.82"/>
+        <g id="421" class="nad-vl120to180" title="L114-115-1">
+            <g>
+                <polyline points="13.77,-7.06 14.70,-7.82"/>
+            </g>
+            <g>
+                <polyline points="15.63,-8.59 14.70,-7.82"/>
+            </g>
         </g>
     </g>
     <g class="nad-vl-nodes">

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -1,99 +1,186 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="774.21" viewBox="-8.95 -7.19 15.08 14.59" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
     <g class="nad-edges">
-        <g id="28" title="L1-2-1">
-            <polyline points="3.84,-3.02 2.61,-3.29"/>
-            <polyline points="1.37,-3.57 2.61,-3.29"/>
+        <g id="28" class="nad-vl120to180" title="L1-2-1">
+            <g>
+                <polyline points="3.84,-3.02 2.61,-3.29"/>
+            </g>
+            <g>
+                <polyline points="1.37,-3.57 2.61,-3.29"/>
+            </g>
         </g>
-        <g id="29" title="L1-5-1">
-            <polyline points="3.84,-3.02 2.86,-1.96"/>
-            <polyline points="1.88,-0.91 2.86,-1.96"/>
+        <g id="29" class="nad-vl120to180" title="L1-5-1">
+            <g>
+                <polyline points="3.84,-3.02 2.86,-1.96"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 2.86,-1.96"/>
+            </g>
         </g>
-        <g id="30" title="L2-3-1">
-            <polyline points="1.37,-3.57 0.42,-4.38"/>
-            <polyline points="-0.54,-5.19 0.42,-4.38"/>
+        <g id="30" class="nad-vl120to180" title="L2-3-1">
+            <g>
+                <polyline points="1.37,-3.57 0.42,-4.38"/>
+            </g>
+            <g>
+                <polyline points="-0.54,-5.19 0.42,-4.38"/>
+            </g>
         </g>
-        <g id="31" title="L2-4-1">
-            <polyline points="1.37,-3.57 0.13,-2.96"/>
-            <polyline points="-1.12,-2.35 0.13,-2.96"/>
+        <g id="31" class="nad-vl120to180" title="L2-4-1">
+            <g>
+                <polyline points="1.37,-3.57 0.13,-2.96"/>
+            </g>
+            <g>
+                <polyline points="-1.12,-2.35 0.13,-2.96"/>
+            </g>
         </g>
-        <g id="32" title="L2-5-1">
-            <polyline points="1.37,-3.57 1.63,-2.24"/>
-            <polyline points="1.88,-0.91 1.63,-2.24"/>
+        <g id="32" class="nad-vl120to180" title="L2-5-1">
+            <g>
+                <polyline points="1.37,-3.57 1.63,-2.24"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 1.63,-2.24"/>
+            </g>
         </g>
-        <g id="33" title="L3-4-1">
-            <polyline points="-0.54,-5.19 -0.83,-3.77"/>
-            <polyline points="-1.12,-2.35 -0.83,-3.77"/>
+        <g id="33" class="nad-vl120to180" title="L3-4-1">
+            <g>
+                <polyline points="-0.54,-5.19 -0.83,-3.77"/>
+            </g>
+            <g>
+                <polyline points="-1.12,-2.35 -0.83,-3.77"/>
+            </g>
         </g>
-        <g id="34" title="L4-5-1">
-            <polyline points="-1.12,-2.35 0.38,-1.63"/>
-            <polyline points="1.88,-0.91 0.38,-1.63"/>
+        <g id="34" class="nad-vl120to180" title="L4-5-1">
+            <g>
+                <polyline points="-1.12,-2.35 0.38,-1.63"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 0.38,-1.63"/>
+            </g>
         </g>
         <g id="35" title="T4-7-1">
-            <polyline points="-1.12,-2.35 -2.69,-2.12"/>
-            <polyline points="-4.25,-1.90 -2.69,-2.12"/>
+            <g class="nad-vl120to180">
+                <polyline points="-1.12,-2.35 -2.69,-2.12"/>
+                <circle cx="-2.59" cy="-2.14" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-4.25,-1.90 -2.69,-2.12"/>
+                <circle cx="-2.78" cy="-2.11" r="0.20"/>
+            </g>
         </g>
         <g id="36" title="T4-9-1">
-            <polyline points="-1.12,-2.35 -1.85,-0.92"/>
-            <polyline points="-2.59,0.50 -1.85,-0.92"/>
+            <g class="nad-vl120to180">
+                <polyline points="-1.12,-2.35 -1.85,-0.92"/>
+                <circle cx="-1.81" cy="-1.01" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-2.59,0.50 -1.85,-0.92"/>
+                <circle cx="-1.90" cy="-0.83" r="0.20"/>
+            </g>
         </g>
         <g id="37" title="T5-6-1">
-            <polyline points="1.88,-0.91 1.82,1.42"/>
-            <polyline points="1.76,3.74 1.82,1.42"/>
+            <g class="nad-vl120to180">
+                <polyline points="1.88,-0.91 1.82,1.42"/>
+                <circle cx="1.82" cy="1.32" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="1.76,3.74 1.82,1.42"/>
+                <circle cx="1.82" cy="1.52" r="0.20"/>
+            </g>
         </g>
-        <g id="38" title="L6-11-1">
-            <polyline points="1.76,3.74 0.34,4.57"/>
-            <polyline points="-1.08,5.40 0.34,4.57"/>
+        <g id="38" class="nad-vl0to30" title="L6-11-1">
+            <g>
+                <polyline points="1.76,3.74 0.34,4.57"/>
+            </g>
+            <g>
+                <polyline points="-1.08,5.40 0.34,4.57"/>
+            </g>
         </g>
-        <g id="39" title="L6-12-1">
-            <polyline points="1.76,3.74 2.94,4.52"/>
-            <polyline points="4.12,5.30 2.94,4.52"/>
+        <g id="39" class="nad-vl0to30" title="L6-12-1">
+            <g>
+                <polyline points="1.76,3.74 2.94,4.52"/>
+            </g>
+            <g>
+                <polyline points="4.12,5.30 2.94,4.52"/>
+            </g>
         </g>
-        <g id="40" title="L6-13-1">
-            <polyline points="1.76,3.74 2.66,3.35"/>
-            <polyline points="3.56,2.95 2.66,3.35"/>
+        <g id="40" class="nad-vl0to30" title="L6-13-1">
+            <g>
+                <polyline points="1.76,3.74 2.66,3.35"/>
+            </g>
+            <g>
+                <polyline points="3.56,2.95 2.66,3.35"/>
+            </g>
         </g>
-        <g id="41" title="L7-8-1">
-            <polyline points="-4.25,-1.90 -5.60,-2.40"/>
-            <polyline points="-6.95,-2.90 -5.60,-2.40"/>
+        <g id="41" class="nad-vl0to30" title="L7-8-1">
+            <g>
+                <polyline points="-4.25,-1.90 -5.60,-2.40"/>
+            </g>
+            <g>
+                <polyline points="-6.95,-2.90 -5.60,-2.40"/>
+            </g>
         </g>
-        <g id="42" title="L7-9-1">
-            <polyline points="-4.25,-1.90 -3.42,-0.70"/>
-            <polyline points="-2.59,0.50 -3.42,-0.70"/>
+        <g id="42" class="nad-vl0to30" title="L7-9-1">
+            <g>
+                <polyline points="-4.25,-1.90 -3.42,-0.70"/>
+            </g>
+            <g>
+                <polyline points="-2.59,0.50 -3.42,-0.70"/>
+            </g>
         </g>
-        <g id="43" title="L9-10-1">
-            <polyline points="-2.59,0.50 -2.97,2.08"/>
-            <polyline points="-3.34,3.67 -2.97,2.08"/>
+        <g id="43" class="nad-vl0to30" title="L9-10-1">
+            <g>
+                <polyline points="-2.59,0.50 -2.97,2.08"/>
+            </g>
+            <g>
+                <polyline points="-3.34,3.67 -2.97,2.08"/>
+            </g>
         </g>
-        <g id="44" title="L9-14-1">
-            <polyline points="-2.59,0.50 -1.17,1.14"/>
-            <polyline points="0.26,1.77 -1.17,1.14"/>
+        <g id="44" class="nad-vl0to30" title="L9-14-1">
+            <g>
+                <polyline points="-2.59,0.50 -1.17,1.14"/>
+            </g>
+            <g>
+                <polyline points="0.26,1.77 -1.17,1.14"/>
+            </g>
         </g>
-        <g id="45" title="L10-11-1">
-            <polyline points="-3.34,3.67 -2.21,4.53"/>
-            <polyline points="-1.08,5.40 -2.21,4.53"/>
+        <g id="45" class="nad-vl0to30" title="L10-11-1">
+            <g>
+                <polyline points="-3.34,3.67 -2.21,4.53"/>
+            </g>
+            <g>
+                <polyline points="-1.08,5.40 -2.21,4.53"/>
+            </g>
         </g>
-        <g id="46" title="L12-13-1">
-            <polyline points="4.12,5.30 3.84,4.13"/>
-            <polyline points="3.56,2.95 3.84,4.13"/>
+        <g id="46" class="nad-vl0to30" title="L12-13-1">
+            <g>
+                <polyline points="4.12,5.30 3.84,4.13"/>
+            </g>
+            <g>
+                <polyline points="3.56,2.95 3.84,4.13"/>
+            </g>
         </g>
-        <g id="47" title="L13-14-1">
-            <polyline points="3.56,2.95 1.91,2.36"/>
-            <polyline points="0.26,1.77 1.91,2.36"/>
+        <g id="47" class="nad-vl0to30" title="L13-14-1">
+            <g>
+                <polyline points="3.56,2.95 1.91,2.36"/>
+            </g>
+            <g>
+                <polyline points="0.26,1.77 1.91,2.36"/>
+            </g>
         </g>
     </g>
     <g class="nad-vl-nodes">

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="774.21" viewBox="-8.95 -7.19 15.08 14.59" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+]]></style>
+    <metadata></metadata>
+    <g class="nad-edges">
+        <g id="28" class="nad-vl120to180" title="L1-2-1">
+            <g>
+                <polyline points="3.84,-3.02 2.61,-3.29"/>
+            </g>
+            <g>
+                <polyline points="1.37,-3.57 2.61,-3.29"/>
+            </g>
+        </g>
+        <g id="29" class="nad-vl120to180" title="L1-5-1">
+            <g>
+                <polyline points="3.84,-3.02 2.86,-1.96"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 2.86,-1.96"/>
+            </g>
+        </g>
+        <g id="30" class="nad-vl120to180" title="L2-3-1">
+            <g>
+                <polyline points="1.37,-3.57 0.42,-4.38"/>
+            </g>
+            <g>
+                <polyline points="-0.54,-5.19 0.42,-4.38"/>
+            </g>
+        </g>
+        <g id="31" class="nad-vl120to180" title="L2-4-1">
+            <g>
+                <polyline points="1.37,-3.57 0.13,-2.96"/>
+            </g>
+            <g>
+                <polyline points="-1.12,-2.35 0.13,-2.96"/>
+            </g>
+        </g>
+        <g id="32" class="nad-vl120to180" title="L2-5-1">
+            <g>
+                <polyline points="1.37,-3.57 1.63,-2.24"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 1.63,-2.24"/>
+            </g>
+        </g>
+        <g id="33" class="nad-vl120to180" title="L3-4-1">
+            <g class="nad-disconnected">
+                <polyline points="-0.54,-5.19 -0.83,-3.77"/>
+            </g>
+            <g>
+                <polyline points="-1.12,-2.35 -0.83,-3.77"/>
+            </g>
+        </g>
+        <g id="34" class="nad-vl120to180" title="L4-5-1">
+            <g>
+                <polyline points="-1.12,-2.35 0.38,-1.63"/>
+            </g>
+            <g>
+                <polyline points="1.88,-0.91 0.38,-1.63"/>
+            </g>
+        </g>
+        <g id="35" title="T4-7-1">
+            <g class="nad-vl120to180">
+                <polyline points="-1.12,-2.35 -2.69,-2.12"/>
+                <circle cx="-2.59" cy="-2.14" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-4.25,-1.90 -2.69,-2.12"/>
+                <circle cx="-2.78" cy="-2.11" r="0.20"/>
+            </g>
+        </g>
+        <g id="36" title="T4-9-1">
+            <g class="nad-vl120to180">
+                <polyline points="-1.12,-2.35 -1.85,-0.92"/>
+                <circle cx="-1.81" cy="-1.01" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-2.59,0.50 -1.85,-0.92"/>
+                <circle cx="-1.90" cy="-0.83" r="0.20"/>
+            </g>
+        </g>
+        <g id="37" title="T5-6-1">
+            <g class="nad-vl120to180">
+                <polyline points="1.88,-0.91 1.82,1.42"/>
+                <circle cx="1.82" cy="1.32" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="1.76,3.74 1.82,1.42"/>
+                <circle cx="1.82" cy="1.52" r="0.20"/>
+            </g>
+        </g>
+        <g id="38" class="nad-vl0to30" title="L6-11-1">
+            <g>
+                <polyline points="1.76,3.74 0.34,4.57"/>
+            </g>
+            <g>
+                <polyline points="-1.08,5.40 0.34,4.57"/>
+            </g>
+        </g>
+        <g id="39" class="nad-vl0to30" title="L6-12-1">
+            <g>
+                <polyline points="1.76,3.74 2.94,4.52"/>
+            </g>
+            <g>
+                <polyline points="4.12,5.30 2.94,4.52"/>
+            </g>
+        </g>
+        <g id="40" class="nad-vl0to30" title="L6-13-1">
+            <g>
+                <polyline points="1.76,3.74 2.66,3.35"/>
+            </g>
+            <g>
+                <polyline points="3.56,2.95 2.66,3.35"/>
+            </g>
+        </g>
+        <g id="41" class="nad-vl0to30" title="L7-8-1">
+            <g>
+                <polyline points="-4.25,-1.90 -5.60,-2.40"/>
+            </g>
+            <g>
+                <polyline points="-6.95,-2.90 -5.60,-2.40"/>
+            </g>
+        </g>
+        <g id="42" class="nad-vl0to30" title="L7-9-1">
+            <g>
+                <polyline points="-4.25,-1.90 -3.42,-0.70"/>
+            </g>
+            <g>
+                <polyline points="-2.59,0.50 -3.42,-0.70"/>
+            </g>
+        </g>
+        <g id="43" class="nad-vl0to30" title="L9-10-1">
+            <g>
+                <polyline points="-2.59,0.50 -2.97,2.08"/>
+            </g>
+            <g>
+                <polyline points="-3.34,3.67 -2.97,2.08"/>
+            </g>
+        </g>
+        <g id="44" class="nad-vl0to30" title="L9-14-1">
+            <g>
+                <polyline points="-2.59,0.50 -1.17,1.14"/>
+            </g>
+            <g>
+                <polyline points="0.26,1.77 -1.17,1.14"/>
+            </g>
+        </g>
+        <g id="45" class="nad-vl0to30" title="L10-11-1">
+            <g>
+                <polyline points="-3.34,3.67 -2.21,4.53"/>
+            </g>
+            <g>
+                <polyline points="-1.08,5.40 -2.21,4.53"/>
+            </g>
+        </g>
+        <g id="46" class="nad-vl0to30" title="L12-13-1">
+            <g>
+                <polyline points="4.12,5.30 3.84,4.13"/>
+            </g>
+            <g>
+                <polyline points="3.56,2.95 3.84,4.13"/>
+            </g>
+        </g>
+        <g id="47" class="nad-vl0to30" title="L13-14-1">
+            <g>
+                <polyline points="3.56,2.95 1.91,2.36"/>
+            </g>
+            <g>
+                <polyline points="0.26,1.77 1.91,2.36"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-vl-nodes">
+        <g transform="translate(3.84,-3.02)">
+            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(1.37,-3.57)">
+            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-0.54,-5.19)">
+            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-1.12,-2.35)">
+            <circle id="6" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(1.88,-0.91)">
+            <circle id="8" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(1.76,3.74)">
+            <circle id="10" class="nad-vl0to30" title="VL6" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-4.25,-1.90)">
+            <circle id="12" class="nad-vl0to30" title="VL7" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-6.95,-2.90)">
+            <circle id="14" class="nad-vl0to30" title="VL8" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-2.59,0.50)">
+            <circle id="16" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-3.34,3.67)">
+            <circle id="18" class="nad-vl0to30" title="VL10" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-1.08,5.40)">
+            <circle id="20" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(4.12,5.30)">
+            <circle id="22" class="nad-vl0to30" title="VL12" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(3.56,2.95)">
+            <circle id="24" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(0.26,1.77)">
+            <circle id="26" class="nad-vl0to30" title="VL14" r="0.60"/>
+            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+    </g>
+</svg>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -73,7 +73,7 @@
             </g>
         </g>
         <g id="35" title="T4-7-1">
-            <g class="nad-vl120to180">
+            <g class="nad-disconnected nad-vl120to180">
                 <polyline points="-1.12,-2.35 -2.69,-2.12"/>
                 <circle cx="-2.59" cy="-2.14" r="0.20"/>
             </g>

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -1,171 +1,336 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="852.54" viewBox="-9.85 -10.79 20.23 21.56" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
     <g class="nad-edges">
-        <g id="48" title="L-1-2-1 ">
-            <polyline points="-2.56,6.78 -1.68,7.75"/>
-            <polyline points="-0.81,8.72 -1.68,7.75"/>
+        <g id="48" class="nad-vl120to180" title="L-1-2-1 ">
+            <g>
+                <polyline points="-2.56,6.78 -1.68,7.75"/>
+            </g>
+            <g>
+                <polyline points="-0.81,8.72 -1.68,7.75"/>
+            </g>
         </g>
-        <g id="49" title="L-3-1-1 ">
-            <polyline points="-2.74,3.22 -2.65,5.00"/>
-            <polyline points="-2.56,6.78 -2.65,5.00"/>
+        <g id="49" class="nad-vl120to180" title="L-3-1-1 ">
+            <g>
+                <polyline points="-2.74,3.22 -2.65,5.00"/>
+            </g>
+            <g>
+                <polyline points="-2.56,6.78 -2.65,5.00"/>
+            </g>
         </g>
-        <g id="50" title="L-1-5-1 ">
-            <polyline points="-2.56,6.78 -0.83,6.84"/>
-            <polyline points="0.89,6.90 -0.83,6.84"/>
+        <g id="50" class="nad-vl120to180" title="L-1-5-1 ">
+            <g>
+                <polyline points="-2.56,6.78 -0.83,6.84"/>
+            </g>
+            <g>
+                <polyline points="0.89,6.90 -0.83,6.84"/>
+            </g>
         </g>
-        <g id="51" title="L-2-4-1 ">
-            <polyline points="-0.81,8.72 -0.72,7.10"/>
-            <polyline points="-0.63,5.48 -0.72,7.10"/>
+        <g id="51" class="nad-vl120to180" title="L-2-4-1 ">
+            <g>
+                <polyline points="-0.81,8.72 -0.72,7.10"/>
+            </g>
+            <g>
+                <polyline points="-0.63,5.48 -0.72,7.10"/>
+            </g>
         </g>
-        <g id="52" title="L-2-6-1 ">
-            <polyline points="-0.81,8.72 0.81,8.74"/>
-            <polyline points="2.43,8.76 0.81,8.74"/>
+        <g id="52" class="nad-vl120to180" title="L-2-6-1 ">
+            <g>
+                <polyline points="-0.81,8.72 0.81,8.74"/>
+            </g>
+            <g>
+                <polyline points="2.43,8.76 0.81,8.74"/>
+            </g>
         </g>
         <g id="53" title="T-24-3-1 ">
-            <polyline points="-4.85,0.21 -3.80,1.72"/>
-            <polyline points="-2.74,3.22 -3.80,1.72"/>
+            <g class="nad-vl180to300">
+                <polyline points="-4.85,0.21 -3.80,1.72"/>
+                <circle cx="-3.85" cy="1.64" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="-2.74,3.22 -3.80,1.72"/>
+                <circle cx="-3.74" cy="1.80" r="0.20"/>
+            </g>
         </g>
-        <g id="54" title="L-3-9-1 ">
-            <polyline points="-2.74,3.22 -0.61,3.25"/>
-            <polyline points="1.52,3.27 -0.61,3.25"/>
+        <g id="54" class="nad-vl120to180" title="L-3-9-1 ">
+            <g>
+                <polyline points="-2.74,3.22 -0.61,3.25"/>
+            </g>
+            <g>
+                <polyline points="1.52,3.27 -0.61,3.25"/>
+            </g>
         </g>
-        <g id="55" title="L-15-24-1 ">
-            <polyline points="-4.99,-3.40 -4.92,-1.59"/>
-            <polyline points="-4.85,0.21 -4.92,-1.59"/>
+        <g id="55" class="nad-vl180to300" title="L-15-24-1 ">
+            <g>
+                <polyline points="-4.99,-3.40 -4.92,-1.59"/>
+            </g>
+            <g>
+                <polyline points="-4.85,0.21 -4.92,-1.59"/>
+            </g>
         </g>
-        <g id="56" title="L-4-9-1 ">
-            <polyline points="-0.63,5.48 0.45,4.38"/>
-            <polyline points="1.52,3.27 0.45,4.38"/>
+        <g id="56" class="nad-vl120to180" title="L-4-9-1 ">
+            <g>
+                <polyline points="-0.63,5.48 0.45,4.38"/>
+            </g>
+            <g>
+                <polyline points="1.52,3.27 0.45,4.38"/>
+            </g>
         </g>
         <g id="57" title="T-5-10-1 ">
-            <polyline points="0.89,6.90 2.08,5.90"/>
-            <polyline points="3.27,4.91 2.08,5.90"/>
+            <g class="nad-vl120to180">
+                <polyline points="0.89,6.90 2.08,5.90"/>
+                <circle cx="2.00" cy="5.97" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="3.27,4.91 2.08,5.90"/>
+                <circle cx="2.16" cy="5.84" r="0.20"/>
+            </g>
         </g>
         <g id="58" title="T-11-9-1 ">
-            <polyline points="1.98,0.84 1.75,2.06"/>
-            <polyline points="1.52,3.27 1.75,2.06"/>
+            <g class="nad-vl180to300">
+                <polyline points="1.98,0.84 1.75,2.06"/>
+                <circle cx="1.77" cy="1.96" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="1.52,3.27 1.75,2.06"/>
+                <circle cx="1.73" cy="2.16" r="0.20"/>
+            </g>
         </g>
         <g id="59" title="T-9-12-1 ">
-            <polyline points="1.52,3.27 3.07,2.47"/>
-            <polyline points="4.61,1.66 3.07,2.47"/>
+            <g class="nad-vl120to180">
+                <polyline points="1.52,3.27 3.07,2.47"/>
+                <circle cx="2.98" cy="2.51" r="0.20"/>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="4.61,1.66 3.07,2.47"/>
+                <circle cx="3.16" cy="2.42" r="0.20"/>
+            </g>
         </g>
-        <g id="60" title="L-8-9-1 ">
-            <polyline points="5.53,5.20 3.53,4.24"/>
-            <polyline points="1.52,3.27 3.53,4.24"/>
+        <g id="60" class="nad-vl180to300" title="L-8-9-1 ">
+            <g>
+                <polyline points="5.53,5.20 3.53,4.24"/>
+            </g>
+            <g>
+                <polyline points="1.52,3.27 3.53,4.24"/>
+            </g>
         </g>
         <g id="61" title="T-11-10-1 ">
-            <polyline points="1.98,0.84 2.62,2.87"/>
-            <polyline points="3.27,4.91 2.62,2.87"/>
+            <g class="nad-vl180to300">
+                <polyline points="1.98,0.84 2.62,2.87"/>
+                <circle cx="2.59" cy="2.78" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="3.27,4.91 2.62,2.87"/>
+                <circle cx="2.65" cy="2.97" r="0.20"/>
+            </g>
         </g>
         <g id="62" title="T-12-10-1 ">
-            <polyline points="4.61,1.66 3.94,3.28"/>
-            <polyline points="3.27,4.91 3.94,3.28"/>
+            <g class="nad-vl180to300">
+                <polyline points="4.61,1.66 3.94,3.28"/>
+                <circle cx="3.98" cy="3.19" r="0.20"/>
+            </g>
+            <g class="nad-vl120to180">
+                <polyline points="3.27,4.91 3.94,3.28"/>
+                <circle cx="3.90" cy="3.38" r="0.20"/>
+            </g>
         </g>
-        <g id="63" title="L-10-6-1 ">
-            <polyline points="3.27,4.91 2.85,6.83"/>
-            <polyline points="2.43,8.76 2.85,6.83"/>
+        <g id="63" class="nad-vl120to180" title="L-10-6-1 ">
+            <g>
+                <polyline points="3.27,4.91 2.85,6.83"/>
+            </g>
+            <g>
+                <polyline points="2.43,8.76 2.85,6.83"/>
+            </g>
         </g>
-        <g id="64" title="L-8-10-1 ">
-            <polyline points="5.53,5.20 4.40,5.05"/>
-            <polyline points="3.27,4.91 4.40,5.05"/>
+        <g id="64" class="nad-vl180to300" title="L-8-10-1 ">
+            <g>
+                <polyline points="5.53,5.20 4.40,5.05"/>
+            </g>
+            <g>
+                <polyline points="3.27,4.91 4.40,5.05"/>
+            </g>
         </g>
-        <g id="65" title="L-11-13-1 ">
-            <polyline points="1.98,0.84 3.25,0.16"/>
-            <polyline points="4.52,-0.53 3.25,0.16"/>
+        <g id="65" class="nad-vl180to300" title="L-11-13-1 ">
+            <g>
+                <polyline points="1.98,0.84 3.25,0.16"/>
+            </g>
+            <g>
+                <polyline points="4.52,-0.53 3.25,0.16"/>
+            </g>
         </g>
-        <g id="66" title="L-11-14-1 ">
-            <polyline points="1.98,0.84 0.99,-0.76"/>
-            <polyline points="0.00,-2.36 0.99,-0.76"/>
+        <g id="66" class="nad-vl180to300" title="L-11-14-1 ">
+            <g>
+                <polyline points="1.98,0.84 0.99,-0.76"/>
+            </g>
+            <g>
+                <polyline points="0.00,-2.36 0.99,-0.76"/>
+            </g>
         </g>
-        <g id="67" title="L-12-13-1 ">
-            <polyline points="4.61,1.66 4.56,0.57"/>
-            <polyline points="4.52,-0.53 4.56,0.57"/>
+        <g id="67" class="nad-vl180to300" title="L-12-13-1 ">
+            <g>
+                <polyline points="4.61,1.66 4.56,0.57"/>
+            </g>
+            <g>
+                <polyline points="4.52,-0.53 4.56,0.57"/>
+            </g>
         </g>
-        <g id="68" title="L-12-23-1 ">
-            <polyline points="4.61,1.66 5.23,-0.29"/>
-            <polyline points="5.84,-2.24 5.23,-0.29"/>
+        <g id="68" class="nad-vl180to300" title="L-12-23-1 ">
+            <g>
+                <polyline points="4.61,1.66 5.23,-0.29"/>
+            </g>
+            <g>
+                <polyline points="5.84,-2.24 5.23,-0.29"/>
+            </g>
         </g>
-        <g id="69" title="L-7-8-1 ">
-            <polyline points="8.37,6.37 6.95,5.78"/>
-            <polyline points="5.53,5.20 6.95,5.78"/>
+        <g id="69" class="nad-vl120to180" title="L-7-8-1 ">
+            <g>
+                <polyline points="8.37,6.37 6.95,5.78"/>
+            </g>
+            <g>
+                <polyline points="5.53,5.20 6.95,5.78"/>
+            </g>
         </g>
-        <g id="70" title="L-23-13-1 ">
-            <polyline points="5.84,-2.24 5.18,-1.38"/>
-            <polyline points="4.52,-0.53 5.18,-1.38"/>
+        <g id="70" class="nad-vl180to300" title="L-23-13-1 ">
+            <g>
+                <polyline points="5.84,-2.24 5.18,-1.38"/>
+            </g>
+            <g>
+                <polyline points="4.52,-0.53 5.18,-1.38"/>
+            </g>
         </g>
-        <g id="71" title="L-14-16-1 ">
-            <polyline points="0.00,-2.36 -0.92,-3.79"/>
-            <polyline points="-1.85,-5.21 -0.92,-3.79"/>
+        <g id="71" class="nad-vl180to300" title="L-14-16-1 ">
+            <g>
+                <polyline points="0.00,-2.36 -0.92,-3.79"/>
+            </g>
+            <g>
+                <polyline points="-1.85,-5.21 -0.92,-3.79"/>
+            </g>
         </g>
-        <g id="72" title="L-16-15-1 ">
-            <polyline points="-1.85,-5.21 -3.42,-4.31"/>
-            <polyline points="-4.99,-3.40 -3.42,-4.31"/>
+        <g id="72" class="nad-vl180to300" title="L-16-15-1 ">
+            <g>
+                <polyline points="-1.85,-5.21 -3.42,-4.31"/>
+            </g>
+            <g>
+                <polyline points="-4.99,-3.40 -3.42,-4.31"/>
+            </g>
         </g>
-        <g id="73" title="L-15-21-1 ">
-            <polyline points="-4.99,-3.40 -5.10,-4.19 -5.45,-4.64"/>
-            <polyline points="-6.54,-5.38 -5.80,-5.08 -5.45,-4.64"/>
+        <g id="73" class="nad-vl180to300" title="L-15-21-1 ">
+            <g>
+                <polyline points="-4.99,-3.40 -5.10,-4.19 -5.45,-4.64"/>
+            </g>
+            <g>
+                <polyline points="-6.54,-5.38 -5.80,-5.08 -5.45,-4.64"/>
+            </g>
         </g>
-        <g id="74" title="L-21-15-2 ">
-            <polyline points="-4.99,-3.40 -5.74,-3.70 -6.08,-4.15"/>
-            <polyline points="-6.54,-5.38 -6.43,-4.59 -6.08,-4.15"/>
+        <g id="74" class="nad-vl180to300" title="L-21-15-2 ">
+            <g>
+                <polyline points="-4.99,-3.40 -5.74,-3.70 -6.08,-4.15"/>
+            </g>
+            <g>
+                <polyline points="-6.54,-5.38 -6.43,-4.59 -6.08,-4.15"/>
+            </g>
         </g>
-        <g id="75" title="L-16-17-1 ">
-            <polyline points="-1.85,-5.21 -3.14,-6.34"/>
-            <polyline points="-4.44,-7.47 -3.14,-6.34"/>
+        <g id="75" class="nad-vl180to300" title="L-16-17-1 ">
+            <g>
+                <polyline points="-1.85,-5.21 -3.14,-6.34"/>
+            </g>
+            <g>
+                <polyline points="-4.44,-7.47 -3.14,-6.34"/>
+            </g>
         </g>
-        <g id="76" title="L-16-19-1 ">
-            <polyline points="-1.85,-5.21 -0.13,-5.83"/>
-            <polyline points="1.59,-6.46 -0.13,-5.83"/>
+        <g id="76" class="nad-vl180to300" title="L-16-19-1 ">
+            <g>
+                <polyline points="-1.85,-5.21 -0.13,-5.83"/>
+            </g>
+            <g>
+                <polyline points="1.59,-6.46 -0.13,-5.83"/>
+            </g>
         </g>
-        <g id="77" title="L-17-18-1 ">
-            <polyline points="-4.44,-7.47 -6.15,-7.32"/>
-            <polyline points="-7.85,-7.16 -6.15,-7.32"/>
+        <g id="77" class="nad-vl180to300" title="L-17-18-1 ">
+            <g>
+                <polyline points="-4.44,-7.47 -6.15,-7.32"/>
+            </g>
+            <g>
+                <polyline points="-7.85,-7.16 -6.15,-7.32"/>
+            </g>
         </g>
-        <g id="78" title="L-17-22-1 ">
-            <polyline points="-4.44,-7.47 -5.31,-8.13"/>
-            <polyline points="-6.18,-8.79 -5.31,-8.13"/>
+        <g id="78" class="nad-vl180to300" title="L-17-22-1 ">
+            <g>
+                <polyline points="-4.44,-7.47 -5.31,-8.13"/>
+            </g>
+            <g>
+                <polyline points="-6.18,-8.79 -5.31,-8.13"/>
+            </g>
         </g>
-        <g id="79" title="L-18-21-1 ">
-            <polyline points="-7.85,-7.16 -7.76,-6.37 -7.52,-6.04"/>
-            <polyline points="-6.54,-5.38 -7.27,-5.70 -7.52,-6.04"/>
+        <g id="79" class="nad-vl180to300" title="L-18-21-1 ">
+            <g>
+                <polyline points="-7.85,-7.16 -7.76,-6.37 -7.52,-6.04"/>
+            </g>
+            <g>
+                <polyline points="-6.54,-5.38 -7.27,-5.70 -7.52,-6.04"/>
+            </g>
         </g>
-        <g id="80" title="L-18-21-2 ">
-            <polyline points="-7.85,-7.16 -7.12,-6.85 -6.87,-6.51"/>
-            <polyline points="-6.54,-5.38 -6.63,-6.18 -6.87,-6.51"/>
+        <g id="80" class="nad-vl180to300" title="L-18-21-2 ">
+            <g>
+                <polyline points="-7.85,-7.16 -7.12,-6.85 -6.87,-6.51"/>
+            </g>
+            <g>
+                <polyline points="-6.54,-5.38 -6.63,-6.18 -6.87,-6.51"/>
+            </g>
         </g>
-        <g id="81" title="L-19-20-1 ">
-            <polyline points="1.59,-6.46 2.11,-5.85 2.98,-5.54"/>
-            <polyline points="4.64,-5.38 3.85,-5.23 2.98,-5.54"/>
+        <g id="81" class="nad-vl180to300" title="L-19-20-1 ">
+            <g>
+                <polyline points="1.59,-6.46 2.11,-5.85 2.98,-5.54"/>
+            </g>
+            <g>
+                <polyline points="4.64,-5.38 3.85,-5.23 2.98,-5.54"/>
+            </g>
         </g>
-        <g id="82" title="L-19-20-2 ">
-            <polyline points="1.59,-6.46 2.38,-6.60 3.25,-6.29"/>
-            <polyline points="4.64,-5.38 4.12,-5.99 3.25,-6.29"/>
+        <g id="82" class="nad-vl180to300" title="L-19-20-2 ">
+            <g>
+                <polyline points="1.59,-6.46 2.38,-6.60 3.25,-6.29"/>
+            </g>
+            <g>
+                <polyline points="4.64,-5.38 4.12,-5.99 3.25,-6.29"/>
+            </g>
         </g>
-        <g id="83" title="L-20-23-1 ">
-            <polyline points="4.64,-5.38 4.51,-4.59 4.86,-3.67"/>
-            <polyline points="5.84,-2.24 5.22,-2.75 4.86,-3.67"/>
+        <g id="83" class="nad-vl180to300" title="L-20-23-1 ">
+            <g>
+                <polyline points="4.64,-5.38 4.51,-4.59 4.86,-3.67"/>
+            </g>
+            <g>
+                <polyline points="5.84,-2.24 5.22,-2.75 4.86,-3.67"/>
+            </g>
         </g>
-        <g id="84" title="L-20-23-2 ">
-            <polyline points="4.64,-5.38 5.26,-4.88 5.61,-3.95"/>
-            <polyline points="5.84,-2.24 5.96,-3.03 5.61,-3.95"/>
+        <g id="84" class="nad-vl180to300" title="L-20-23-2 ">
+            <g>
+                <polyline points="4.64,-5.38 5.26,-4.88 5.61,-3.95"/>
+            </g>
+            <g>
+                <polyline points="5.84,-2.24 5.96,-3.03 5.61,-3.95"/>
+            </g>
         </g>
-        <g id="85" title="L-21-22-1 ">
-            <polyline points="-6.54,-5.38 -6.36,-7.09"/>
-            <polyline points="-6.18,-8.79 -6.36,-7.09"/>
+        <g id="85" class="nad-vl180to300" title="L-21-22-1 ">
+            <g>
+                <polyline points="-6.54,-5.38 -6.36,-7.09"/>
+            </g>
+            <g>
+                <polyline points="-6.18,-8.79 -6.36,-7.09"/>
+            </g>
         </g>
     </g>
     <g class="nad-vl-nodes">

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -1,183 +1,356 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="786.81" viewBox="-12.47 -11.21 23.46 23.08" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
     <g class="nad-edges">
-        <g id="60" title="L1-2-1">
-            <polyline points="3.43,-8.61 2.21,-7.58"/>
-            <polyline points="0.99,-6.56 2.21,-7.58"/>
+        <g id="60" class="nad-vl120to180" title="L1-2-1">
+            <g>
+                <polyline points="3.43,-8.61 2.21,-7.58"/>
+            </g>
+            <g>
+                <polyline points="0.99,-6.56 2.21,-7.58"/>
+            </g>
         </g>
-        <g id="61" title="L1-3-1">
-            <polyline points="3.43,-8.61 4.11,-7.56"/>
-            <polyline points="4.78,-6.52 4.11,-7.56"/>
+        <g id="61" class="nad-vl120to180" title="L1-3-1">
+            <g>
+                <polyline points="3.43,-8.61 4.11,-7.56"/>
+            </g>
+            <g>
+                <polyline points="4.78,-6.52 4.11,-7.56"/>
+            </g>
         </g>
-        <g id="62" title="L2-4-1">
-            <polyline points="0.99,-6.56 1.87,-5.15"/>
-            <polyline points="2.76,-3.75 1.87,-5.15"/>
+        <g id="62" class="nad-vl120to180" title="L2-4-1">
+            <g>
+                <polyline points="0.99,-6.56 1.87,-5.15"/>
+            </g>
+            <g>
+                <polyline points="2.76,-3.75 1.87,-5.15"/>
+            </g>
         </g>
-        <g id="63" title="L2-5-1">
-            <polyline points="0.99,-6.56 0.18,-7.89"/>
-            <polyline points="-0.63,-9.21 0.18,-7.89"/>
+        <g id="63" class="nad-vl120to180" title="L2-5-1">
+            <g>
+                <polyline points="0.99,-6.56 0.18,-7.89"/>
+            </g>
+            <g>
+                <polyline points="-0.63,-9.21 0.18,-7.89"/>
+            </g>
         </g>
-        <g id="64" title="L2-6-1">
-            <polyline points="0.99,-6.56 -0.39,-5.11"/>
-            <polyline points="-1.77,-3.65 -0.39,-5.11"/>
+        <g id="64" class="nad-vl120to180" title="L2-6-1">
+            <g>
+                <polyline points="0.99,-6.56 -0.39,-5.11"/>
+            </g>
+            <g>
+                <polyline points="-1.77,-3.65 -0.39,-5.11"/>
+            </g>
         </g>
-        <g id="65" title="L3-4-1">
-            <polyline points="4.78,-6.52 3.77,-5.13"/>
-            <polyline points="2.76,-3.75 3.77,-5.13"/>
+        <g id="65" class="nad-vl120to180" title="L3-4-1">
+            <g>
+                <polyline points="4.78,-6.52 3.77,-5.13"/>
+            </g>
+            <g>
+                <polyline points="2.76,-3.75 3.77,-5.13"/>
+            </g>
         </g>
-        <g id="66" title="L4-6-1">
-            <polyline points="2.76,-3.75 0.50,-3.70"/>
-            <polyline points="-1.77,-3.65 0.50,-3.70"/>
+        <g id="66" class="nad-vl120to180" title="L4-6-1">
+            <g>
+                <polyline points="2.76,-3.75 0.50,-3.70"/>
+            </g>
+            <g>
+                <polyline points="-1.77,-3.65 0.50,-3.70"/>
+            </g>
         </g>
         <g id="67" title="T4-12-1">
-            <polyline points="2.76,-3.75 4.46,-0.93"/>
-            <polyline points="6.15,1.89 4.46,-0.93"/>
+            <g class="nad-vl120to180">
+                <polyline points="2.76,-3.75 4.46,-0.93"/>
+                <circle cx="4.40" cy="-1.01" r="0.20"/>
+            </g>
+            <g class="nad-vl30to50">
+                <polyline points="6.15,1.89 4.46,-0.93"/>
+                <circle cx="4.51" cy="-0.84" r="0.20"/>
+            </g>
         </g>
-        <g id="68" title="L5-7-1">
-            <polyline points="-0.63,-9.21 -1.48,-8.27"/>
-            <polyline points="-2.32,-7.33 -1.48,-8.27"/>
+        <g id="68" class="nad-vl120to180" title="L5-7-1">
+            <g>
+                <polyline points="-0.63,-9.21 -1.48,-8.27"/>
+            </g>
+            <g>
+                <polyline points="-2.32,-7.33 -1.48,-8.27"/>
+            </g>
         </g>
-        <g id="69" title="L6-7-1">
-            <polyline points="-1.77,-3.65 -2.04,-5.49"/>
-            <polyline points="-2.32,-7.33 -2.04,-5.49"/>
+        <g id="69" class="nad-vl120to180" title="L6-7-1">
+            <g>
+                <polyline points="-1.77,-3.65 -2.04,-5.49"/>
+            </g>
+            <g>
+                <polyline points="-2.32,-7.33 -2.04,-5.49"/>
+            </g>
         </g>
-        <g id="70" title="L6-8-1">
-            <polyline points="-1.77,-3.65 -3.47,-3.00"/>
-            <polyline points="-5.17,-2.35 -3.47,-3.00"/>
+        <g id="70" class="nad-vl120to180" title="L6-8-1">
+            <g>
+                <polyline points="-1.77,-3.65 -3.47,-3.00"/>
+            </g>
+            <g>
+                <polyline points="-5.17,-2.35 -3.47,-3.00"/>
+            </g>
         </g>
         <g id="71" title="T6-9-1">
-            <polyline points="-1.77,-3.65 -2.80,-3.96"/>
-            <polyline points="-3.83,-4.28 -2.80,-3.96"/>
+            <g class="nad-vl120to180">
+                <polyline points="-1.77,-3.65 -2.80,-3.96"/>
+                <circle cx="-2.70" cy="-3.94" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-3.83,-4.28 -2.80,-3.96"/>
+                <circle cx="-2.90" cy="-3.99" r="0.20"/>
+            </g>
         </g>
         <g id="72" title="T6-10-1">
-            <polyline points="-1.77,-3.65 -1.18,-2.23"/>
-            <polyline points="-0.59,-0.81 -1.18,-2.23"/>
+            <g class="nad-vl120to180">
+                <polyline points="-1.77,-3.65 -1.18,-2.23"/>
+                <circle cx="-1.22" cy="-2.32" r="0.20"/>
+            </g>
+            <g class="nad-vl30to50">
+                <polyline points="-0.59,-0.81 -1.18,-2.23"/>
+                <circle cx="-1.14" cy="-2.14" r="0.20"/>
+            </g>
         </g>
-        <g id="73" title="L6-28-1">
-            <polyline points="-1.77,-3.65 -3.72,-1.87"/>
-            <polyline points="-5.67,-0.09 -3.72,-1.87"/>
+        <g id="73" class="nad-vl120to180" title="L6-28-1">
+            <g>
+                <polyline points="-1.77,-3.65 -3.72,-1.87"/>
+            </g>
+            <g>
+                <polyline points="-5.67,-0.09 -3.72,-1.87"/>
+            </g>
         </g>
-        <g id="74" title="L8-28-1">
-            <polyline points="-5.17,-2.35 -5.42,-1.22"/>
-            <polyline points="-5.67,-0.09 -5.42,-1.22"/>
+        <g id="74" class="nad-vl120to180" title="L8-28-1">
+            <g>
+                <polyline points="-5.17,-2.35 -5.42,-1.22"/>
+            </g>
+            <g>
+                <polyline points="-5.67,-0.09 -5.42,-1.22"/>
+            </g>
         </g>
-        <g id="75" title="L9-11-1">
-            <polyline points="-3.83,-4.28 -5.24,-5.26"/>
-            <polyline points="-6.64,-6.25 -5.24,-5.26"/>
+        <g id="75" class="nad-vl0to30" title="L9-11-1">
+            <g>
+                <polyline points="-3.83,-4.28 -5.24,-5.26"/>
+            </g>
+            <g>
+                <polyline points="-6.64,-6.25 -5.24,-5.26"/>
+            </g>
         </g>
-        <g id="76" title="L9-10-1">
-            <polyline points="-3.83,-4.28 -2.21,-2.54"/>
-            <polyline points="-0.59,-0.81 -2.21,-2.54"/>
+        <g id="76" class="nad-vl0to30" title="L9-10-1">
+            <g>
+                <polyline points="-3.83,-4.28 -2.21,-2.54"/>
+            </g>
+            <g>
+                <polyline points="-0.59,-0.81 -2.21,-2.54"/>
+            </g>
         </g>
-        <g id="77" title="L10-20-1">
-            <polyline points="-0.59,-0.81 1.70,-1.13"/>
-            <polyline points="3.99,-1.46 1.70,-1.13"/>
+        <g id="77" class="nad-vl30to50" title="L10-20-1">
+            <g>
+                <polyline points="-0.59,-0.81 1.70,-1.13"/>
+            </g>
+            <g>
+                <polyline points="3.99,-1.46 1.70,-1.13"/>
+            </g>
         </g>
-        <g id="78" title="L10-17-1">
-            <polyline points="-0.59,-0.81 0.45,0.16"/>
-            <polyline points="1.50,1.13 0.45,0.16"/>
+        <g id="78" class="nad-vl30to50" title="L10-17-1">
+            <g>
+                <polyline points="-0.59,-0.81 0.45,0.16"/>
+            </g>
+            <g>
+                <polyline points="1.50,1.13 0.45,0.16"/>
+            </g>
         </g>
-        <g id="79" title="L10-21-1">
-            <polyline points="-0.59,-0.81 -1.43,0.26"/>
-            <polyline points="-2.26,1.32 -1.43,0.26"/>
+        <g id="79" class="nad-vl30to50" title="L10-21-1">
+            <g>
+                <polyline points="-0.59,-0.81 -1.43,0.26"/>
+            </g>
+            <g>
+                <polyline points="-2.26,1.32 -1.43,0.26"/>
+            </g>
         </g>
-        <g id="80" title="L10-22-1">
-            <polyline points="-0.59,-0.81 -0.94,1.26"/>
-            <polyline points="-1.28,3.32 -0.94,1.26"/>
+        <g id="80" class="nad-vl30to50" title="L10-22-1">
+            <g>
+                <polyline points="-0.59,-0.81 -0.94,1.26"/>
+            </g>
+            <g>
+                <polyline points="-1.28,3.32 -0.94,1.26"/>
+            </g>
         </g>
-        <g id="81" title="L12-13-1">
-            <polyline points="6.15,1.89 7.22,3.88"/>
-            <polyline points="8.28,5.88 7.22,3.88"/>
+        <g id="81" class="nad-vl30to50" title="L12-13-1">
+            <g>
+                <polyline points="6.15,1.89 7.22,3.88"/>
+            </g>
+            <g>
+                <polyline points="8.28,5.88 7.22,3.88"/>
+            </g>
         </g>
-        <g id="82" title="L12-14-1">
-            <polyline points="6.15,1.89 7.52,2.62"/>
-            <polyline points="8.90,3.36 7.52,2.62"/>
+        <g id="82" class="nad-vl30to50" title="L12-14-1">
+            <g>
+                <polyline points="6.15,1.89 7.52,2.62"/>
+            </g>
+            <g>
+                <polyline points="8.90,3.36 7.52,2.62"/>
+            </g>
         </g>
-        <g id="83" title="L12-15-1">
-            <polyline points="6.15,1.89 6.37,2.99"/>
-            <polyline points="6.58,4.09 6.37,2.99"/>
+        <g id="83" class="nad-vl30to50" title="L12-15-1">
+            <g>
+                <polyline points="6.15,1.89 6.37,2.99"/>
+            </g>
+            <g>
+                <polyline points="6.58,4.09 6.37,2.99"/>
+            </g>
         </g>
-        <g id="84" title="L12-16-1">
-            <polyline points="6.15,1.89 4.91,2.22"/>
-            <polyline points="3.66,2.54 4.91,2.22"/>
+        <g id="84" class="nad-vl30to50" title="L12-16-1">
+            <g>
+                <polyline points="6.15,1.89 4.91,2.22"/>
+            </g>
+            <g>
+                <polyline points="3.66,2.54 4.91,2.22"/>
+            </g>
         </g>
-        <g id="85" title="L14-15-1">
-            <polyline points="8.90,3.36 7.74,3.72"/>
-            <polyline points="6.58,4.09 7.74,3.72"/>
+        <g id="85" class="nad-vl30to50" title="L14-15-1">
+            <g>
+                <polyline points="8.90,3.36 7.74,3.72"/>
+            </g>
+            <g>
+                <polyline points="6.58,4.09 7.74,3.72"/>
+            </g>
         </g>
-        <g id="86" title="L15-18-1">
-            <polyline points="6.58,4.09 7.79,2.40"/>
-            <polyline points="8.99,0.72 7.79,2.40"/>
+        <g id="86" class="nad-vl30to50" title="L15-18-1">
+            <g>
+                <polyline points="6.58,4.09 7.79,2.40"/>
+            </g>
+            <g>
+                <polyline points="8.99,0.72 7.79,2.40"/>
+            </g>
         </g>
-        <g id="87" title="L15-23-1">
-            <polyline points="6.58,4.09 4.79,5.37"/>
-            <polyline points="3.00,6.66 4.79,5.37"/>
+        <g id="87" class="nad-vl30to50" title="L15-23-1">
+            <g>
+                <polyline points="6.58,4.09 4.79,5.37"/>
+            </g>
+            <g>
+                <polyline points="3.00,6.66 4.79,5.37"/>
+            </g>
         </g>
-        <g id="88" title="L16-17-1">
-            <polyline points="3.66,2.54 2.58,1.83"/>
-            <polyline points="1.50,1.13 2.58,1.83"/>
+        <g id="88" class="nad-vl30to50" title="L16-17-1">
+            <g>
+                <polyline points="3.66,2.54 2.58,1.83"/>
+            </g>
+            <g>
+                <polyline points="1.50,1.13 2.58,1.83"/>
+            </g>
         </g>
-        <g id="89" title="L18-19-1">
-            <polyline points="8.99,0.72 8.27,-0.49"/>
-            <polyline points="7.55,-1.71 8.27,-0.49"/>
+        <g id="89" class="nad-vl30to50" title="L18-19-1">
+            <g>
+                <polyline points="8.99,0.72 8.27,-0.49"/>
+            </g>
+            <g>
+                <polyline points="7.55,-1.71 8.27,-0.49"/>
+            </g>
         </g>
-        <g id="90" title="L19-20-1">
-            <polyline points="7.55,-1.71 5.77,-1.58"/>
-            <polyline points="3.99,-1.46 5.77,-1.58"/>
+        <g id="90" class="nad-vl30to50" title="L19-20-1">
+            <g>
+                <polyline points="7.55,-1.71 5.77,-1.58"/>
+            </g>
+            <g>
+                <polyline points="3.99,-1.46 5.77,-1.58"/>
+            </g>
         </g>
-        <g id="91" title="L21-22-1">
-            <polyline points="-2.26,1.32 -1.77,2.32"/>
-            <polyline points="-1.28,3.32 -1.77,2.32"/>
+        <g id="91" class="nad-vl30to50" title="L21-22-1">
+            <g>
+                <polyline points="-2.26,1.32 -1.77,2.32"/>
+            </g>
+            <g>
+                <polyline points="-1.28,3.32 -1.77,2.32"/>
+            </g>
         </g>
-        <g id="92" title="L22-24-1">
-            <polyline points="-1.28,3.32 -1.14,4.96"/>
-            <polyline points="-1.01,6.59 -1.14,4.96"/>
+        <g id="92" class="nad-vl30to50" title="L22-24-1">
+            <g>
+                <polyline points="-1.28,3.32 -1.14,4.96"/>
+            </g>
+            <g>
+                <polyline points="-1.01,6.59 -1.14,4.96"/>
+            </g>
         </g>
-        <g id="93" title="L23-24-1">
-            <polyline points="3.00,6.66 1.00,6.62"/>
-            <polyline points="-1.01,6.59 1.00,6.62"/>
+        <g id="93" class="nad-vl30to50" title="L23-24-1">
+            <g>
+                <polyline points="3.00,6.66 1.00,6.62"/>
+            </g>
+            <g>
+                <polyline points="-1.01,6.59 1.00,6.62"/>
+            </g>
         </g>
-        <g id="94" title="L24-25-1">
-            <polyline points="-1.01,6.59 -2.93,6.80"/>
-            <polyline points="-4.86,7.02 -2.93,6.80"/>
+        <g id="94" class="nad-vl30to50" title="L24-25-1">
+            <g>
+                <polyline points="-1.01,6.59 -2.93,6.80"/>
+            </g>
+            <g>
+                <polyline points="-4.86,7.02 -2.93,6.80"/>
+            </g>
         </g>
-        <g id="95" title="L25-26-1">
-            <polyline points="-4.86,7.02 -5.22,8.44"/>
-            <polyline points="-5.57,9.86 -5.22,8.44"/>
+        <g id="95" class="nad-vl30to50" title="L25-26-1">
+            <g>
+                <polyline points="-4.86,7.02 -5.22,8.44"/>
+            </g>
+            <g>
+                <polyline points="-5.57,9.86 -5.22,8.44"/>
+            </g>
         </g>
-        <g id="96" title="L25-27-1">
-            <polyline points="-4.86,7.02 -6.22,5.49"/>
-            <polyline points="-7.57,3.96 -6.22,5.49"/>
+        <g id="96" class="nad-vl30to50" title="L25-27-1">
+            <g>
+                <polyline points="-4.86,7.02 -6.22,5.49"/>
+            </g>
+            <g>
+                <polyline points="-7.57,3.96 -6.22,5.49"/>
+            </g>
         </g>
         <g id="97" title="T28-27-1">
-            <polyline points="-5.67,-0.09 -6.62,1.94"/>
-            <polyline points="-7.57,3.96 -6.62,1.94"/>
+            <g class="nad-vl120to180">
+                <polyline points="-5.67,-0.09 -6.62,1.94"/>
+                <circle cx="-6.58" cy="1.85" r="0.20"/>
+            </g>
+            <g class="nad-vl30to50">
+                <polyline points="-7.57,3.96 -6.62,1.94"/>
+                <circle cx="-6.66" cy="2.03" r="0.20"/>
+            </g>
         </g>
-        <g id="98" title="L27-29-1">
-            <polyline points="-7.57,3.96 -9.02,3.74"/>
-            <polyline points="-10.47,3.51 -9.02,3.74"/>
+        <g id="98" class="nad-vl30to50" title="L27-29-1">
+            <g>
+                <polyline points="-7.57,3.96 -9.02,3.74"/>
+            </g>
+            <g>
+                <polyline points="-10.47,3.51 -9.02,3.74"/>
+            </g>
         </g>
-        <g id="99" title="L27-30-1">
-            <polyline points="-7.57,3.96 -8.78,4.79"/>
-            <polyline points="-9.99,5.61 -8.78,4.79"/>
+        <g id="99" class="nad-vl30to50" title="L27-30-1">
+            <g>
+                <polyline points="-7.57,3.96 -8.78,4.79"/>
+            </g>
+            <g>
+                <polyline points="-9.99,5.61 -8.78,4.79"/>
+            </g>
         </g>
-        <g id="100" title="L29-30-1">
-            <polyline points="-10.47,3.51 -10.23,4.56"/>
-            <polyline points="-9.99,5.61 -10.23,4.56"/>
+        <g id="100" class="nad-vl30to50" title="L29-30-1">
+            <g>
+                <polyline points="-10.47,3.51 -10.23,4.56"/>
+            </g>
+            <g>
+                <polyline points="-9.99,5.61 -10.23,4.56"/>
+            </g>
         </g>
     </g>
     <g class="nad-vl-nodes">

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -1,339 +1,694 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="977.06" viewBox="-14.64 -20.78 30.77 37.59" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges {stroke: black; stroke-width: 0.05; fill: none}
+.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
-.nad-vl-nodes {fill: lightblue}
-.nad-vl0to30 {fill: #AFB42B}
-.nad-vl30to50 {fill: #EF9A9A}
-.nad-vl50to70 {fill: #9C27B0}
-.nad-vl120to180 {fill: #00ACC1}
-.nad-vl70to120 {fill: #E65100}
-.nad-vl180to300 {fill: #2E7D32}
-.nad-vl300to500 {fill: #D32F2F}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
     <g class="nad-edges">
-        <g id="114" title="L1-2-1">
-            <polyline points="-7.03,10.20 -6.09,11.46"/>
-            <polyline points="-5.14,12.72 -6.09,11.46"/>
+        <g id="114" class="nad-vl0to30" title="L1-2-1">
+            <g>
+                <polyline points="-7.03,10.20 -6.09,11.46"/>
+            </g>
+            <g>
+                <polyline points="-5.14,12.72 -6.09,11.46"/>
+            </g>
         </g>
-        <g id="115" title="L1-15-1">
-            <polyline points="-7.03,10.20 -5.68,8.52"/>
-            <polyline points="-4.33,6.84 -5.68,8.52"/>
+        <g id="115" class="nad-vl0to30" title="L1-15-1">
+            <g>
+                <polyline points="-7.03,10.20 -5.68,8.52"/>
+            </g>
+            <g>
+                <polyline points="-4.33,6.84 -5.68,8.52"/>
+            </g>
         </g>
-        <g id="116" title="L1-16-1">
-            <polyline points="-7.03,10.20 -8.18,10.49"/>
-            <polyline points="-9.33,10.78 -8.18,10.49"/>
+        <g id="116" class="nad-vl0to30" title="L1-16-1">
+            <g>
+                <polyline points="-7.03,10.20 -8.18,10.49"/>
+            </g>
+            <g>
+                <polyline points="-9.33,10.78 -8.18,10.49"/>
+            </g>
         </g>
-        <g id="117" title="L1-17-1">
-            <polyline points="-7.03,10.20 -8.66,9.60"/>
-            <polyline points="-10.30,8.99 -8.66,9.60"/>
+        <g id="117" class="nad-vl0to30" title="L1-17-1">
+            <g>
+                <polyline points="-7.03,10.20 -8.66,9.60"/>
+            </g>
+            <g>
+                <polyline points="-10.30,8.99 -8.66,9.60"/>
+            </g>
         </g>
-        <g id="118" title="L2-3-1">
-            <polyline points="-5.14,12.72 -3.77,12.13"/>
-            <polyline points="-2.40,11.54 -3.77,12.13"/>
+        <g id="118" class="nad-vl0to30" title="L2-3-1">
+            <g>
+                <polyline points="-5.14,12.72 -3.77,12.13"/>
+            </g>
+            <g>
+                <polyline points="-2.40,11.54 -3.77,12.13"/>
+            </g>
         </g>
-        <g id="119" title="L3-4-1">
-            <polyline points="-2.40,11.54 -0.28,12.41"/>
-            <polyline points="1.83,13.29 -0.28,12.41"/>
+        <g id="119" class="nad-vl0to30" title="L3-4-1">
+            <g>
+                <polyline points="-2.40,11.54 -0.28,12.41"/>
+            </g>
+            <g>
+                <polyline points="1.83,13.29 -0.28,12.41"/>
+            </g>
         </g>
-        <g id="120" title="L3-15-1">
-            <polyline points="-2.40,11.54 -3.37,9.19"/>
-            <polyline points="-4.33,6.84 -3.37,9.19"/>
+        <g id="120" class="nad-vl0to30" title="L3-15-1">
+            <g>
+                <polyline points="-2.40,11.54 -3.37,9.19"/>
+            </g>
+            <g>
+                <polyline points="-4.33,6.84 -3.37,9.19"/>
+            </g>
         </g>
-        <g id="121" title="L4-5-1">
-            <polyline points="1.83,13.29 2.52,14.04"/>
-            <polyline points="3.21,14.80 2.52,14.04"/>
+        <g id="121" class="nad-vl0to30" title="L4-5-1">
+            <g>
+                <polyline points="1.83,13.29 2.52,14.04"/>
+            </g>
+            <g>
+                <polyline points="3.21,14.80 2.52,14.04"/>
+            </g>
         </g>
-        <g id="122" title="L4-6-1">
-            <polyline points="1.83,13.29 2.15,12.30"/>
-            <polyline points="2.46,11.32 2.15,12.30"/>
+        <g id="122" class="nad-vl0to30" title="L4-6-1">
+            <g>
+                <polyline points="1.83,13.29 2.15,12.30"/>
+            </g>
+            <g>
+                <polyline points="2.46,11.32 2.15,12.30"/>
+            </g>
         </g>
         <g id="123" title="T4-18-1">
-            <polyline points="1.83,13.29 2.57,13.60 4.21,13.41"/>
-            <polyline points="6.49,12.74 5.85,13.22 4.21,13.41"/>
+            <g class="nad-vl0to30">
+                <polyline points="1.83,13.29 2.57,13.60 4.21,13.41"/>
+                <circle cx="4.11" cy="13.42" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="6.49,12.74 5.85,13.22 4.21,13.41"/>
+                <circle cx="4.31" cy="13.40" r="0.20"/>
+            </g>
         </g>
         <g id="124" title="T4-18-2">
-            <polyline points="1.83,13.29 2.48,12.81 4.11,12.62"/>
-            <polyline points="6.49,12.74 5.75,12.42 4.11,12.62"/>
+            <g class="nad-vl0to30">
+                <polyline points="1.83,13.29 2.48,12.81 4.11,12.62"/>
+                <circle cx="4.02" cy="12.63" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="6.49,12.74 5.75,12.42 4.11,12.62"/>
+                <circle cx="4.21" cy="12.60" r="0.20"/>
+            </g>
         </g>
-        <g id="125" title="L5-6-1">
-            <polyline points="3.21,14.80 2.83,13.06"/>
-            <polyline points="2.46,11.32 2.83,13.06"/>
+        <g id="125" class="nad-vl0to30" title="L5-6-1">
+            <g>
+                <polyline points="3.21,14.80 2.83,13.06"/>
+            </g>
+            <g>
+                <polyline points="2.46,11.32 2.83,13.06"/>
+            </g>
         </g>
-        <g id="126" title="L6-7-1">
-            <polyline points="2.46,11.32 3.27,10.08"/>
-            <polyline points="4.08,8.85 3.27,10.08"/>
+        <g id="126" class="nad-vl0to30" title="L6-7-1">
+            <g>
+                <polyline points="2.46,11.32 3.27,10.08"/>
+            </g>
+            <g>
+                <polyline points="4.08,8.85 3.27,10.08"/>
+            </g>
         </g>
-        <g id="127" title="L6-8-1">
-            <polyline points="2.46,11.32 1.18,10.00"/>
-            <polyline points="-0.09,8.68 1.18,10.00"/>
+        <g id="127" class="nad-vl0to30" title="L6-8-1">
+            <g>
+                <polyline points="2.46,11.32 1.18,10.00"/>
+            </g>
+            <g>
+                <polyline points="-0.09,8.68 1.18,10.00"/>
+            </g>
         </g>
-        <g id="128" title="L7-8-1">
-            <polyline points="4.08,8.85 1.99,8.76"/>
-            <polyline points="-0.09,8.68 1.99,8.76"/>
+        <g id="128" class="nad-vl0to30" title="L7-8-1">
+            <g>
+                <polyline points="4.08,8.85 1.99,8.76"/>
+            </g>
+            <g>
+                <polyline points="-0.09,8.68 1.99,8.76"/>
+            </g>
         </g>
         <g id="129" title="T7-29-1">
-            <polyline points="4.08,8.85 6.09,7.68"/>
-            <polyline points="8.10,6.52 6.09,7.68"/>
+            <g class="nad-vl0to30">
+                <polyline points="4.08,8.85 6.09,7.68"/>
+                <circle cx="6.00" cy="7.73" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="8.10,6.52 6.09,7.68"/>
+                <circle cx="6.18" cy="7.63" r="0.20"/>
+            </g>
         </g>
-        <g id="130" title="L8-9-1">
-            <polyline points="-0.09,8.68 -3.14,6.94"/>
-            <polyline points="-6.18,5.19 -3.14,6.94"/>
+        <g id="130" class="nad-vl0to30" title="L8-9-1">
+            <g>
+                <polyline points="-0.09,8.68 -3.14,6.94"/>
+            </g>
+            <g>
+                <polyline points="-6.18,5.19 -3.14,6.94"/>
+            </g>
         </g>
-        <g id="131" title="L9-10-1">
-            <polyline points="-6.18,5.19 -8.25,5.01"/>
-            <polyline points="-10.33,4.82 -8.25,5.01"/>
+        <g id="131" class="nad-vl0to30" title="L9-10-1">
+            <g>
+                <polyline points="-6.18,5.19 -8.25,5.01"/>
+            </g>
+            <g>
+                <polyline points="-10.33,4.82 -8.25,5.01"/>
+            </g>
         </g>
-        <g id="132" title="L9-11-1">
-            <polyline points="-6.18,5.19 -7.37,2.48"/>
-            <polyline points="-8.56,-0.23 -7.37,2.48"/>
+        <g id="132" class="nad-vl0to30" title="L9-11-1">
+            <g>
+                <polyline points="-6.18,5.19 -7.37,2.48"/>
+            </g>
+            <g>
+                <polyline points="-8.56,-0.23 -7.37,2.48"/>
+            </g>
         </g>
-        <g id="133" title="L9-12-1">
-            <polyline points="-6.18,5.19 -7.51,6.00"/>
-            <polyline points="-8.83,6.82 -7.51,6.00"/>
+        <g id="133" class="nad-vl0to30" title="L9-12-1">
+            <g>
+                <polyline points="-6.18,5.19 -7.51,6.00"/>
+            </g>
+            <g>
+                <polyline points="-8.83,6.82 -7.51,6.00"/>
+            </g>
         </g>
-        <g id="134" title="L9-13-1">
-            <polyline points="-6.18,5.19 -6.53,4.13"/>
-            <polyline points="-6.88,3.07 -6.53,4.13"/>
+        <g id="134" class="nad-vl0to30" title="L9-13-1">
+            <g>
+                <polyline points="-6.18,5.19 -6.53,4.13"/>
+            </g>
+            <g>
+                <polyline points="-6.88,3.07 -6.53,4.13"/>
+            </g>
         </g>
         <g id="135" title="T9-55-1">
-            <polyline points="-6.18,5.19 -4.04,5.46"/>
-            <polyline points="-1.90,5.73 -4.04,5.46"/>
+            <g class="nad-vl0to30">
+                <polyline points="-6.18,5.19 -4.04,5.46"/>
+                <circle cx="-4.14" cy="5.45" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-1.90,5.73 -4.04,5.46"/>
+                <circle cx="-3.94" cy="5.47" r="0.20"/>
+            </g>
         </g>
-        <g id="136" title="L10-12-1">
-            <polyline points="-10.33,4.82 -9.58,5.82"/>
-            <polyline points="-8.83,6.82 -9.58,5.82"/>
+        <g id="136" class="nad-vl0to30" title="L10-12-1">
+            <g>
+                <polyline points="-10.33,4.82 -9.58,5.82"/>
+            </g>
+            <g>
+                <polyline points="-8.83,6.82 -9.58,5.82"/>
+            </g>
         </g>
         <g id="137" title="T10-51-1">
-            <polyline points="-10.33,4.82 -11.48,3.76"/>
-            <polyline points="-12.64,2.69 -11.48,3.76"/>
+            <g class="nad-vl0to30">
+                <polyline points="-10.33,4.82 -11.48,3.76"/>
+                <circle cx="-11.41" cy="3.83" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-12.64,2.69 -11.48,3.76"/>
+                <circle cx="-11.56" cy="3.69" r="0.20"/>
+            </g>
         </g>
-        <g id="138" title="L11-13-1">
-            <polyline points="-8.56,-0.23 -7.72,1.42"/>
-            <polyline points="-6.88,3.07 -7.72,1.42"/>
+        <g id="138" class="nad-vl0to30" title="L11-13-1">
+            <g>
+                <polyline points="-8.56,-0.23 -7.72,1.42"/>
+            </g>
+            <g>
+                <polyline points="-6.88,3.07 -7.72,1.42"/>
+            </g>
         </g>
         <g id="139" title="T11-41-1">
-            <polyline points="-8.56,-0.23 -9.34,-2.82"/>
-            <polyline points="-10.12,-5.40 -9.34,-2.82"/>
+            <g class="nad-vl0to30">
+                <polyline points="-8.56,-0.23 -9.34,-2.82"/>
+                <circle cx="-9.31" cy="-2.72" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-10.12,-5.40 -9.34,-2.82"/>
+                <circle cx="-9.37" cy="-2.91" r="0.20"/>
+            </g>
         </g>
         <g id="140" title="T11-43-1">
-            <polyline points="-8.56,-0.23 -9.68,-1.59"/>
-            <polyline points="-10.79,-2.94 -9.68,-1.59"/>
+            <g class="nad-vl0to30">
+                <polyline points="-8.56,-0.23 -9.68,-1.59"/>
+                <circle cx="-9.61" cy="-1.51" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-10.79,-2.94 -9.68,-1.59"/>
+                <circle cx="-9.74" cy="-1.66" r="0.20"/>
+            </g>
         </g>
-        <g id="141" title="L12-13-1">
-            <polyline points="-8.83,6.82 -7.85,4.94"/>
-            <polyline points="-6.88,3.07 -7.85,4.94"/>
+        <g id="141" class="nad-vl0to30" title="L12-13-1">
+            <g>
+                <polyline points="-8.83,6.82 -7.85,4.94"/>
+            </g>
+            <g>
+                <polyline points="-6.88,3.07 -7.85,4.94"/>
+            </g>
         </g>
-        <g id="142" title="L12-16-1">
-            <polyline points="-8.83,6.82 -9.08,8.80"/>
-            <polyline points="-9.33,10.78 -9.08,8.80"/>
+        <g id="142" class="nad-vl0to30" title="L12-16-1">
+            <g>
+                <polyline points="-8.83,6.82 -9.08,8.80"/>
+            </g>
+            <g>
+                <polyline points="-9.33,10.78 -9.08,8.80"/>
+            </g>
         </g>
-        <g id="143" title="L12-17-1">
-            <polyline points="-8.83,6.82 -9.57,7.91"/>
-            <polyline points="-10.30,8.99 -9.57,7.91"/>
+        <g id="143" class="nad-vl0to30" title="L12-17-1">
+            <g>
+                <polyline points="-8.83,6.82 -9.57,7.91"/>
+            </g>
+            <g>
+                <polyline points="-10.30,8.99 -9.57,7.91"/>
+            </g>
         </g>
-        <g id="144" title="L13-14-1">
-            <polyline points="-6.88,3.07 -5.67,3.26"/>
-            <polyline points="-4.46,3.45 -5.67,3.26"/>
+        <g id="144" class="nad-vl0to30" title="L13-14-1">
+            <g>
+                <polyline points="-6.88,3.07 -5.67,3.26"/>
+            </g>
+            <g>
+                <polyline points="-4.46,3.45 -5.67,3.26"/>
+            </g>
         </g>
-        <g id="145" title="L13-15-1">
-            <polyline points="-6.88,3.07 -5.60,4.95"/>
-            <polyline points="-4.33,6.84 -5.60,4.95"/>
+        <g id="145" class="nad-vl0to30" title="L13-15-1">
+            <g>
+                <polyline points="-6.88,3.07 -5.60,4.95"/>
+            </g>
+            <g>
+                <polyline points="-4.33,6.84 -5.60,4.95"/>
+            </g>
         </g>
         <g id="146" title="T13-49-1">
-            <polyline points="-6.88,3.07 -6.29,0.80"/>
-            <polyline points="-5.70,-1.46 -6.29,0.80"/>
+            <g class="nad-vl0to30">
+                <polyline points="-6.88,3.07 -6.29,0.80"/>
+                <circle cx="-6.31" cy="0.90" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-5.70,-1.46 -6.29,0.80"/>
+                <circle cx="-6.26" cy="0.70" r="0.20"/>
+            </g>
         </g>
-        <g id="147" title="L14-15-1">
-            <polyline points="-4.46,3.45 -4.39,5.15"/>
-            <polyline points="-4.33,6.84 -4.39,5.15"/>
+        <g id="147" class="nad-vl0to30" title="L14-15-1">
+            <g>
+                <polyline points="-4.46,3.45 -4.39,5.15"/>
+            </g>
+            <g>
+                <polyline points="-4.33,6.84 -4.39,5.15"/>
+            </g>
         </g>
         <g id="148" title="T14-46-1">
-            <polyline points="-4.46,3.45 -3.97,2.08"/>
-            <polyline points="-3.48,0.72 -3.97,2.08"/>
+            <g class="nad-vl0to30">
+                <polyline points="-4.46,3.45 -3.97,2.08"/>
+                <circle cx="-4.00" cy="2.18" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-3.48,0.72 -3.97,2.08"/>
+                <circle cx="-3.93" cy="1.99" r="0.20"/>
+            </g>
         </g>
         <g id="149" title="T15-45-1">
-            <polyline points="-4.33,6.84 -2.73,4.86"/>
-            <polyline points="-1.12,2.87 -2.73,4.86"/>
+            <g class="nad-vl0to30">
+                <polyline points="-4.33,6.84 -2.73,4.86"/>
+                <circle cx="-2.79" cy="4.94" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-1.12,2.87 -2.73,4.86"/>
+                <circle cx="-2.66" cy="4.78" r="0.20"/>
+            </g>
         </g>
-        <g id="150" title="L18-19-1">
-            <polyline points="6.49,12.74 8.01,11.50"/>
-            <polyline points="9.54,10.26 8.01,11.50"/>
+        <g id="150" class="nad-vl0to30" title="L18-19-1">
+            <g>
+                <polyline points="6.49,12.74 8.01,11.50"/>
+            </g>
+            <g>
+                <polyline points="9.54,10.26 8.01,11.50"/>
+            </g>
         </g>
-        <g id="151" title="L19-20-1">
-            <polyline points="9.54,10.26 10.01,8.22"/>
-            <polyline points="10.49,6.18 10.01,8.22"/>
+        <g id="151" class="nad-vl0to30" title="L19-20-1">
+            <g>
+                <polyline points="9.54,10.26 10.01,8.22"/>
+            </g>
+            <g>
+                <polyline points="10.49,6.18 10.01,8.22"/>
+            </g>
         </g>
         <g id="152" title="T21-20-1">
-            <polyline points="8.54,1.31 9.52,3.74"/>
-            <polyline points="10.49,6.18 9.52,3.74"/>
+            <g class="nad-vl0to30">
+                <polyline points="8.54,1.31 9.52,3.74"/>
+                <circle cx="9.48" cy="3.65" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="10.49,6.18 9.52,3.74"/>
+                <circle cx="9.55" cy="3.84" r="0.20"/>
+            </g>
         </g>
-        <g id="153" title="L21-22-1">
-            <polyline points="8.54,1.31 7.08,-0.63"/>
-            <polyline points="5.62,-2.58 7.08,-0.63"/>
+        <g id="153" class="nad-vl0to30" title="L21-22-1">
+            <g>
+                <polyline points="8.54,1.31 7.08,-0.63"/>
+            </g>
+            <g>
+                <polyline points="5.62,-2.58 7.08,-0.63"/>
+            </g>
         </g>
-        <g id="154" title="L22-23-1">
-            <polyline points="5.62,-2.58 7.28,-3.46"/>
-            <polyline points="8.93,-4.35 7.28,-3.46"/>
+        <g id="154" class="nad-vl0to30" title="L22-23-1">
+            <g>
+                <polyline points="5.62,-2.58 7.28,-3.46"/>
+            </g>
+            <g>
+                <polyline points="8.93,-4.35 7.28,-3.46"/>
+            </g>
         </g>
-        <g id="155" title="L22-38-1">
-            <polyline points="5.62,-2.58 2.65,-3.25"/>
-            <polyline points="-0.32,-3.93 2.65,-3.25"/>
+        <g id="155" class="nad-vl0to30" title="L22-38-1">
+            <g>
+                <polyline points="5.62,-2.58 2.65,-3.25"/>
+            </g>
+            <g>
+                <polyline points="-0.32,-3.93 2.65,-3.25"/>
+            </g>
         </g>
-        <g id="156" title="L23-24-1">
-            <polyline points="8.93,-4.35 10.58,-4.86"/>
-            <polyline points="12.23,-5.38 10.58,-4.86"/>
+        <g id="156" class="nad-vl0to30" title="L23-24-1">
+            <g>
+                <polyline points="8.93,-4.35 10.58,-4.86"/>
+            </g>
+            <g>
+                <polyline points="12.23,-5.38 10.58,-4.86"/>
+            </g>
         </g>
         <g id="157" title="T24-25-1">
-            <polyline points="12.23,-5.38 12.69,-6.03 12.78,-7.03"/>
-            <polyline points="12.54,-8.75 12.87,-8.02 12.78,-7.03"/>
+            <g class="nad-vl0to30">
+                <polyline points="12.23,-5.38 12.69,-6.03 12.78,-7.03"/>
+                <circle cx="12.77" cy="-6.93" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="12.54,-8.75 12.87,-8.02 12.78,-7.03"/>
+                <circle cx="12.79" cy="-7.13" r="0.20"/>
+            </g>
         </g>
         <g id="158" title="T24-25-2">
-            <polyline points="12.23,-5.38 11.90,-6.10 11.99,-7.10"/>
-            <polyline points="12.54,-8.75 12.08,-8.09 11.99,-7.10"/>
+            <g class="nad-vl0to30">
+                <polyline points="12.23,-5.38 11.90,-6.10 11.99,-7.10"/>
+                <circle cx="11.98" cy="-7.00" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="12.54,-8.75 12.08,-8.09 11.99,-7.10"/>
+                <circle cx="12.00" cy="-7.20" r="0.20"/>
+            </g>
         </g>
         <g id="159" title="T24-26-1">
-            <polyline points="12.23,-5.38 13.18,-3.94"/>
-            <polyline points="14.12,-2.50 13.18,-3.94"/>
+            <g class="nad-vl0to30">
+                <polyline points="12.23,-5.38 13.18,-3.94"/>
+                <circle cx="13.12" cy="-4.02" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="14.12,-2.50 13.18,-3.94"/>
+                <circle cx="13.23" cy="-3.86" r="0.20"/>
+            </g>
         </g>
-        <g id="160" title="L25-30-1">
-            <polyline points="12.54,-8.75 12.06,-10.26"/>
-            <polyline points="11.58,-11.77 12.06,-10.26"/>
+        <g id="160" class="nad-vl0to30" title="L25-30-1">
+            <g>
+                <polyline points="12.54,-8.75 12.06,-10.26"/>
+            </g>
+            <g>
+                <polyline points="11.58,-11.77 12.06,-10.26"/>
+            </g>
         </g>
-        <g id="161" title="L26-27-1">
-            <polyline points="14.12,-2.50 14.13,-0.85"/>
-            <polyline points="14.13,0.81 14.13,-0.85"/>
+        <g id="161" class="nad-vl0to30" title="L26-27-1">
+            <g>
+                <polyline points="14.12,-2.50 14.13,-0.85"/>
+            </g>
+            <g>
+                <polyline points="14.13,0.81 14.13,-0.85"/>
+            </g>
         </g>
-        <g id="162" title="L27-28-1">
-            <polyline points="14.13,0.81 13.13,2.29"/>
-            <polyline points="12.13,3.77 13.13,2.29"/>
+        <g id="162" class="nad-vl0to30" title="L27-28-1">
+            <g>
+                <polyline points="14.13,0.81 13.13,2.29"/>
+            </g>
+            <g>
+                <polyline points="12.13,3.77 13.13,2.29"/>
+            </g>
         </g>
-        <g id="163" title="L28-29-1">
-            <polyline points="12.13,3.77 10.11,5.14"/>
-            <polyline points="8.10,6.52 10.11,5.14"/>
+        <g id="163" class="nad-vl0to30" title="L28-29-1">
+            <g>
+                <polyline points="12.13,3.77 10.11,5.14"/>
+            </g>
+            <g>
+                <polyline points="8.10,6.52 10.11,5.14"/>
+            </g>
         </g>
-        <g id="164" title="L29-52-1">
-            <polyline points="8.10,6.52 7.41,5.59"/>
-            <polyline points="6.72,4.66 7.41,5.59"/>
+        <g id="164" class="nad-vl0to30" title="L29-52-1">
+            <g>
+                <polyline points="8.10,6.52 7.41,5.59"/>
+            </g>
+            <g>
+                <polyline points="6.72,4.66 7.41,5.59"/>
+            </g>
         </g>
-        <g id="165" title="L30-31-1">
-            <polyline points="11.58,-11.77 10.57,-13.00"/>
-            <polyline points="9.57,-14.22 10.57,-13.00"/>
+        <g id="165" class="nad-vl0to30" title="L30-31-1">
+            <g>
+                <polyline points="11.58,-11.77 10.57,-13.00"/>
+            </g>
+            <g>
+                <polyline points="9.57,-14.22 10.57,-13.00"/>
+            </g>
         </g>
-        <g id="166" title="L31-32-1">
-            <polyline points="9.57,-14.22 8.24,-15.21"/>
-            <polyline points="6.90,-16.19 8.24,-15.21"/>
+        <g id="166" class="nad-vl0to30" title="L31-32-1">
+            <g>
+                <polyline points="9.57,-14.22 8.24,-15.21"/>
+            </g>
+            <g>
+                <polyline points="6.90,-16.19 8.24,-15.21"/>
+            </g>
         </g>
-        <g id="167" title="L32-33-1">
-            <polyline points="6.90,-16.19 7.26,-17.49"/>
-            <polyline points="7.62,-18.78 7.26,-17.49"/>
+        <g id="167" class="nad-vl0to30" title="L32-33-1">
+            <g>
+                <polyline points="6.90,-16.19 7.26,-17.49"/>
+            </g>
+            <g>
+                <polyline points="7.62,-18.78 7.26,-17.49"/>
+            </g>
         </g>
         <g id="168" title="T34-32-1">
-            <polyline points="3.58,-15.95 5.24,-16.07"/>
-            <polyline points="6.90,-16.19 5.24,-16.07"/>
+            <g class="nad-vl0to30">
+                <polyline points="3.58,-15.95 5.24,-16.07"/>
+                <circle cx="5.14" cy="-16.06" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="6.90,-16.19 5.24,-16.07"/>
+                <circle cx="5.34" cy="-16.08" r="0.20"/>
+            </g>
         </g>
-        <g id="169" title="L34-35-1">
-            <polyline points="3.58,-15.95 2.04,-15.41"/>
-            <polyline points="0.50,-14.87 2.04,-15.41"/>
+        <g id="169" class="nad-vl0to30" title="L34-35-1">
+            <g>
+                <polyline points="3.58,-15.95 2.04,-15.41"/>
+            </g>
+            <g>
+                <polyline points="0.50,-14.87 2.04,-15.41"/>
+            </g>
         </g>
-        <g id="170" title="L35-36-1">
-            <polyline points="0.50,-14.87 -0.87,-13.75"/>
-            <polyline points="-2.25,-12.64 -0.87,-13.75"/>
+        <g id="170" class="nad-vl0to30" title="L35-36-1">
+            <g>
+                <polyline points="0.50,-14.87 -0.87,-13.75"/>
+            </g>
+            <g>
+                <polyline points="-2.25,-12.64 -0.87,-13.75"/>
+            </g>
         </g>
-        <g id="171" title="L36-37-1">
-            <polyline points="-2.25,-12.64 -1.80,-10.68"/>
-            <polyline points="-1.36,-8.72 -1.80,-10.68"/>
+        <g id="171" class="nad-vl0to30" title="L36-37-1">
+            <g>
+                <polyline points="-2.25,-12.64 -1.80,-10.68"/>
+            </g>
+            <g>
+                <polyline points="-1.36,-8.72 -1.80,-10.68"/>
+            </g>
         </g>
-        <g id="172" title="L36-40-1">
-            <polyline points="-2.25,-12.64 -4.22,-12.63"/>
-            <polyline points="-6.20,-12.61 -4.22,-12.63"/>
+        <g id="172" class="nad-vl0to30" title="L36-40-1">
+            <g>
+                <polyline points="-2.25,-12.64 -4.22,-12.63"/>
+            </g>
+            <g>
+                <polyline points="-6.20,-12.61 -4.22,-12.63"/>
+            </g>
         </g>
-        <g id="173" title="L37-38-1">
-            <polyline points="-1.36,-8.72 -0.84,-6.32"/>
-            <polyline points="-0.32,-3.93 -0.84,-6.32"/>
+        <g id="173" class="nad-vl0to30" title="L37-38-1">
+            <g>
+                <polyline points="-1.36,-8.72 -0.84,-6.32"/>
+            </g>
+            <g>
+                <polyline points="-0.32,-3.93 -0.84,-6.32"/>
+            </g>
         </g>
-        <g id="174" title="L37-39-1">
-            <polyline points="-1.36,-8.72 -2.66,-9.16"/>
-            <polyline points="-3.95,-9.60 -2.66,-9.16"/>
+        <g id="174" class="nad-vl0to30" title="L37-39-1">
+            <g>
+                <polyline points="-1.36,-8.72 -2.66,-9.16"/>
+            </g>
+            <g>
+                <polyline points="-3.95,-9.60 -2.66,-9.16"/>
+            </g>
         </g>
-        <g id="175" title="L38-44-1">
-            <polyline points="-0.32,-3.93 0.10,-2.31"/>
-            <polyline points="0.52,-0.69 0.10,-2.31"/>
+        <g id="175" class="nad-vl0to30" title="L38-44-1">
+            <g>
+                <polyline points="-0.32,-3.93 0.10,-2.31"/>
+            </g>
+            <g>
+                <polyline points="0.52,-0.69 0.10,-2.31"/>
+            </g>
         </g>
-        <g id="176" title="L38-49-1">
-            <polyline points="-0.32,-3.93 -3.01,-2.70"/>
-            <polyline points="-5.70,-1.46 -3.01,-2.70"/>
+        <g id="176" class="nad-vl0to30" title="L38-49-1">
+            <g>
+                <polyline points="-0.32,-3.93 -3.01,-2.70"/>
+            </g>
+            <g>
+                <polyline points="-5.70,-1.46 -3.01,-2.70"/>
+            </g>
         </g>
-        <g id="177" title="L38-48-1">
-            <polyline points="-0.32,-3.93 -1.81,-3.88"/>
-            <polyline points="-3.31,-3.83 -1.81,-3.88"/>
+        <g id="177" class="nad-vl0to30" title="L38-48-1">
+            <g>
+                <polyline points="-0.32,-3.93 -1.81,-3.88"/>
+            </g>
+            <g>
+                <polyline points="-3.31,-3.83 -1.81,-3.88"/>
+            </g>
         </g>
         <g id="178" title="T39-57-1">
-            <polyline points="-3.95,-9.60 -5.34,-9.75"/>
-            <polyline points="-6.73,-9.90 -5.34,-9.75"/>
+            <g class="nad-vl0to30">
+                <polyline points="-3.95,-9.60 -5.34,-9.75"/>
+                <circle cx="-5.24" cy="-9.74" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-6.73,-9.90 -5.34,-9.75"/>
+                <circle cx="-5.44" cy="-9.76" r="0.20"/>
+            </g>
         </g>
         <g id="179" title="T40-56-1">
-            <polyline points="-6.20,-12.61 -7.66,-11.02"/>
-            <polyline points="-9.12,-9.43 -7.66,-11.02"/>
+            <g class="nad-vl0to30">
+                <polyline points="-6.20,-12.61 -7.66,-11.02"/>
+                <circle cx="-7.59" cy="-11.10" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-9.12,-9.43 -7.66,-11.02"/>
+                <circle cx="-7.73" cy="-10.95" r="0.20"/>
+            </g>
         </g>
-        <g id="180" title="L41-42-1">
-            <polyline points="-10.12,-5.40 -10.79,-6.74"/>
-            <polyline points="-11.47,-8.07 -10.79,-6.74"/>
+        <g id="180" class="nad-vl0to30" title="L41-42-1">
+            <g>
+                <polyline points="-10.12,-5.40 -10.79,-6.74"/>
+            </g>
+            <g>
+                <polyline points="-11.47,-8.07 -10.79,-6.74"/>
+            </g>
         </g>
-        <g id="181" title="L41-43-1">
-            <polyline points="-10.12,-5.40 -10.46,-4.17"/>
-            <polyline points="-10.79,-2.94 -10.46,-4.17"/>
+        <g id="181" class="nad-vl0to30" title="L41-43-1">
+            <g>
+                <polyline points="-10.12,-5.40 -10.46,-4.17"/>
+            </g>
+            <g>
+                <polyline points="-10.79,-2.94 -10.46,-4.17"/>
+            </g>
         </g>
-        <g id="182" title="L56-41-1">
-            <polyline points="-9.12,-9.43 -9.62,-7.41"/>
-            <polyline points="-10.12,-5.40 -9.62,-7.41"/>
+        <g id="182" class="nad-vl0to30" title="L56-41-1">
+            <g>
+                <polyline points="-9.12,-9.43 -9.62,-7.41"/>
+            </g>
+            <g>
+                <polyline points="-10.12,-5.40 -9.62,-7.41"/>
+            </g>
         </g>
-        <g id="183" title="L56-42-1">
-            <polyline points="-9.12,-9.43 -10.29,-8.75"/>
-            <polyline points="-11.47,-8.07 -10.29,-8.75"/>
+        <g id="183" class="nad-vl0to30" title="L56-42-1">
+            <g>
+                <polyline points="-9.12,-9.43 -10.29,-8.75"/>
+            </g>
+            <g>
+                <polyline points="-11.47,-8.07 -10.29,-8.75"/>
+            </g>
         </g>
-        <g id="184" title="L44-45-1">
-            <polyline points="0.52,-0.69 -0.30,1.09"/>
-            <polyline points="-1.12,2.87 -0.30,1.09"/>
+        <g id="184" class="nad-vl0to30" title="L44-45-1">
+            <g>
+                <polyline points="0.52,-0.69 -0.30,1.09"/>
+            </g>
+            <g>
+                <polyline points="-1.12,2.87 -0.30,1.09"/>
+            </g>
         </g>
-        <g id="185" title="L46-47-1">
-            <polyline points="-3.48,0.72 -3.08,-0.52"/>
-            <polyline points="-2.69,-1.76 -3.08,-0.52"/>
+        <g id="185" class="nad-vl0to30" title="L46-47-1">
+            <g>
+                <polyline points="-3.48,0.72 -3.08,-0.52"/>
+            </g>
+            <g>
+                <polyline points="-2.69,-1.76 -3.08,-0.52"/>
+            </g>
         </g>
-        <g id="186" title="L47-48-1">
-            <polyline points="-2.69,-1.76 -3.00,-2.80"/>
-            <polyline points="-3.31,-3.83 -3.00,-2.80"/>
+        <g id="186" class="nad-vl0to30" title="L47-48-1">
+            <g>
+                <polyline points="-2.69,-1.76 -3.00,-2.80"/>
+            </g>
+            <g>
+                <polyline points="-3.31,-3.83 -3.00,-2.80"/>
+            </g>
         </g>
-        <g id="187" title="L48-49-1">
-            <polyline points="-3.31,-3.83 -4.50,-2.65"/>
-            <polyline points="-5.70,-1.46 -4.50,-2.65"/>
+        <g id="187" class="nad-vl0to30" title="L48-49-1">
+            <g>
+                <polyline points="-3.31,-3.83 -4.50,-2.65"/>
+            </g>
+            <g>
+                <polyline points="-5.70,-1.46 -4.50,-2.65"/>
+            </g>
         </g>
-        <g id="188" title="L49-50-1">
-            <polyline points="-5.70,-1.46 -8.20,-0.58"/>
-            <polyline points="-10.70,0.31 -8.20,-0.58"/>
+        <g id="188" class="nad-vl0to30" title="L49-50-1">
+            <g>
+                <polyline points="-5.70,-1.46 -8.20,-0.58"/>
+            </g>
+            <g>
+                <polyline points="-10.70,0.31 -8.20,-0.58"/>
+            </g>
         </g>
-        <g id="189" title="L50-51-1">
-            <polyline points="-10.70,0.31 -11.67,1.50"/>
-            <polyline points="-12.64,2.69 -11.67,1.50"/>
+        <g id="189" class="nad-vl0to30" title="L50-51-1">
+            <g>
+                <polyline points="-10.70,0.31 -11.67,1.50"/>
+            </g>
+            <g>
+                <polyline points="-12.64,2.69 -11.67,1.50"/>
+            </g>
         </g>
-        <g id="190" title="L52-53-1">
-            <polyline points="6.72,4.66 5.48,4.48"/>
-            <polyline points="4.24,4.30 5.48,4.48"/>
+        <g id="190" class="nad-vl0to30" title="L52-53-1">
+            <g>
+                <polyline points="6.72,4.66 5.48,4.48"/>
+            </g>
+            <g>
+                <polyline points="4.24,4.30 5.48,4.48"/>
+            </g>
         </g>
-        <g id="191" title="L53-54-1">
-            <polyline points="4.24,4.30 2.88,4.72"/>
-            <polyline points="1.52,5.13 2.88,4.72"/>
+        <g id="191" class="nad-vl0to30" title="L53-54-1">
+            <g>
+                <polyline points="4.24,4.30 2.88,4.72"/>
+            </g>
+            <g>
+                <polyline points="1.52,5.13 2.88,4.72"/>
+            </g>
         </g>
-        <g id="192" title="L54-55-1">
-            <polyline points="1.52,5.13 -0.19,5.43"/>
-            <polyline points="-1.90,5.73 -0.19,5.43"/>
+        <g id="192" class="nad-vl0to30" title="L54-55-1">
+            <g>
+                <polyline points="1.52,5.13 -0.19,5.43"/>
+            </g>
+            <g>
+                <polyline points="-1.90,5.73 -0.19,5.43"/>
+            </g>
         </g>
-        <g id="193" title="L57-56-1">
-            <polyline points="-6.73,-9.90 -7.93,-9.66"/>
-            <polyline points="-9.12,-9.43 -7.93,-9.66"/>
+        <g id="193" class="nad-vl0to30" title="L57-56-1">
+            <g>
+                <polyline points="-6.73,-9.90 -7.93,-9.66"/>
+            </g>
+            <g>
+                <polyline points="-9.12,-9.43 -7.93,-9.66"/>
+            </g>
         </g>
     </g>
     <g class="nad-vl-nodes">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Two-windings transformers not displayed and wires not coloured.


**What is the new behavior (if this is a feature change)?**
Two-windings transformers displayed and wires coloured.
![screenshot](https://user-images.githubusercontent.com/66690739/142479269-56d46ef2-7292-4732-8e3f-c15f196fca1e.png)



**Does this PR introduce a breaking change or deprecate an API?** 
No
