### PR TITLE
Add text nodes displaying name of voltage levels

### DIFF
--- a/src/main/java/com/powsybl/forcedlayout/ForceLayout.java
+++ b/src/main/java/com/powsybl/forcedlayout/ForceLayout.java
@@ -126,7 +126,7 @@ public class ForceLayout<V, E> {
         for (E e : graph.edgeSet()) {
             Point pointSource = points.get(graph.getEdgeSource(e));
             Point pointTarget = points.get(graph.getEdgeTarget(e));
-            springs.add(new Spring(pointSource, pointTarget));
+            springs.add(new Spring(pointSource, pointTarget, graph.getEdgeWeight(e)));
         }
     }
 

--- a/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -47,9 +47,12 @@ public class NetworkGraphBuilder implements GraphBuilder {
 
     private void addGraphNodes(Graph graph) {
         for (VoltageLevel voltageLevel : network.getVoltageLevels()) {
+            TextNode textNode = new TextNode(idProvider.createId(voltageLevel), voltageLevel.getNameOrId());
+            graph.addNode(textNode);
             VoltageLevelNode vlNode = new VoltageLevelNode(idProvider.createId(voltageLevel),
-                    voltageLevel.getId(), voltageLevel.getNameOrId(), voltageLevel.getNominalV());
+                    voltageLevel.getId(), voltageLevel.getNameOrId(), voltageLevel.getNominalV(), textNode);
             graph.addNode(vlNode);
+            graph.addEdge(vlNode, textNode, new TextEdge(idProvider.createId(voltageLevel)));
             voltageLevel.getBusView().getBusStream()
                     .map(bus -> new BusInnerNode(idProvider.createId(bus), bus.getId()))
                     .forEach(vlNode::addBusNode);

--- a/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -48,11 +48,9 @@ public class NetworkGraphBuilder implements GraphBuilder {
     private void addGraphNodes(Graph graph) {
         for (VoltageLevel voltageLevel : network.getVoltageLevels()) {
             TextNode textNode = new TextNode(idProvider.createId(voltageLevel), voltageLevel.getNameOrId());
-            graph.addNode(textNode);
             VoltageLevelNode vlNode = new VoltageLevelNode(idProvider.createId(voltageLevel),
                     voltageLevel.getId(), voltageLevel.getNameOrId(), voltageLevel.getNominalV(), textNode);
             graph.addNode(vlNode);
-            graph.addEdge(vlNode, textNode, new TextEdge(idProvider.createId(voltageLevel)));
             voltageLevel.getBusView().getBusStream()
                     .map(bus -> new BusInnerNode(idProvider.createId(bus), bus.getId()))
                     .forEach(vlNode::addBusNode);

--- a/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
+++ b/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
@@ -1,23 +1,30 @@
 package com.powsybl.nad.layout;
 
-import com.powsybl.nad.model.Edge;
-import com.powsybl.nad.model.Graph;
-import com.powsybl.nad.model.Node;
-import com.powsybl.nad.model.Point;
+import com.powsybl.nad.model.*;
 
 import java.util.Objects;
 import java.util.Set;
 
 public abstract class AbstractLayout implements Layout {
 
+    private static final double TEXT_EDGE_SHIFT = 0.5;
+
     protected void edgeLayout(Graph graph, LayoutParameters layoutParameters) {
         Objects.requireNonNull(graph);
         Objects.requireNonNull(layoutParameters);
-        graph.getNonMultiEdgesStream().forEach(edge -> singleEdgeLayout(graph.getNode1(edge), graph.getNode2(edge), edge));
-        graph.getMultiEdgesStream().forEach(edges -> multiEdgesLayout(graph, edges, layoutParameters));
+        graph.getNonMultiBranchEdgesStream().forEach(edge -> singleEdgeLayout(graph.getNode1(edge), graph.getNode2(edge), edge));
+        graph.getMultiBranchEdgesStream().forEach(edges -> multiEdgesLayout(graph, edges, layoutParameters));
+        graph.getTextEdgesStream().forEach(edge -> textEdgeLayout(graph.getNode1(edge), graph.getNode2(edge), edge));
     }
 
-    private void singleEdgeLayout(Node node1, Node node2, Edge edge) {
+    protected void textEdgeLayout(Node node1, Node node2, TextEdge edge) {
+        Point point1 = new Point(node1.getX(), node1.getY());
+        Point point2 = new Point(node2.getX(), node2.getY());
+        Point point3 = point2.atDistance(TEXT_EDGE_SHIFT, point1);
+        edge.setPoints(point1, point3);
+    }
+
+    private void singleEdgeLayout(Node node1, Node node2, BranchEdge edge) {
         Point point1 = new Point(node1.getX(), node1.getY());
         Point point2 = new Point(node2.getX(), node2.getY());
         Point middle = Point.createMiddlePoint(point1, point2);
@@ -43,8 +50,12 @@ public abstract class AbstractLayout implements Layout {
 
         int i = 0;
         for (Edge edge : edges) {
+            if (!(edge instanceof BranchEdge)) {
+                continue;
+            }
+            BranchEdge branchEdge = (BranchEdge) edge;
             if (2 * i + 1 == nbForks) { // in the middle, hence alpha = 0
-                singleEdgeLayout(node1, node2, edge);
+                singleEdgeLayout(node1, node2, branchEdge);
             } else {
                 double alpha = -forkAperture / 2 + i * angleStep;
                 double angleFork1 = angle - alpha;
@@ -53,8 +64,8 @@ public abstract class AbstractLayout implements Layout {
                 Point fork2 = pointB.shift(forkLength * Math.cos(angleFork2), forkLength * Math.sin(angleFork2));
 
                 Point middle = Point.createMiddlePoint(fork1, fork2);
-                edge.setSide1(pointA, fork1, middle);
-                edge.setSide2(pointB, fork2, middle);
+                branchEdge.setSide1(pointA, fork1, middle);
+                branchEdge.setSide2(pointB, fork2, middle);
             }
             i++;
         }

--- a/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -12,6 +12,7 @@ package com.powsybl.nad.layout;
 public class LayoutParameters {
     private double edgesForkAperture = Math.toRadians(60);
     private double edgesForkLength = 0.8;
+    private boolean textNodesForceLayout = false;
 
     public double getEdgesForkAperture() {
         return edgesForkAperture;
@@ -28,6 +29,15 @@ public class LayoutParameters {
 
     public LayoutParameters setEdgesForkLength(double edgesForkLength) {
         this.edgesForkLength = edgesForkLength;
+        return this;
+    }
+
+    public boolean isTextNodesForceLayout() {
+        return textNodesForceLayout;
+    }
+
+    public LayoutParameters setTextNodesForceLayout(boolean textNodesForceLayout) {
+        this.textNodesForceLayout = textNodesForceLayout;
         return this;
     }
 }

--- a/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractBranchEdge.java
@@ -6,17 +6,50 @@
  */
 package com.powsybl.nad.model;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public abstract class AbstractBranchEdge extends AbstractEdge {
+public abstract class AbstractBranchEdge extends AbstractEdge implements BranchEdge {
     private final boolean side1Connected;
     private final boolean side2Connected;
+    private List<Point> line1 = Collections.emptyList();
+    private List<Point> line2 = Collections.emptyList();
 
     protected AbstractBranchEdge(String diagramId, String equipmentId, String nameOrId, boolean side1Connected, boolean side2Connected) {
         super(diagramId, equipmentId, nameOrId);
         this.side1Connected = side1Connected;
         this.side2Connected = side2Connected;
+    }
+
+    public List<Point> getLine(Side side) {
+        return side == Side.ONE ? getSide1() : getSide2();
+    }
+
+    @Override
+    public List<Point> getSide1() {
+        return Collections.unmodifiableList(line1);
+    }
+
+    @Override
+    public List<Point> getSide2() {
+        return Collections.unmodifiableList(line2);
+    }
+
+    @Override
+    public void setSide1(Point... points) {
+        Arrays.stream(points).forEach(Objects::requireNonNull);
+        this.line1 = Arrays.asList(points);
+    }
+
+    @Override
+    public void setSide2(Point... points) {
+        Arrays.stream(points).forEach(Objects::requireNonNull);
+        this.line2 = Arrays.asList(points);
     }
 
     public boolean isConnected(Side side) {

--- a/src/main/java/com/powsybl/nad/model/AbstractEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractEdge.java
@@ -16,39 +16,11 @@ public abstract class AbstractEdge implements Edge {
     private final String diagramId;
     private final String equipmentId;
     private final String name;
-    private List<Point> line1 = Collections.emptyList();
-    private List<Point> line2 = Collections.emptyList();
 
     protected AbstractEdge(String diagramId, String equipmentId, String nameOrId) {
         this.diagramId = Objects.requireNonNull(diagramId);
         this.equipmentId = equipmentId;
         this.name = nameOrId;
-    }
-
-    public List<Point> getLine(Side side) {
-        return side == Side.ONE ? getSide1() : getSide2();
-    }
-
-    @Override
-    public List<Point> getSide1() {
-        return Collections.unmodifiableList(line1);
-    }
-
-    @Override
-    public List<Point> getSide2() {
-        return Collections.unmodifiableList(line2);
-    }
-
-    @Override
-    public void setSide1(Point... points) {
-        Arrays.stream(points).forEach(Objects::requireNonNull);
-        this.line1 = Arrays.asList(points);
-    }
-
-    @Override
-    public void setSide2(Point... points) {
-        Arrays.stream(points).forEach(Objects::requireNonNull);
-        this.line2 = Arrays.asList(points);
     }
 
     @Override

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -1,7 +1,16 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.nad.model;
 
 import java.util.List;
 
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
 public interface BranchEdge extends Edge {
     enum Side {
         ONE, TWO

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -1,0 +1,19 @@
+package com.powsybl.nad.model;
+
+import java.util.List;
+
+public interface BranchEdge extends Edge {
+    enum Side {
+        ONE, TWO
+    }
+
+    List<Point> getLine(Side side);
+
+    List<Point> getSide1();
+
+    List<Point> getSide2();
+
+    void setSide1(Point... points);
+
+    void setSide2(Point... points);
+}

--- a/src/main/java/com/powsybl/nad/model/Edge.java
+++ b/src/main/java/com/powsybl/nad/model/Edge.java
@@ -6,27 +6,12 @@
  */
 package com.powsybl.nad.model;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public interface Edge {
-
-    enum Side {
-        ONE, TWO
-    }
-
-    List<Point> getLine(Side side);
-
-    List<Point> getSide1();
-
-    List<Point> getSide2();
-
-    void setSide1(Point... points);
-
-    void setSide2(Point... points);
 
     String getDiagramId();
 

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -37,10 +37,13 @@ public class Graph {
         Objects.requireNonNull(edge);
         edges.put(edge.getEquipmentId(), edge);
         jgrapht.addEdge(node1, node2, edge);
+        if (edge instanceof TextEdge) {
+            jgrapht.setEdgeWeight(edge, 1);
+        }
     }
 
     public Stream<Node> getNodesStream() {
-        return nodes.values().stream();
+        return jgrapht.vertexSet().stream();
     }
 
     public Stream<VoltageLevelNode> getVoltageLevelNodesStream() {
@@ -60,16 +63,25 @@ public class Graph {
     }
 
     public Collection<Edge> getEdges() {
-        return Collections.unmodifiableCollection(edges.values());
+        return Collections.unmodifiableCollection(jgrapht.edgeSet());
     }
 
-    public Stream<Edge> getNonMultiEdgesStream() {
-        return edges.values().stream()
+    public Stream<TextEdge> getTextEdgesStream() {
+        return jgrapht.edgeSet().stream()
+                .filter(TextEdge.class::isInstance)
+                .map(TextEdge.class::cast)
                 .filter(e -> jgrapht.getAllEdges(jgrapht.getEdgeSource(e), jgrapht.getEdgeTarget(e)).size() == 1);
     }
 
-    public Stream<Set<Edge>> getMultiEdgesStream() {
-        return edges.values().stream()
+    public Stream<BranchEdge> getNonMultiBranchEdgesStream() {
+        return jgrapht.edgeSet().stream()
+                .filter(BranchEdge.class::isInstance)
+                .map(BranchEdge.class::cast)
+                .filter(e -> jgrapht.getAllEdges(jgrapht.getEdgeSource(e), jgrapht.getEdgeTarget(e)).size() == 1);
+    }
+
+    public Stream<Set<Edge>> getMultiBranchEdgesStream() {
+        return jgrapht.edgeSet().stream()
                 .map(e -> jgrapht.getAllEdges(jgrapht.getEdgeSource(e), jgrapht.getEdgeTarget(e)))
                 .filter(e -> e.size() > 1)
                 .distinct();

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -9,6 +9,7 @@ package com.powsybl.nad.model;
 import org.jgrapht.graph.WeightedPseudograph;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -66,11 +67,21 @@ public class Graph {
         return Collections.unmodifiableCollection(jgrapht.edgeSet());
     }
 
+    public List<BranchEdge> getBranchEdges() {
+        return jgrapht.edgeSet().stream()
+                .filter(BranchEdge.class::isInstance)
+                .map(BranchEdge.class::cast)
+                .collect(Collectors.toList());
+    }
+
     public Stream<TextEdge> getTextEdgesStream() {
         return jgrapht.edgeSet().stream()
                 .filter(TextEdge.class::isInstance)
-                .map(TextEdge.class::cast)
-                .filter(e -> jgrapht.getAllEdges(jgrapht.getEdgeSource(e), jgrapht.getEdgeTarget(e)).size() == 1);
+                .map(TextEdge.class::cast);
+    }
+
+    public List<TextEdge> getTextEdges() {
+        return getTextEdgesStream().collect(Collectors.toList());
     }
 
     public Stream<BranchEdge> getNonMultiBranchEdgesStream() {
@@ -145,4 +156,5 @@ public class Graph {
     public boolean containsNode(String equipmentId) {
         return nodes.containsKey(equipmentId);
     }
+
 }

--- a/src/main/java/com/powsybl/nad/model/TextEdge.java
+++ b/src/main/java/com/powsybl/nad/model/TextEdge.java
@@ -6,13 +6,25 @@
  */
 package com.powsybl.nad.model;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public class TextEdge extends AbstractEdge {
 
+    private Point[] points;
+
     public TextEdge(String diagramId) {
         super(diagramId, null, null);
     }
 
+    public void setPoints(Point... points) {
+        this.points = points;
+    }
+
+    public List<Point> getPoints() {
+        return Arrays.asList(points);
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/TextNode.java
+++ b/src/main/java/com/powsybl/nad/model/TextNode.java
@@ -15,7 +15,7 @@ public class TextNode extends AbstractNode {
 
     private final String text;
 
-    protected TextNode(String diagramId, String text) {
+    public TextNode(String diagramId, String text) {
         super(diagramId, null, null);
         this.text = Objects.requireNonNull(text);
     }

--- a/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
+++ b/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
@@ -16,10 +16,12 @@ public class VoltageLevelNode extends AbstractNode {
 
     private final double nominalV;
     private final List<BusInnerNode> busInnerNodes = new ArrayList<>();
+    private final TextNode textNode;
 
-    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, double nominalV) {
+    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, double nominalV, TextNode textNode) {
         super(diagramId, equipmentId, nameOrId);
         this.nominalV = nominalV;
+        this.textNode = textNode;
     }
 
     public double getNominalV() {
@@ -32,5 +34,9 @@ public class VoltageLevelNode extends AbstractNode {
 
     public int getBusNodesCount() {
         return busInnerNodes.size();
+    }
+
+    public TextNode getTextNode() {
+        return textNode;
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -24,8 +24,11 @@ public abstract class AbstractStyleProvider implements StyleProvider {
 
     private static final String CLASSES_PREFIX = "nad-";
     private static final String VOLTAGE_LEVEL_NODES_CLASS = CLASSES_PREFIX + "vl-nodes";
+    private static final String BUSES_TEXT_CLASS = CLASSES_PREFIX + "text-buses";
+    private static final String TEXT_NODE_CLASS = CLASSES_PREFIX + "text-node";
     private static final String DISCONNECTED_SIDE_EDGE_CLASS = CLASSES_PREFIX + "disconnected";
     private static final String EDGES_CLASS = CLASSES_PREFIX + "edges";
+    private static final String TEXT_EDGES_CLASS = CLASSES_PREFIX + "text-edges";
 
     private final BaseVoltagesConfig baseVoltagesConfig;
 
@@ -79,16 +82,29 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
+    public String getBusesTextStyle() {
+        return BUSES_TEXT_CLASS;
+    }
+
+    @Override
+    public String getTextNodeStyle() {
+        return TEXT_NODE_CLASS;
+    }
+
+    @Override
     public List<String> getEdgeStyleClasses(Edge edge) {
         if (edge instanceof LineEdge) {
             return getBaseVoltageStyle(((LineEdge) edge).getNominalV())
                     .map(Collections::singletonList).orElse(Collections.emptyList());
         }
+        if (edge instanceof TextEdge) {
+            return Collections.singletonList(TEXT_EDGES_CLASS);
+        }
         return Collections.emptyList();
     }
 
     @Override
-    public List<String> getSideEdgeStyleClasses(Edge edge, Edge.Side side) {
+    public List<String> getSideEdgeStyleClasses(BranchEdge edge, BranchEdge.Side side) {
         Objects.requireNonNull(side);
         List<String> result = new ArrayList<>();
         if (edge instanceof AbstractBranchEdge && !((AbstractBranchEdge) edge).isConnected(side)) {

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -24,10 +24,10 @@ public abstract class AbstractStyleProvider implements StyleProvider {
 
     private static final String CLASSES_PREFIX = "nad-";
     private static final String VOLTAGE_LEVEL_NODES_CLASS = CLASSES_PREFIX + "vl-nodes";
+    private static final String TEXT_NODES_CLASS = CLASSES_PREFIX + "text-nodes";
     private static final String BUSES_TEXT_CLASS = CLASSES_PREFIX + "text-buses";
-    private static final String TEXT_NODE_CLASS = CLASSES_PREFIX + "text-node";
     private static final String DISCONNECTED_SIDE_EDGE_CLASS = CLASSES_PREFIX + "disconnected";
-    private static final String EDGES_CLASS = CLASSES_PREFIX + "edges";
+    private static final String BRANCH_EDGES_CLASS = CLASSES_PREFIX + "branch-edges";
     private static final String TEXT_EDGES_CLASS = CLASSES_PREFIX + "text-edges";
 
     private final BaseVoltagesConfig baseVoltagesConfig;
@@ -72,13 +72,23 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
-    public String getEdgesStyle() {
-        return EDGES_CLASS;
+    public String getBranchEdgesStyle() {
+        return BRANCH_EDGES_CLASS;
     }
 
     @Override
-    public String getVoltageLevelNodeStyle() {
+    public String getTextEdgesStyle() {
+        return TEXT_EDGES_CLASS;
+    }
+
+    @Override
+    public String getVoltageLevelNodesStyle() {
         return VOLTAGE_LEVEL_NODES_CLASS;
+    }
+
+    @Override
+    public String getTextNodesStyle() {
+        return TEXT_NODES_CLASS;
     }
 
     @Override
@@ -87,18 +97,10 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
-    public String getTextNodeStyle() {
-        return TEXT_NODE_CLASS;
-    }
-
-    @Override
     public List<String> getEdgeStyleClasses(Edge edge) {
         if (edge instanceof LineEdge) {
             return getBaseVoltageStyle(((LineEdge) edge).getNominalV())
                     .map(Collections::singletonList).orElse(Collections.emptyList());
-        }
-        if (edge instanceof TextEdge) {
-            return Collections.singletonList(TEXT_EDGES_CLASS);
         }
         return Collections.emptyList();
     }

--- a/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.nad.svg;
 
+import com.powsybl.nad.model.BranchEdge;
 import com.powsybl.nad.model.Edge;
 import com.powsybl.nad.model.Node;
 
@@ -25,7 +26,11 @@ public interface StyleProvider {
 
     String getVoltageLevelNodeStyle();
 
+    String getBusesTextStyle();
+
+    String getTextNodeStyle();
+
     List<String> getEdgeStyleClasses(Edge edge);
 
-    List<String> getSideEdgeStyleClasses(Edge edge, Edge.Side side);
+    List<String> getSideEdgeStyleClasses(BranchEdge edge, BranchEdge.Side side);
 }

--- a/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -22,15 +22,18 @@ public interface StyleProvider {
 
     List<String> getNodeStyleClasses(Node node);
 
-    String getEdgesStyle();
+    String getBranchEdgesStyle();
 
-    String getVoltageLevelNodeStyle();
+    String getTextEdgesStyle();
+
+    String getVoltageLevelNodesStyle();
+
+    String getTextNodesStyle();
 
     String getBusesTextStyle();
-
-    String getTextNodeStyle();
 
     List<String> getEdgeStyleClasses(Edge edge);
 
     List<String> getSideEdgeStyleClasses(BranchEdge edge, BranchEdge.Side side);
+
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -46,6 +46,8 @@ public class SvgWriter {
     private static final String CLASS_ATTRIBUTE = "class";
     private static final String TRANSFORM_ATTRIBUTE = "transform";
     public static final String CIRCLE_RADIUS_ATTRIBUTE = "r";
+    private static final String X_ATTRIBUTE = "x";
+    private static final String Y_ATTRIBUTE = "y";
     private static final double CIRCLE_RADIUS = 0.6;
     private static final double TRANSFORMER_CIRCLE_RADIUS = 0.2;
 
@@ -173,7 +175,8 @@ public class SvgWriter {
 
     private void writeTextNode(XMLStreamWriter writer, TextNode textNode) throws XMLStreamException {
         writer.writeStartElement(TEXT_ELEMENT_NAME);
-        writer.writeAttribute(TRANSFORM_ATTRIBUTE, getTranslateString(textNode));
+        writer.writeAttribute(X_ATTRIBUTE, getFormattedValue(textNode.getX()));
+        writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textNode.getY()));
         writer.writeAttribute(STYLE_ELEMENT_NAME, "dominant-baseline:middle");
         writer.writeCharacters(textNode.getText());
         writer.writeEndElement();

--- a/src/main/resources/defaultStyle.css
+++ b/src/main/resources/defaultStyle.css
@@ -1,8 +1,10 @@
 .nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-edges .nad-text-edges {stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-node {font: 0.3px "Verdana"}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/main/resources/defaultStyle.css
+++ b/src/main/resources/defaultStyle.css
@@ -1,10 +1,10 @@
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
-.nad-edges .nad-text-edges {stroke-width: 0.02; ; stroke-dasharray: .1,.1}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
-.nad-text-node {font: 0.3px "Verdana"}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/java/com/powsybl/nad/AbstractTest.java
+++ b/src/test/java/com/powsybl/nad/AbstractTest.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public abstract class AbstractTest {
 
-    protected boolean debugSvg = true;
+    protected boolean debugSvg = false;
     protected boolean overrideTestReferences = false;
 
     protected abstract LayoutParameters getLayoutParameters();

--- a/src/test/java/com/powsybl/nad/AbstractTest.java
+++ b/src/test/java/com/powsybl/nad/AbstractTest.java
@@ -26,7 +26,7 @@ import java.util.Objects;
  */
 public abstract class AbstractTest {
 
-    protected boolean debugSvg = false;
+    protected boolean debugSvg = true;
     protected boolean overrideTestReferences = false;
 
     protected abstract LayoutParameters getLayoutParameters();

--- a/src/test/java/com/powsybl/nad/SvgWriterTest.java
+++ b/src/test/java/com/powsybl/nad/SvgWriterTest.java
@@ -13,6 +13,7 @@ import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.svg.DefaultStyleProvider;
 import com.powsybl.nad.svg.StyleProvider;
 import com.powsybl.nad.svg.SvgParameters;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,9 +23,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class SvgWriterTest extends AbstractTest {
 
+    private LayoutParameters layoutParameters;
+
+    @BeforeEach
+    public void setup() {
+        this.layoutParameters = new LayoutParameters();
+    }
+
     @Override
     protected LayoutParameters getLayoutParameters() {
-        return new LayoutParameters();
+        return layoutParameters;
     }
 
     @Override
@@ -50,6 +58,13 @@ class SvgWriterTest extends AbstractTest {
     void testIEEE14() {
         Network network = IeeeCdfNetworkFactory.create14();
         assertEquals(toString("/IEEE_14_bus.svg"), generateSvgString(network, "/IEEE_14_bus.svg"));
+    }
+
+    @Test
+    void testIEEE14ForceLayoutWithTextNodes() {
+        Network network = IeeeCdfNetworkFactory.create14();
+        getLayoutParameters().setTextNodesForceLayout(true);
+        assertEquals(toString("/IEEE_14_bus_text_nodes.svg"), generateSvgString(network, "/IEEE_14_bus_text_nodes.svg"));
     }
 
     @Test

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -2592,123 +2592,123 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(28.03,10.72)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(27.15,8.45)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(24.87,10.22)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(23.56,13.16)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(21.26,10.90)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(21.96,6.22)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(23.79,4.92)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(16.05,11.34)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(16.12,15.94)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(16.46,18.97)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(20.91,12.54)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(23.90,8.56)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(18.46,12.32)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(18.73,8.79)" style="dominant-baseline:middle">VL14</text>
-        <text transform="translate(14.64,9.63)" style="dominant-baseline:middle">VL15</text>
-        <text transform="translate(19.62,5.39)" style="dominant-baseline:middle">VL16</text>
-        <text transform="translate(15.65,4.68)" style="dominant-baseline:middle">VL17</text>
-        <text transform="translate(13.49,6.90)" style="dominant-baseline:middle">VL18</text>
-        <text transform="translate(10.62,9.30)" style="dominant-baseline:middle">VL19</text>
-        <text transform="translate(8.39,6.12)" style="dominant-baseline:middle">VL20</text>
-        <text transform="translate(8.02,2.80)" style="dominant-baseline:middle">VL21</text>
-        <text transform="translate(9.09,-0.32)" style="dominant-baseline:middle">VL22</text>
-        <text transform="translate(10.74,-3.02)" style="dominant-baseline:middle">VL23</text>
-        <text transform="translate(6.43,-3.64)" style="dominant-baseline:middle">VL24</text>
-        <text transform="translate(13.21,-2.05)" style="dominant-baseline:middle">VL25</text>
-        <text transform="translate(12.13,2.34)" style="dominant-baseline:middle">VL26</text>
-        <text transform="translate(16.67,-5.34)" style="dominant-baseline:middle">VL27</text>
-        <text transform="translate(19.87,-5.91)" style="dominant-baseline:middle">VL28</text>
-        <text transform="translate(20.41,-3.24)" style="dominant-baseline:middle">VL29</text>
-        <text transform="translate(11.89,7.10)" style="dominant-baseline:middle">VL30</text>
-        <text transform="translate(17.89,-0.57)" style="dominant-baseline:middle">VL31</text>
-        <text transform="translate(15.25,-3.21)" style="dominant-baseline:middle">VL32</text>
-        <text transform="translate(10.43,12.71)" style="dominant-baseline:middle">VL33</text>
-        <text transform="translate(7.37,12.65)" style="dominant-baseline:middle">VL34</text>
-        <text transform="translate(6.77,17.43)" style="dominant-baseline:middle">VL35</text>
-        <text transform="translate(8.48,15.88)" style="dominant-baseline:middle">VL36</text>
-        <text transform="translate(5.76,14.59)" style="dominant-baseline:middle">VL37</text>
-        <text transform="translate(6.22,10.46)" style="dominant-baseline:middle">VL38</text>
-        <text transform="translate(3.38,16.92)" style="dominant-baseline:middle">VL39</text>
-        <text transform="translate(1.12,15.27)" style="dominant-baseline:middle">VL40</text>
-        <text transform="translate(-1.56,15.82)" style="dominant-baseline:middle">VL41</text>
-        <text transform="translate(-3.05,13.53)" style="dominant-baseline:middle">VL42</text>
-        <text transform="translate(2.89,11.30)" style="dominant-baseline:middle">VL43</text>
-        <text transform="translate(-1.88,7.40)" style="dominant-baseline:middle">VL44</text>
-        <text transform="translate(-5.32,6.02)" style="dominant-baseline:middle">VL45</text>
-        <text transform="translate(-5.37,7.34)" style="dominant-baseline:middle">VL46</text>
-        <text transform="translate(-3.66,4.90)" style="dominant-baseline:middle">VL47</text>
-        <text transform="translate(-10.75,13.24)" style="dominant-baseline:middle">VL48</text>
-        <text transform="translate(-7.20,5.75)" style="dominant-baseline:middle">VL49</text>
-        <text transform="translate(-10.45,-0.04)" style="dominant-baseline:middle">VL50</text>
-        <text transform="translate(-12.42,6.08)" style="dominant-baseline:middle">VL51</text>
-        <text transform="translate(-16.07,7.21)" style="dominant-baseline:middle">VL52</text>
-        <text transform="translate(-15.25,9.46)" style="dominant-baseline:middle">VL53</text>
-        <text transform="translate(-3.92,16.19)" style="dominant-baseline:middle">VL54</text>
-        <text transform="translate(-5.98,16.47)" style="dominant-baseline:middle">VL55</text>
-        <text transform="translate(-8.51,15.65)" style="dominant-baseline:middle">VL56</text>
-        <text transform="translate(-13.14,5.51)" style="dominant-baseline:middle">VL57</text>
-        <text transform="translate(-12.58,8.12)" style="dominant-baseline:middle">VL58</text>
-        <text transform="translate(-9.53,14.64)" style="dominant-baseline:middle">VL59</text>
-        <text transform="translate(-6.01,18.61)" style="dominant-baseline:middle">VL60</text>
-        <text transform="translate(-13.43,13.95)" style="dominant-baseline:middle">VL61</text>
-        <text transform="translate(-23.05,3.01)" style="dominant-baseline:middle">VL62</text>
-        <text transform="translate(-2.93,22.99)" style="dominant-baseline:middle">VL63</text>
-        <text transform="translate(-8.38,15.01)" style="dominant-baseline:middle">VL64</text>
-        <text transform="translate(-3.73,9.08)" style="dominant-baseline:middle">VL65</text>
-        <text transform="translate(-13.81,6.82)" style="dominant-baseline:middle">VL66</text>
-        <text transform="translate(-17.92,8.69)" style="dominant-baseline:middle">VL67</text>
-        <text transform="translate(2.51,10.13)" style="dominant-baseline:middle">VL68</text>
-        <text transform="translate(-11.14,-6.89)" style="dominant-baseline:middle">VL69</text>
-        <text transform="translate(1.13,-2.86)" style="dominant-baseline:middle">VL70</text>
-        <text transform="translate(3.87,-6.32)" style="dominant-baseline:middle">VL71</text>
-        <text transform="translate(6.34,-6.36)" style="dominant-baseline:middle">VL72</text>
-        <text transform="translate(4.59,-9.39)" style="dominant-baseline:middle">VL73</text>
-        <text transform="translate(0.15,-0.96)" style="dominant-baseline:middle">VL74</text>
-        <text transform="translate(-1.92,-2.06)" style="dominant-baseline:middle">VL75</text>
-        <text transform="translate(-3.13,-2.99)" style="dominant-baseline:middle">VL76</text>
-        <text transform="translate(-6.34,-4.37)" style="dominant-baseline:middle">VL77</text>
-        <text transform="translate(-9.09,-5.31)" style="dominant-baseline:middle">VL78</text>
-        <text transform="translate(-10.22,-5.48)" style="dominant-baseline:middle">VL79</text>
-        <text transform="translate(-6.95,-9.65)" style="dominant-baseline:middle">VL80</text>
-        <text transform="translate(-4.79,-6.89)" style="dominant-baseline:middle">VL81</text>
-        <text transform="translate(-11.54,-8.08)" style="dominant-baseline:middle">VL82</text>
-        <text transform="translate(-15.93,-9.33)" style="dominant-baseline:middle">VL83</text>
-        <text transform="translate(-18.82,-8.93)" style="dominant-baseline:middle">VL84</text>
-        <text transform="translate(-18.24,-11.39)" style="dominant-baseline:middle">VL85</text>
-        <text transform="translate(-21.87,-10.65)" style="dominant-baseline:middle">VL86</text>
-        <text transform="translate(-24.41,-9.61)" style="dominant-baseline:middle">VL87</text>
-        <text transform="translate(-18.17,-14.14)" style="dominant-baseline:middle">VL88</text>
-        <text transform="translate(-15.45,-14.23)" style="dominant-baseline:middle">VL89</text>
-        <text transform="translate(-15.78,-17.52)" style="dominant-baseline:middle">VL90</text>
-        <text transform="translate(-12.52,-17.20)" style="dominant-baseline:middle">VL91</text>
-        <text transform="translate(-13.28,-20.83)" style="dominant-baseline:middle">VL92</text>
-        <text transform="translate(-7.78,-17.46)" style="dominant-baseline:middle">VL93</text>
-        <text transform="translate(-7.67,-12.03)" style="dominant-baseline:middle">VL94</text>
-        <text transform="translate(-13.22,-15.43)" style="dominant-baseline:middle">VL95</text>
-        <text transform="translate(-10.72,-12.77)" style="dominant-baseline:middle">VL96</text>
-        <text transform="translate(-8.30,-10.66)" style="dominant-baseline:middle">VL97</text>
-        <text transform="translate(-5.13,-12.88)" style="dominant-baseline:middle">VL98</text>
-        <text transform="translate(-5.49,-14.34)" style="dominant-baseline:middle">VL99</text>
-        <text transform="translate(-4.81,-18.48)" style="dominant-baseline:middle">VL100</text>
-        <text transform="translate(-7.59,-20.33)" style="dominant-baseline:middle">VL101</text>
-        <text transform="translate(-9.54,-19.05)" style="dominant-baseline:middle">VL102</text>
-        <text transform="translate(-0.20,-19.52)" style="dominant-baseline:middle">VL103</text>
-        <text transform="translate(-2.45,-19.00)" style="dominant-baseline:middle">VL104</text>
-        <text transform="translate(-1.20,-22.23)" style="dominant-baseline:middle">VL105</text>
-        <text transform="translate(-4.18,-21.38)" style="dominant-baseline:middle">VL106</text>
-        <text transform="translate(-3.06,-24.10)" style="dominant-baseline:middle">VL107</text>
-        <text transform="translate(1.17,-24.21)" style="dominant-baseline:middle">VL108</text>
-        <text transform="translate(3.74,-23.81)" style="dominant-baseline:middle">VL109</text>
-        <text transform="translate(4.38,-21.02)" style="dominant-baseline:middle">VL110</text>
-        <text transform="translate(7.20,-22.32)" style="dominant-baseline:middle">VL111</text>
-        <text transform="translate(6.64,-19.15)" style="dominant-baseline:middle">VL112</text>
-        <text transform="translate(15.70,0.80)" style="dominant-baseline:middle">VL113</text>
-        <text transform="translate(14.77,-7.06)" style="dominant-baseline:middle">VL114</text>
-        <text transform="translate(16.63,-8.59)" style="dominant-baseline:middle">VL115</text>
-        <text transform="translate(-8.66,-0.16)" style="dominant-baseline:middle">VL116</text>
-        <text transform="translate(26.75,5.39)" style="dominant-baseline:middle">VL117</text>
-        <text transform="translate(-1.25,-5.16)" style="dominant-baseline:middle">VL118</text>
+        <text x="28.03" y="10.72" style="dominant-baseline:middle">VL1</text>
+        <text x="27.15" y="8.45" style="dominant-baseline:middle">VL2</text>
+        <text x="24.87" y="10.22" style="dominant-baseline:middle">VL3</text>
+        <text x="23.56" y="13.16" style="dominant-baseline:middle">VL4</text>
+        <text x="21.26" y="10.90" style="dominant-baseline:middle">VL5</text>
+        <text x="21.96" y="6.22" style="dominant-baseline:middle">VL6</text>
+        <text x="23.79" y="4.92" style="dominant-baseline:middle">VL7</text>
+        <text x="16.05" y="11.34" style="dominant-baseline:middle">VL8</text>
+        <text x="16.12" y="15.94" style="dominant-baseline:middle">VL9</text>
+        <text x="16.46" y="18.97" style="dominant-baseline:middle">VL10</text>
+        <text x="20.91" y="12.54" style="dominant-baseline:middle">VL11</text>
+        <text x="23.90" y="8.56" style="dominant-baseline:middle">VL12</text>
+        <text x="18.46" y="12.32" style="dominant-baseline:middle">VL13</text>
+        <text x="18.73" y="8.79" style="dominant-baseline:middle">VL14</text>
+        <text x="14.64" y="9.63" style="dominant-baseline:middle">VL15</text>
+        <text x="19.62" y="5.39" style="dominant-baseline:middle">VL16</text>
+        <text x="15.65" y="4.68" style="dominant-baseline:middle">VL17</text>
+        <text x="13.49" y="6.90" style="dominant-baseline:middle">VL18</text>
+        <text x="10.62" y="9.30" style="dominant-baseline:middle">VL19</text>
+        <text x="8.39" y="6.12" style="dominant-baseline:middle">VL20</text>
+        <text x="8.02" y="2.80" style="dominant-baseline:middle">VL21</text>
+        <text x="9.09" y="-0.32" style="dominant-baseline:middle">VL22</text>
+        <text x="10.74" y="-3.02" style="dominant-baseline:middle">VL23</text>
+        <text x="6.43" y="-3.64" style="dominant-baseline:middle">VL24</text>
+        <text x="13.21" y="-2.05" style="dominant-baseline:middle">VL25</text>
+        <text x="12.13" y="2.34" style="dominant-baseline:middle">VL26</text>
+        <text x="16.67" y="-5.34" style="dominant-baseline:middle">VL27</text>
+        <text x="19.87" y="-5.91" style="dominant-baseline:middle">VL28</text>
+        <text x="20.41" y="-3.24" style="dominant-baseline:middle">VL29</text>
+        <text x="11.89" y="7.10" style="dominant-baseline:middle">VL30</text>
+        <text x="17.89" y="-0.57" style="dominant-baseline:middle">VL31</text>
+        <text x="15.25" y="-3.21" style="dominant-baseline:middle">VL32</text>
+        <text x="10.43" y="12.71" style="dominant-baseline:middle">VL33</text>
+        <text x="7.37" y="12.65" style="dominant-baseline:middle">VL34</text>
+        <text x="6.77" y="17.43" style="dominant-baseline:middle">VL35</text>
+        <text x="8.48" y="15.88" style="dominant-baseline:middle">VL36</text>
+        <text x="5.76" y="14.59" style="dominant-baseline:middle">VL37</text>
+        <text x="6.22" y="10.46" style="dominant-baseline:middle">VL38</text>
+        <text x="3.38" y="16.92" style="dominant-baseline:middle">VL39</text>
+        <text x="1.12" y="15.27" style="dominant-baseline:middle">VL40</text>
+        <text x="-1.56" y="15.82" style="dominant-baseline:middle">VL41</text>
+        <text x="-3.05" y="13.53" style="dominant-baseline:middle">VL42</text>
+        <text x="2.89" y="11.30" style="dominant-baseline:middle">VL43</text>
+        <text x="-1.88" y="7.40" style="dominant-baseline:middle">VL44</text>
+        <text x="-5.32" y="6.02" style="dominant-baseline:middle">VL45</text>
+        <text x="-5.37" y="7.34" style="dominant-baseline:middle">VL46</text>
+        <text x="-3.66" y="4.90" style="dominant-baseline:middle">VL47</text>
+        <text x="-10.75" y="13.24" style="dominant-baseline:middle">VL48</text>
+        <text x="-7.20" y="5.75" style="dominant-baseline:middle">VL49</text>
+        <text x="-10.45" y="-0.04" style="dominant-baseline:middle">VL50</text>
+        <text x="-12.42" y="6.08" style="dominant-baseline:middle">VL51</text>
+        <text x="-16.07" y="7.21" style="dominant-baseline:middle">VL52</text>
+        <text x="-15.25" y="9.46" style="dominant-baseline:middle">VL53</text>
+        <text x="-3.92" y="16.19" style="dominant-baseline:middle">VL54</text>
+        <text x="-5.98" y="16.47" style="dominant-baseline:middle">VL55</text>
+        <text x="-8.51" y="15.65" style="dominant-baseline:middle">VL56</text>
+        <text x="-13.14" y="5.51" style="dominant-baseline:middle">VL57</text>
+        <text x="-12.58" y="8.12" style="dominant-baseline:middle">VL58</text>
+        <text x="-9.53" y="14.64" style="dominant-baseline:middle">VL59</text>
+        <text x="-6.01" y="18.61" style="dominant-baseline:middle">VL60</text>
+        <text x="-13.43" y="13.95" style="dominant-baseline:middle">VL61</text>
+        <text x="-23.05" y="3.01" style="dominant-baseline:middle">VL62</text>
+        <text x="-2.93" y="22.99" style="dominant-baseline:middle">VL63</text>
+        <text x="-8.38" y="15.01" style="dominant-baseline:middle">VL64</text>
+        <text x="-3.73" y="9.08" style="dominant-baseline:middle">VL65</text>
+        <text x="-13.81" y="6.82" style="dominant-baseline:middle">VL66</text>
+        <text x="-17.92" y="8.69" style="dominant-baseline:middle">VL67</text>
+        <text x="2.51" y="10.13" style="dominant-baseline:middle">VL68</text>
+        <text x="-11.14" y="-6.89" style="dominant-baseline:middle">VL69</text>
+        <text x="1.13" y="-2.86" style="dominant-baseline:middle">VL70</text>
+        <text x="3.87" y="-6.32" style="dominant-baseline:middle">VL71</text>
+        <text x="6.34" y="-6.36" style="dominant-baseline:middle">VL72</text>
+        <text x="4.59" y="-9.39" style="dominant-baseline:middle">VL73</text>
+        <text x="0.15" y="-0.96" style="dominant-baseline:middle">VL74</text>
+        <text x="-1.92" y="-2.06" style="dominant-baseline:middle">VL75</text>
+        <text x="-3.13" y="-2.99" style="dominant-baseline:middle">VL76</text>
+        <text x="-6.34" y="-4.37" style="dominant-baseline:middle">VL77</text>
+        <text x="-9.09" y="-5.31" style="dominant-baseline:middle">VL78</text>
+        <text x="-10.22" y="-5.48" style="dominant-baseline:middle">VL79</text>
+        <text x="-6.95" y="-9.65" style="dominant-baseline:middle">VL80</text>
+        <text x="-4.79" y="-6.89" style="dominant-baseline:middle">VL81</text>
+        <text x="-11.54" y="-8.08" style="dominant-baseline:middle">VL82</text>
+        <text x="-15.93" y="-9.33" style="dominant-baseline:middle">VL83</text>
+        <text x="-18.82" y="-8.93" style="dominant-baseline:middle">VL84</text>
+        <text x="-18.24" y="-11.39" style="dominant-baseline:middle">VL85</text>
+        <text x="-21.87" y="-10.65" style="dominant-baseline:middle">VL86</text>
+        <text x="-24.41" y="-9.61" style="dominant-baseline:middle">VL87</text>
+        <text x="-18.17" y="-14.14" style="dominant-baseline:middle">VL88</text>
+        <text x="-15.45" y="-14.23" style="dominant-baseline:middle">VL89</text>
+        <text x="-15.78" y="-17.52" style="dominant-baseline:middle">VL90</text>
+        <text x="-12.52" y="-17.20" style="dominant-baseline:middle">VL91</text>
+        <text x="-13.28" y="-20.83" style="dominant-baseline:middle">VL92</text>
+        <text x="-7.78" y="-17.46" style="dominant-baseline:middle">VL93</text>
+        <text x="-7.67" y="-12.03" style="dominant-baseline:middle">VL94</text>
+        <text x="-13.22" y="-15.43" style="dominant-baseline:middle">VL95</text>
+        <text x="-10.72" y="-12.77" style="dominant-baseline:middle">VL96</text>
+        <text x="-8.30" y="-10.66" style="dominant-baseline:middle">VL97</text>
+        <text x="-5.13" y="-12.88" style="dominant-baseline:middle">VL98</text>
+        <text x="-5.49" y="-14.34" style="dominant-baseline:middle">VL99</text>
+        <text x="-4.81" y="-18.48" style="dominant-baseline:middle">VL100</text>
+        <text x="-7.59" y="-20.33" style="dominant-baseline:middle">VL101</text>
+        <text x="-9.54" y="-19.05" style="dominant-baseline:middle">VL102</text>
+        <text x="-0.20" y="-19.52" style="dominant-baseline:middle">VL103</text>
+        <text x="-2.45" y="-19.00" style="dominant-baseline:middle">VL104</text>
+        <text x="-1.20" y="-22.23" style="dominant-baseline:middle">VL105</text>
+        <text x="-4.18" y="-21.38" style="dominant-baseline:middle">VL106</text>
+        <text x="-3.06" y="-24.10" style="dominant-baseline:middle">VL107</text>
+        <text x="1.17" y="-24.21" style="dominant-baseline:middle">VL108</text>
+        <text x="3.74" y="-23.81" style="dominant-baseline:middle">VL109</text>
+        <text x="4.38" y="-21.02" style="dominant-baseline:middle">VL110</text>
+        <text x="7.20" y="-22.32" style="dominant-baseline:middle">VL111</text>
+        <text x="6.64" y="-19.15" style="dominant-baseline:middle">VL112</text>
+        <text x="15.70" y="0.80" style="dominant-baseline:middle">VL113</text>
+        <text x="14.77" y="-7.06" style="dominant-baseline:middle">VL114</text>
+        <text x="16.63" y="-8.59" style="dominant-baseline:middle">VL115</text>
+        <text x="-8.66" y="-0.16" style="dominant-baseline:middle">VL116</text>
+        <text x="26.75" y="5.39" style="dominant-baseline:middle">VL117</text>
+        <text x="-1.25" y="-5.16" style="dominant-baseline:middle">VL118</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="725.76" viewBox="-27.41 -26.21 56.44 51.20" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="713.13" viewBox="-27.41 -26.21 57.44 51.20" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="236" class="nad-vl120to180" title="L1-2-1">
+    <g class="nad-branch-edges">
+        <g id="354" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="27.03,10.72 26.59,9.59"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="26.15,8.45 26.59,9.59"/>
             </g>
         </g>
-        <g id="237" class="nad-vl120to180" title="L1-3-1">
+        <g id="355" class="nad-vl120to180" title="L1-3-1">
             <g>
                 <polyline points="27.03,10.72 25.45,10.47"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="23.87,10.22 25.45,10.47"/>
             </g>
         </g>
-        <g id="238" class="nad-vl120to180" title="L2-12-1">
+        <g id="356" class="nad-vl120to180" title="L2-12-1">
             <g>
                 <polyline points="26.15,8.45 24.53,8.51"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="22.90,8.56 24.53,8.51"/>
             </g>
         </g>
-        <g id="239" class="nad-vl120to180" title="L3-5-1">
+        <g id="357" class="nad-vl120to180" title="L3-5-1">
             <g>
                 <polyline points="23.87,10.22 22.06,10.56"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="20.26,10.90 22.06,10.56"/>
             </g>
         </g>
-        <g id="240" class="nad-vl120to180" title="L3-12-1">
+        <g id="358" class="nad-vl120to180" title="L3-12-1">
             <g>
                 <polyline points="23.87,10.22 23.38,9.39"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="22.90,8.56 23.38,9.39"/>
             </g>
         </g>
-        <g id="241" class="nad-vl120to180" title="L4-5-1">
+        <g id="359" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="22.56,13.16 21.41,12.03"/>
             </g>
@@ -64,7 +66,7 @@
                 <polyline points="20.26,10.90 21.41,12.03"/>
             </g>
         </g>
-        <g id="242" class="nad-vl120to180" title="L4-11-1">
+        <g id="360" class="nad-vl120to180" title="L4-11-1">
             <g>
                 <polyline points="22.56,13.16 21.23,12.85"/>
             </g>
@@ -72,7 +74,7 @@
                 <polyline points="19.91,12.54 21.23,12.85"/>
             </g>
         </g>
-        <g id="243" class="nad-vl120to180" title="L5-6-1">
+        <g id="361" class="nad-vl120to180" title="L5-6-1">
             <g>
                 <polyline points="20.26,10.90 20.61,8.56"/>
             </g>
@@ -80,7 +82,7 @@
                 <polyline points="20.96,6.22 20.61,8.56"/>
             </g>
         </g>
-        <g id="244" title="T8-5-1">
+        <g id="362" title="T8-5-1">
             <g class="nad-vl120to180">
                 <polyline points="15.05,11.34 17.65,11.12"/>
                 <circle cx="17.55" cy="11.13" r="0.20"/>
@@ -90,7 +92,7 @@
                 <circle cx="17.75" cy="11.11" r="0.20"/>
             </g>
         </g>
-        <g id="245" class="nad-vl120to180" title="L5-11-1">
+        <g id="363" class="nad-vl120to180" title="L5-11-1">
             <g>
                 <polyline points="20.26,10.90 20.08,11.72"/>
             </g>
@@ -98,7 +100,7 @@
                 <polyline points="19.91,12.54 20.08,11.72"/>
             </g>
         </g>
-        <g id="246" class="nad-vl120to180" title="L6-7-1">
+        <g id="364" class="nad-vl120to180" title="L6-7-1">
             <g>
                 <polyline points="20.96,6.22 21.87,5.57"/>
             </g>
@@ -106,7 +108,7 @@
                 <polyline points="22.79,4.92 21.87,5.57"/>
             </g>
         </g>
-        <g id="247" class="nad-vl120to180" title="L7-12-1">
+        <g id="365" class="nad-vl120to180" title="L7-12-1">
             <g>
                 <polyline points="22.79,4.92 22.84,6.74"/>
             </g>
@@ -114,7 +116,7 @@
                 <polyline points="22.90,8.56 22.84,6.74"/>
             </g>
         </g>
-        <g id="248" class="nad-vl120to180" title="L8-9-1">
+        <g id="366" class="nad-vl120to180" title="L8-9-1">
             <g>
                 <polyline points="15.05,11.34 15.08,13.64"/>
             </g>
@@ -122,7 +124,7 @@
                 <polyline points="15.12,15.94 15.08,13.64"/>
             </g>
         </g>
-        <g id="249" class="nad-vl120to180" title="L8-30-1">
+        <g id="367" class="nad-vl120to180" title="L8-30-1">
             <g>
                 <polyline points="15.05,11.34 12.97,9.22"/>
             </g>
@@ -130,7 +132,7 @@
                 <polyline points="10.89,7.10 12.97,9.22"/>
             </g>
         </g>
-        <g id="250" class="nad-vl120to180" title="L9-10-1">
+        <g id="368" class="nad-vl120to180" title="L9-10-1">
             <g>
                 <polyline points="15.12,15.94 15.29,17.46"/>
             </g>
@@ -138,7 +140,7 @@
                 <polyline points="15.46,18.97 15.29,17.46"/>
             </g>
         </g>
-        <g id="251" class="nad-vl120to180" title="L11-12-1">
+        <g id="369" class="nad-vl120to180" title="L11-12-1">
             <g>
                 <polyline points="19.91,12.54 21.41,10.55"/>
             </g>
@@ -146,7 +148,7 @@
                 <polyline points="22.90,8.56 21.41,10.55"/>
             </g>
         </g>
-        <g id="252" class="nad-vl120to180" title="L11-13-1">
+        <g id="370" class="nad-vl120to180" title="L11-13-1">
             <g>
                 <polyline points="19.91,12.54 18.68,12.43"/>
             </g>
@@ -154,7 +156,7 @@
                 <polyline points="17.46,12.32 18.68,12.43"/>
             </g>
         </g>
-        <g id="253" class="nad-vl120to180" title="L12-14-1">
+        <g id="371" class="nad-vl120to180" title="L12-14-1">
             <g>
                 <polyline points="22.90,8.56 20.32,8.68"/>
             </g>
@@ -162,7 +164,7 @@
                 <polyline points="17.73,8.79 20.32,8.68"/>
             </g>
         </g>
-        <g id="254" class="nad-vl120to180" title="L12-16-1">
+        <g id="372" class="nad-vl120to180" title="L12-16-1">
             <g>
                 <polyline points="22.90,8.56 20.76,6.97"/>
             </g>
@@ -170,7 +172,7 @@
                 <polyline points="18.62,5.39 20.76,6.97"/>
             </g>
         </g>
-        <g id="255" class="nad-vl120to180" title="L12-117-1">
+        <g id="373" class="nad-vl120to180" title="L12-117-1">
             <g>
                 <polyline points="22.90,8.56 24.32,6.98"/>
             </g>
@@ -178,7 +180,7 @@
                 <polyline points="25.75,5.39 24.32,6.98"/>
             </g>
         </g>
-        <g id="256" class="nad-vl120to180" title="L13-15-1">
+        <g id="374" class="nad-vl120to180" title="L13-15-1">
             <g>
                 <polyline points="17.46,12.32 15.55,10.97"/>
             </g>
@@ -186,7 +188,7 @@
                 <polyline points="13.64,9.63 15.55,10.97"/>
             </g>
         </g>
-        <g id="257" class="nad-vl120to180" title="L14-15-1">
+        <g id="375" class="nad-vl120to180" title="L14-15-1">
             <g>
                 <polyline points="17.73,8.79 15.69,9.21"/>
             </g>
@@ -194,7 +196,7 @@
                 <polyline points="13.64,9.63 15.69,9.21"/>
             </g>
         </g>
-        <g id="258" class="nad-vl120to180" title="L15-17-1">
+        <g id="376" class="nad-vl120to180" title="L15-17-1">
             <g>
                 <polyline points="13.64,9.63 14.14,7.15"/>
             </g>
@@ -202,7 +204,7 @@
                 <polyline points="14.65,4.68 14.14,7.15"/>
             </g>
         </g>
-        <g id="259" class="nad-vl120to180" title="L15-19-1">
+        <g id="377" class="nad-vl120to180" title="L15-19-1">
             <g>
                 <polyline points="13.64,9.63 11.63,9.46"/>
             </g>
@@ -210,7 +212,7 @@
                 <polyline points="9.62,9.30 11.63,9.46"/>
             </g>
         </g>
-        <g id="260" class="nad-vl120to180" title="L15-33-1">
+        <g id="378" class="nad-vl120to180" title="L15-33-1">
             <g>
                 <polyline points="13.64,9.63 11.54,11.17"/>
             </g>
@@ -218,7 +220,7 @@
                 <polyline points="9.43,12.71 11.54,11.17"/>
             </g>
         </g>
-        <g id="261" class="nad-vl120to180" title="L16-17-1">
+        <g id="379" class="nad-vl120to180" title="L16-17-1">
             <g>
                 <polyline points="18.62,5.39 16.63,5.03"/>
             </g>
@@ -226,7 +228,7 @@
                 <polyline points="14.65,4.68 16.63,5.03"/>
             </g>
         </g>
-        <g id="262" class="nad-vl120to180" title="L17-18-1">
+        <g id="380" class="nad-vl120to180" title="L17-18-1">
             <g>
                 <polyline points="14.65,4.68 13.57,5.79"/>
             </g>
@@ -234,7 +236,7 @@
                 <polyline points="12.49,6.90 13.57,5.79"/>
             </g>
         </g>
-        <g id="263" title="T30-17-1">
+        <g id="381" title="T30-17-1">
             <g class="nad-vl120to180">
                 <polyline points="10.89,7.10 12.77,5.89"/>
                 <circle cx="12.68" cy="5.95" r="0.20"/>
@@ -244,7 +246,7 @@
                 <circle cx="12.85" cy="5.84" r="0.20"/>
             </g>
         </g>
-        <g id="264" class="nad-vl120to180" title="L17-31-1">
+        <g id="382" class="nad-vl120to180" title="L17-31-1">
             <g>
                 <polyline points="14.65,4.68 15.77,2.06"/>
             </g>
@@ -252,7 +254,7 @@
                 <polyline points="16.89,-0.57 15.77,2.06"/>
             </g>
         </g>
-        <g id="265" class="nad-vl120to180" title="L17-113-1">
+        <g id="383" class="nad-vl120to180" title="L17-113-1">
             <g>
                 <polyline points="14.65,4.68 14.67,2.74"/>
             </g>
@@ -260,7 +262,7 @@
                 <polyline points="14.70,0.80 14.67,2.74"/>
             </g>
         </g>
-        <g id="266" class="nad-vl120to180" title="L18-19-1">
+        <g id="384" class="nad-vl120to180" title="L18-19-1">
             <g>
                 <polyline points="12.49,6.90 11.05,8.10"/>
             </g>
@@ -268,7 +270,7 @@
                 <polyline points="9.62,9.30 11.05,8.10"/>
             </g>
         </g>
-        <g id="267" class="nad-vl120to180" title="L19-20-1">
+        <g id="385" class="nad-vl120to180" title="L19-20-1">
             <g>
                 <polyline points="9.62,9.30 8.51,7.71"/>
             </g>
@@ -276,7 +278,7 @@
                 <polyline points="7.39,6.12 8.51,7.71"/>
             </g>
         </g>
-        <g id="268" class="nad-vl120to180" title="L19-34-1">
+        <g id="386" class="nad-vl120to180" title="L19-34-1">
             <g>
                 <polyline points="9.62,9.30 7.99,10.97"/>
             </g>
@@ -284,7 +286,7 @@
                 <polyline points="6.37,12.65 7.99,10.97"/>
             </g>
         </g>
-        <g id="269" class="nad-vl120to180" title="L20-21-1">
+        <g id="387" class="nad-vl120to180" title="L20-21-1">
             <g>
                 <polyline points="7.39,6.12 7.21,4.46"/>
             </g>
@@ -292,7 +294,7 @@
                 <polyline points="7.02,2.80 7.21,4.46"/>
             </g>
         </g>
-        <g id="270" class="nad-vl120to180" title="L21-22-1">
+        <g id="388" class="nad-vl120to180" title="L21-22-1">
             <g>
                 <polyline points="7.02,2.80 7.56,1.24"/>
             </g>
@@ -300,7 +302,7 @@
                 <polyline points="8.09,-0.32 7.56,1.24"/>
             </g>
         </g>
-        <g id="271" class="nad-vl120to180" title="L22-23-1">
+        <g id="389" class="nad-vl120to180" title="L22-23-1">
             <g>
                 <polyline points="8.09,-0.32 8.92,-1.67"/>
             </g>
@@ -308,7 +310,7 @@
                 <polyline points="9.74,-3.02 8.92,-1.67"/>
             </g>
         </g>
-        <g id="272" class="nad-vl120to180" title="L23-24-1">
+        <g id="390" class="nad-vl120to180" title="L23-24-1">
             <g>
                 <polyline points="9.74,-3.02 7.58,-3.33"/>
             </g>
@@ -316,7 +318,7 @@
                 <polyline points="5.43,-3.64 7.58,-3.33"/>
             </g>
         </g>
-        <g id="273" class="nad-vl120to180" title="L23-25-1">
+        <g id="391" class="nad-vl120to180" title="L23-25-1">
             <g>
                 <polyline points="9.74,-3.02 10.98,-2.53"/>
             </g>
@@ -324,7 +326,7 @@
                 <polyline points="12.21,-2.05 10.98,-2.53"/>
             </g>
         </g>
-        <g id="274" class="nad-vl120to180" title="L23-32-1">
+        <g id="392" class="nad-vl120to180" title="L23-32-1">
             <g>
                 <polyline points="9.74,-3.02 12.00,-3.11"/>
             </g>
@@ -332,7 +334,7 @@
                 <polyline points="14.25,-3.21 12.00,-3.11"/>
             </g>
         </g>
-        <g id="275" class="nad-vl120to180" title="L24-70-1">
+        <g id="393" class="nad-vl120to180" title="L24-70-1">
             <g>
                 <polyline points="5.43,-3.64 2.78,-3.25"/>
             </g>
@@ -340,7 +342,7 @@
                 <polyline points="0.13,-2.86 2.78,-3.25"/>
             </g>
         </g>
-        <g id="276" class="nad-vl120to180" title="L24-72-1">
+        <g id="394" class="nad-vl120to180" title="L24-72-1">
             <g>
                 <polyline points="5.43,-3.64 5.39,-5.00"/>
             </g>
@@ -348,7 +350,7 @@
                 <polyline points="5.34,-6.36 5.39,-5.00"/>
             </g>
         </g>
-        <g id="277" title="T26-25-1">
+        <g id="395" title="T26-25-1">
             <g class="nad-vl120to180">
                 <polyline points="11.13,2.34 11.67,0.15"/>
                 <circle cx="11.65" cy="0.24" r="0.20"/>
@@ -358,7 +360,7 @@
                 <circle cx="11.70" cy="0.05" r="0.20"/>
             </g>
         </g>
-        <g id="278" class="nad-vl120to180" title="L25-27-1">
+        <g id="396" class="nad-vl120to180" title="L25-27-1">
             <g>
                 <polyline points="12.21,-2.05 13.94,-3.69"/>
             </g>
@@ -366,7 +368,7 @@
                 <polyline points="15.67,-5.34 13.94,-3.69"/>
             </g>
         </g>
-        <g id="279" class="nad-vl120to180" title="L26-30-1">
+        <g id="397" class="nad-vl120to180" title="L26-30-1">
             <g>
                 <polyline points="11.13,2.34 11.01,4.72"/>
             </g>
@@ -374,7 +376,7 @@
                 <polyline points="10.89,7.10 11.01,4.72"/>
             </g>
         </g>
-        <g id="280" class="nad-vl120to180" title="L27-28-1">
+        <g id="398" class="nad-vl120to180" title="L27-28-1">
             <g>
                 <polyline points="15.67,-5.34 17.27,-5.62"/>
             </g>
@@ -382,7 +384,7 @@
                 <polyline points="18.87,-5.91 17.27,-5.62"/>
             </g>
         </g>
-        <g id="281" class="nad-vl120to180" title="L27-32-1">
+        <g id="399" class="nad-vl120to180" title="L27-32-1">
             <g>
                 <polyline points="15.67,-5.34 14.96,-4.27"/>
             </g>
@@ -390,7 +392,7 @@
                 <polyline points="14.25,-3.21 14.96,-4.27"/>
             </g>
         </g>
-        <g id="282" class="nad-vl120to180" title="L27-115-1">
+        <g id="400" class="nad-vl120to180" title="L27-115-1">
             <g>
                 <polyline points="15.67,-5.34 15.65,-6.96"/>
             </g>
@@ -398,7 +400,7 @@
                 <polyline points="15.63,-8.59 15.65,-6.96"/>
             </g>
         </g>
-        <g id="283" class="nad-vl120to180" title="L28-29-1">
+        <g id="401" class="nad-vl120to180" title="L28-29-1">
             <g>
                 <polyline points="18.87,-5.91 19.14,-4.57"/>
             </g>
@@ -406,7 +408,7 @@
                 <polyline points="19.41,-3.24 19.14,-4.57"/>
             </g>
         </g>
-        <g id="284" class="nad-vl120to180" title="L29-31-1">
+        <g id="402" class="nad-vl120to180" title="L29-31-1">
             <g>
                 <polyline points="19.41,-3.24 18.15,-1.90"/>
             </g>
@@ -414,7 +416,7 @@
                 <polyline points="16.89,-0.57 18.15,-1.90"/>
             </g>
         </g>
-        <g id="285" class="nad-vl120to180" title="L30-38-1">
+        <g id="403" class="nad-vl120to180" title="L30-38-1">
             <g>
                 <polyline points="10.89,7.10 8.05,8.78"/>
             </g>
@@ -422,7 +424,7 @@
                 <polyline points="5.22,10.46 8.05,8.78"/>
             </g>
         </g>
-        <g id="286" class="nad-vl120to180" title="L31-32-1">
+        <g id="404" class="nad-vl120to180" title="L31-32-1">
             <g>
                 <polyline points="16.89,-0.57 15.57,-1.89"/>
             </g>
@@ -430,7 +432,7 @@
                 <polyline points="14.25,-3.21 15.57,-1.89"/>
             </g>
         </g>
-        <g id="287" class="nad-vl120to180" title="L32-113-1">
+        <g id="405" class="nad-vl120to180" title="L32-113-1">
             <g>
                 <polyline points="14.25,-3.21 14.48,-1.20"/>
             </g>
@@ -438,7 +440,7 @@
                 <polyline points="14.70,0.80 14.48,-1.20"/>
             </g>
         </g>
-        <g id="288" class="nad-vl120to180" title="L32-114-1">
+        <g id="406" class="nad-vl120to180" title="L32-114-1">
             <g>
                 <polyline points="14.25,-3.21 14.01,-5.13"/>
             </g>
@@ -446,7 +448,7 @@
                 <polyline points="13.77,-7.06 14.01,-5.13"/>
             </g>
         </g>
-        <g id="289" class="nad-vl120to180" title="L33-37-1">
+        <g id="407" class="nad-vl120to180" title="L33-37-1">
             <g>
                 <polyline points="9.43,12.71 7.10,13.65"/>
             </g>
@@ -454,7 +456,7 @@
                 <polyline points="4.76,14.59 7.10,13.65"/>
             </g>
         </g>
-        <g id="290" class="nad-vl120to180" title="L34-36-1">
+        <g id="408" class="nad-vl120to180" title="L34-36-1">
             <g>
                 <polyline points="6.37,12.65 6.93,14.26"/>
             </g>
@@ -462,7 +464,7 @@
                 <polyline points="7.48,15.88 6.93,14.26"/>
             </g>
         </g>
-        <g id="291" class="nad-vl120to180" title="L34-37-1">
+        <g id="409" class="nad-vl120to180" title="L34-37-1">
             <g>
                 <polyline points="6.37,12.65 5.57,13.62"/>
             </g>
@@ -470,7 +472,7 @@
                 <polyline points="4.76,14.59 5.57,13.62"/>
             </g>
         </g>
-        <g id="292" class="nad-vl120to180" title="L34-43-1">
+        <g id="410" class="nad-vl120to180" title="L34-43-1">
             <g>
                 <polyline points="6.37,12.65 4.13,11.98"/>
             </g>
@@ -478,7 +480,7 @@
                 <polyline points="1.89,11.30 4.13,11.98"/>
             </g>
         </g>
-        <g id="293" class="nad-vl120to180" title="L35-36-1">
+        <g id="411" class="nad-vl120to180" title="L35-36-1">
             <g>
                 <polyline points="5.77,17.43 6.63,16.65"/>
             </g>
@@ -486,7 +488,7 @@
                 <polyline points="7.48,15.88 6.63,16.65"/>
             </g>
         </g>
-        <g id="294" class="nad-vl120to180" title="L35-37-1">
+        <g id="412" class="nad-vl120to180" title="L35-37-1">
             <g>
                 <polyline points="5.77,17.43 5.27,16.01"/>
             </g>
@@ -494,7 +496,7 @@
                 <polyline points="4.76,14.59 5.27,16.01"/>
             </g>
         </g>
-        <g id="295" title="T38-37-1">
+        <g id="413" title="T38-37-1">
             <g class="nad-vl120to180">
                 <polyline points="5.22,10.46 4.99,12.52"/>
                 <circle cx="5.00" cy="12.42" r="0.20"/>
@@ -504,7 +506,7 @@
                 <circle cx="4.98" cy="12.62" r="0.20"/>
             </g>
         </g>
-        <g id="296" class="nad-vl120to180" title="L37-39-1">
+        <g id="414" class="nad-vl120to180" title="L37-39-1">
             <g>
                 <polyline points="4.76,14.59 3.57,15.75"/>
             </g>
@@ -512,7 +514,7 @@
                 <polyline points="2.38,16.92 3.57,15.75"/>
             </g>
         </g>
-        <g id="297" class="nad-vl120to180" title="L37-40-1">
+        <g id="415" class="nad-vl120to180" title="L37-40-1">
             <g>
                 <polyline points="4.76,14.59 2.44,14.93"/>
             </g>
@@ -520,7 +522,7 @@
                 <polyline points="0.12,15.27 2.44,14.93"/>
             </g>
         </g>
-        <g id="298" class="nad-vl120to180" title="L38-65-1">
+        <g id="416" class="nad-vl120to180" title="L38-65-1">
             <g>
                 <polyline points="5.22,10.46 0.24,9.77"/>
             </g>
@@ -528,7 +530,7 @@
                 <polyline points="-4.73,9.08 0.24,9.77"/>
             </g>
         </g>
-        <g id="299" class="nad-vl120to180" title="L39-40-1">
+        <g id="417" class="nad-vl120to180" title="L39-40-1">
             <g>
                 <polyline points="2.38,16.92 1.25,16.10"/>
             </g>
@@ -536,7 +538,7 @@
                 <polyline points="0.12,15.27 1.25,16.10"/>
             </g>
         </g>
-        <g id="300" class="nad-vl120to180" title="L40-41-1">
+        <g id="418" class="nad-vl120to180" title="L40-41-1">
             <g>
                 <polyline points="0.12,15.27 -1.22,15.55"/>
             </g>
@@ -544,7 +546,7 @@
                 <polyline points="-2.56,15.82 -1.22,15.55"/>
             </g>
         </g>
-        <g id="301" class="nad-vl120to180" title="L40-42-1">
+        <g id="419" class="nad-vl120to180" title="L40-42-1">
             <g>
                 <polyline points="0.12,15.27 -1.97,14.40"/>
             </g>
@@ -552,7 +554,7 @@
                 <polyline points="-4.05,13.53 -1.97,14.40"/>
             </g>
         </g>
-        <g id="302" class="nad-vl120to180" title="L41-42-1">
+        <g id="420" class="nad-vl120to180" title="L41-42-1">
             <g>
                 <polyline points="-2.56,15.82 -3.31,14.67"/>
             </g>
@@ -560,7 +562,7 @@
                 <polyline points="-4.05,13.53 -3.31,14.67"/>
             </g>
         </g>
-        <g id="303" class="nad-vl120to180" title="L42-49-1">
+        <g id="421" class="nad-vl120to180" title="L42-49-1">
             <g>
                 <polyline points="-4.05,13.53 -4.02,12.73 -5.77,9.45"/>
             </g>
@@ -568,7 +570,7 @@
                 <polyline points="-8.20,5.75 -7.52,6.18 -5.77,9.45"/>
             </g>
         </g>
-        <g id="304" class="nad-vl120to180" title="L42-49-2">
+        <g id="422" class="nad-vl120to180" title="L42-49-2">
             <g>
                 <polyline points="-4.05,13.53 -4.73,13.11 -6.48,9.83"/>
             </g>
@@ -576,7 +578,7 @@
                 <polyline points="-8.20,5.75 -8.23,6.55 -6.48,9.83"/>
             </g>
         </g>
-        <g id="305" class="nad-vl120to180" title="L43-44-1">
+        <g id="423" class="nad-vl120to180" title="L43-44-1">
             <g>
                 <polyline points="1.89,11.30 -0.49,9.35"/>
             </g>
@@ -584,7 +586,7 @@
                 <polyline points="-2.88,7.40 -0.49,9.35"/>
             </g>
         </g>
-        <g id="306" class="nad-vl120to180" title="L44-45-1">
+        <g id="424" class="nad-vl120to180" title="L44-45-1">
             <g>
                 <polyline points="-2.88,7.40 -4.60,6.71"/>
             </g>
@@ -592,7 +594,7 @@
                 <polyline points="-6.32,6.02 -4.60,6.71"/>
             </g>
         </g>
-        <g id="307" class="nad-vl120to180" title="L45-46-1">
+        <g id="425" class="nad-vl120to180" title="L45-46-1">
             <g>
                 <polyline points="-6.32,6.02 -6.34,6.68"/>
             </g>
@@ -600,7 +602,7 @@
                 <polyline points="-6.37,7.34 -6.34,6.68"/>
             </g>
         </g>
-        <g id="308" class="nad-vl120to180" title="L45-49-1">
+        <g id="426" class="nad-vl120to180" title="L45-49-1">
             <g>
                 <polyline points="-6.32,6.02 -7.26,5.88"/>
             </g>
@@ -608,7 +610,7 @@
                 <polyline points="-8.20,5.75 -7.26,5.88"/>
             </g>
         </g>
-        <g id="309" class="nad-vl120to180" title="L46-47-1">
+        <g id="427" class="nad-vl120to180" title="L46-47-1">
             <g>
                 <polyline points="-6.37,7.34 -5.51,6.12"/>
             </g>
@@ -616,7 +618,7 @@
                 <polyline points="-4.66,4.90 -5.51,6.12"/>
             </g>
         </g>
-        <g id="310" class="nad-vl120to180" title="L46-48-1">
+        <g id="428" class="nad-vl120to180" title="L46-48-1">
             <g>
                 <polyline points="-6.37,7.34 -9.06,10.29"/>
             </g>
@@ -624,7 +626,7 @@
                 <polyline points="-11.75,13.24 -9.06,10.29"/>
             </g>
         </g>
-        <g id="311" class="nad-vl120to180" title="L47-49-1">
+        <g id="429" class="nad-vl120to180" title="L47-49-1">
             <g>
                 <polyline points="-4.66,4.90 -6.43,5.33"/>
             </g>
@@ -632,7 +634,7 @@
                 <polyline points="-8.20,5.75 -6.43,5.33"/>
             </g>
         </g>
-        <g id="312" class="nad-vl120to180" title="L47-69-1">
+        <g id="430" class="nad-vl120to180" title="L47-69-1">
             <g>
                 <polyline points="-4.66,4.90 -8.40,-1.00"/>
             </g>
@@ -640,7 +642,7 @@
                 <polyline points="-12.14,-6.89 -8.40,-1.00"/>
             </g>
         </g>
-        <g id="313" class="nad-vl120to180" title="L48-49-1">
+        <g id="431" class="nad-vl120to180" title="L48-49-1">
             <g>
                 <polyline points="-11.75,13.24 -9.98,9.50"/>
             </g>
@@ -648,7 +650,7 @@
                 <polyline points="-8.20,5.75 -9.98,9.50"/>
             </g>
         </g>
-        <g id="314" class="nad-vl120to180" title="L49-50-1">
+        <g id="432" class="nad-vl120to180" title="L49-50-1">
             <g>
                 <polyline points="-8.20,5.75 -9.82,2.86"/>
             </g>
@@ -656,7 +658,7 @@
                 <polyline points="-11.45,-0.04 -9.82,2.86"/>
             </g>
         </g>
-        <g id="315" class="nad-vl120to180" title="L49-51-1">
+        <g id="433" class="nad-vl120to180" title="L49-51-1">
             <g>
                 <polyline points="-8.20,5.75 -10.81,5.92"/>
             </g>
@@ -664,7 +666,7 @@
                 <polyline points="-13.42,6.08 -10.81,5.92"/>
             </g>
         </g>
-        <g id="316" class="nad-vl120to180" title="L49-54-1">
+        <g id="434" class="nad-vl120to180" title="L49-54-1">
             <g>
                 <polyline points="-8.20,5.75 -8.38,6.53 -6.94,11.09"/>
             </g>
@@ -672,7 +674,7 @@
                 <polyline points="-4.92,16.19 -5.51,15.65 -6.94,11.09"/>
             </g>
         </g>
-        <g id="317" class="nad-vl120to180" title="L49-54-2">
+        <g id="435" class="nad-vl120to180" title="L49-54-2">
             <g>
                 <polyline points="-8.20,5.75 -7.61,6.29 -6.18,10.85"/>
             </g>
@@ -680,7 +682,7 @@
                 <polyline points="-4.92,16.19 -4.74,15.41 -6.18,10.85"/>
             </g>
         </g>
-        <g id="318" class="nad-vl120to180" title="L49-66-1">
+        <g id="436" class="nad-vl120to180" title="L49-66-1">
             <g>
                 <polyline points="-8.20,5.75 -8.95,5.47 -11.57,5.89"/>
             </g>
@@ -688,7 +690,7 @@
                 <polyline points="-14.81,6.82 -14.19,6.32 -11.57,5.89"/>
             </g>
         </g>
-        <g id="319" class="nad-vl120to180" title="L49-66-2">
+        <g id="437" class="nad-vl120to180" title="L49-66-2">
             <g>
                 <polyline points="-8.20,5.75 -8.82,6.26 -11.44,6.68"/>
             </g>
@@ -696,7 +698,7 @@
                 <polyline points="-14.81,6.82 -14.06,7.10 -11.44,6.68"/>
             </g>
         </g>
-        <g id="320" class="nad-vl120to180" title="L49-69-1">
+        <g id="438" class="nad-vl120to180" title="L49-69-1">
             <g>
                 <polyline points="-8.20,5.75 -10.17,-0.57"/>
             </g>
@@ -704,7 +706,7 @@
                 <polyline points="-12.14,-6.89 -10.17,-0.57"/>
             </g>
         </g>
-        <g id="321" class="nad-vl120to180" title="L50-57-1">
+        <g id="439" class="nad-vl120to180" title="L50-57-1">
             <g>
                 <polyline points="-11.45,-0.04 -12.79,2.74"/>
             </g>
@@ -712,7 +714,7 @@
                 <polyline points="-14.14,5.51 -12.79,2.74"/>
             </g>
         </g>
-        <g id="322" class="nad-vl120to180" title="L51-52-1">
+        <g id="440" class="nad-vl120to180" title="L51-52-1">
             <g>
                 <polyline points="-13.42,6.08 -15.24,6.64"/>
             </g>
@@ -720,7 +722,7 @@
                 <polyline points="-17.07,7.21 -15.24,6.64"/>
             </g>
         </g>
-        <g id="323" class="nad-vl120to180" title="L51-58-1">
+        <g id="441" class="nad-vl120to180" title="L51-58-1">
             <g>
                 <polyline points="-13.42,6.08 -13.50,7.10"/>
             </g>
@@ -728,7 +730,7 @@
                 <polyline points="-13.58,8.12 -13.50,7.10"/>
             </g>
         </g>
-        <g id="324" class="nad-vl120to180" title="L52-53-1">
+        <g id="442" class="nad-vl120to180" title="L52-53-1">
             <g>
                 <polyline points="-17.07,7.21 -16.66,8.33"/>
             </g>
@@ -736,7 +738,7 @@
                 <polyline points="-16.25,9.46 -16.66,8.33"/>
             </g>
         </g>
-        <g id="325" class="nad-vl120to180" title="L53-54-1">
+        <g id="443" class="nad-vl120to180" title="L53-54-1">
             <g>
                 <polyline points="-16.25,9.46 -10.58,12.83"/>
             </g>
@@ -744,7 +746,7 @@
                 <polyline points="-4.92,16.19 -10.58,12.83"/>
             </g>
         </g>
-        <g id="326" class="nad-vl120to180" title="L54-55-1">
+        <g id="444" class="nad-vl120to180" title="L54-55-1">
             <g>
                 <polyline points="-4.92,16.19 -5.95,16.33"/>
             </g>
@@ -752,7 +754,7 @@
                 <polyline points="-6.98,16.47 -5.95,16.33"/>
             </g>
         </g>
-        <g id="327" class="nad-vl120to180" title="L54-56-1">
+        <g id="445" class="nad-vl120to180" title="L54-56-1">
             <g>
                 <polyline points="-4.92,16.19 -7.21,15.92"/>
             </g>
@@ -760,7 +762,7 @@
                 <polyline points="-9.51,15.65 -7.21,15.92"/>
             </g>
         </g>
-        <g id="328" class="nad-vl120to180" title="L54-59-1">
+        <g id="446" class="nad-vl120to180" title="L54-59-1">
             <g>
                 <polyline points="-4.92,16.19 -7.73,15.42"/>
             </g>
@@ -768,7 +770,7 @@
                 <polyline points="-10.53,14.64 -7.73,15.42"/>
             </g>
         </g>
-        <g id="329" class="nad-vl120to180" title="L55-56-1">
+        <g id="447" class="nad-vl120to180" title="L55-56-1">
             <g>
                 <polyline points="-6.98,16.47 -8.25,16.06"/>
             </g>
@@ -776,7 +778,7 @@
                 <polyline points="-9.51,15.65 -8.25,16.06"/>
             </g>
         </g>
-        <g id="330" class="nad-vl120to180" title="L55-59-1">
+        <g id="448" class="nad-vl120to180" title="L55-59-1">
             <g>
                 <polyline points="-6.98,16.47 -8.76,15.56"/>
             </g>
@@ -784,7 +786,7 @@
                 <polyline points="-10.53,14.64 -8.76,15.56"/>
             </g>
         </g>
-        <g id="331" class="nad-vl120to180" title="L56-57-1">
+        <g id="449" class="nad-vl120to180" title="L56-57-1">
             <g>
                 <polyline points="-9.51,15.65 -11.82,10.58"/>
             </g>
@@ -792,7 +794,7 @@
                 <polyline points="-14.14,5.51 -11.82,10.58"/>
             </g>
         </g>
-        <g id="332" class="nad-vl120to180" title="L56-58-1">
+        <g id="450" class="nad-vl120to180" title="L56-58-1">
             <g>
                 <polyline points="-9.51,15.65 -11.54,11.89"/>
             </g>
@@ -800,7 +802,7 @@
                 <polyline points="-13.58,8.12 -11.54,11.89"/>
             </g>
         </g>
-        <g id="333" class="nad-vl120to180" title="L56-59-1">
+        <g id="451" class="nad-vl120to180" title="L56-59-1">
             <g>
                 <polyline points="-9.51,15.65 -9.72,14.88 -9.74,14.86"/>
             </g>
@@ -808,7 +810,7 @@
                 <polyline points="-10.53,14.64 -9.76,14.84 -9.74,14.86"/>
             </g>
         </g>
-        <g id="334" class="nad-vl120to180" title="L56-59-2">
+        <g id="452" class="nad-vl120to180" title="L56-59-2">
             <g>
                 <polyline points="-9.51,15.65 -10.28,15.45 -10.30,15.43"/>
             </g>
@@ -816,7 +818,7 @@
                 <polyline points="-10.53,14.64 -10.32,15.41 -10.30,15.43"/>
             </g>
         </g>
-        <g id="335" class="nad-vl120to180" title="L59-60-1">
+        <g id="453" class="nad-vl120to180" title="L59-60-1">
             <g>
                 <polyline points="-10.53,14.64 -8.77,16.63"/>
             </g>
@@ -824,7 +826,7 @@
                 <polyline points="-7.01,18.61 -8.77,16.63"/>
             </g>
         </g>
-        <g id="336" class="nad-vl120to180" title="L59-61-1">
+        <g id="454" class="nad-vl120to180" title="L59-61-1">
             <g>
                 <polyline points="-10.53,14.64 -12.48,14.29"/>
             </g>
@@ -832,7 +834,7 @@
                 <polyline points="-14.43,13.95 -12.48,14.29"/>
             </g>
         </g>
-        <g id="337" title="T63-59-1">
+        <g id="455" title="T63-59-1">
             <g class="nad-vl120to180">
                 <polyline points="-3.93,22.99 -7.23,18.82"/>
                 <circle cx="-7.17" cy="18.90" r="0.20"/>
@@ -842,7 +844,7 @@
                 <circle cx="-7.30" cy="18.74" r="0.20"/>
             </g>
         </g>
-        <g id="338" class="nad-vl120to180" title="L60-61-1">
+        <g id="456" class="nad-vl120to180" title="L60-61-1">
             <g>
                 <polyline points="-7.01,18.61 -10.72,16.28"/>
             </g>
@@ -850,7 +852,7 @@
                 <polyline points="-14.43,13.95 -10.72,16.28"/>
             </g>
         </g>
-        <g id="339" class="nad-vl120to180" title="L60-62-1">
+        <g id="457" class="nad-vl120to180" title="L60-62-1">
             <g>
                 <polyline points="-7.01,18.61 -15.53,10.81"/>
             </g>
@@ -858,7 +860,7 @@
                 <polyline points="-24.05,3.01 -15.53,10.81"/>
             </g>
         </g>
-        <g id="340" class="nad-vl120to180" title="L61-62-1">
+        <g id="458" class="nad-vl120to180" title="L61-62-1">
             <g>
                 <polyline points="-14.43,13.95 -19.24,8.48"/>
             </g>
@@ -866,7 +868,7 @@
                 <polyline points="-24.05,3.01 -19.24,8.48"/>
             </g>
         </g>
-        <g id="341" title="T64-61-1">
+        <g id="459" title="T64-61-1">
             <g class="nad-vl120to180">
                 <polyline points="-9.38,15.01 -11.90,14.48"/>
                 <circle cx="-11.80" cy="14.50" r="0.20"/>
@@ -876,7 +878,7 @@
                 <circle cx="-12.00" cy="14.46" r="0.20"/>
             </g>
         </g>
-        <g id="342" class="nad-vl120to180" title="L62-66-1">
+        <g id="460" class="nad-vl120to180" title="L62-66-1">
             <g>
                 <polyline points="-24.05,3.01 -19.43,4.92"/>
             </g>
@@ -884,7 +886,7 @@
                 <polyline points="-14.81,6.82 -19.43,4.92"/>
             </g>
         </g>
-        <g id="343" class="nad-vl120to180" title="L62-67-1">
+        <g id="461" class="nad-vl120to180" title="L62-67-1">
             <g>
                 <polyline points="-24.05,3.01 -21.48,5.85"/>
             </g>
@@ -892,7 +894,7 @@
                 <polyline points="-18.92,8.69 -21.48,5.85"/>
             </g>
         </g>
-        <g id="344" class="nad-vl120to180" title="L63-64-1">
+        <g id="462" class="nad-vl120to180" title="L63-64-1">
             <g>
                 <polyline points="-3.93,22.99 -6.66,19.00"/>
             </g>
@@ -900,7 +902,7 @@
                 <polyline points="-9.38,15.01 -6.66,19.00"/>
             </g>
         </g>
-        <g id="345" class="nad-vl120to180" title="L64-65-1">
+        <g id="463" class="nad-vl120to180" title="L64-65-1">
             <g>
                 <polyline points="-9.38,15.01 -7.06,12.05"/>
             </g>
@@ -908,7 +910,7 @@
                 <polyline points="-4.73,9.08 -7.06,12.05"/>
             </g>
         </g>
-        <g id="346" title="T65-66-1">
+        <g id="464" title="T65-66-1">
             <g class="nad-vl120to180">
                 <polyline points="-4.73,9.08 -9.77,7.95"/>
                 <circle cx="-9.67" cy="7.97" r="0.20"/>
@@ -918,7 +920,7 @@
                 <circle cx="-9.87" cy="7.93" r="0.20"/>
             </g>
         </g>
-        <g id="347" class="nad-vl120to180" title="L65-68-1">
+        <g id="465" class="nad-vl120to180" title="L65-68-1">
             <g>
                 <polyline points="-4.73,9.08 -1.61,9.61"/>
             </g>
@@ -926,7 +928,7 @@
                 <polyline points="1.51,10.13 -1.61,9.61"/>
             </g>
         </g>
-        <g id="348" class="nad-vl120to180" title="L66-67-1">
+        <g id="466" class="nad-vl120to180" title="L66-67-1">
             <g>
                 <polyline points="-14.81,6.82 -16.86,7.76"/>
             </g>
@@ -934,7 +936,7 @@
                 <polyline points="-18.92,8.69 -16.86,7.76"/>
             </g>
         </g>
-        <g id="349" title="T68-69-1">
+        <g id="467" title="T68-69-1">
             <g class="nad-vl120to180">
                 <polyline points="1.51,10.13 -5.32,1.62"/>
                 <circle cx="-5.25" cy="1.70" r="0.20"/>
@@ -944,7 +946,7 @@
                 <circle cx="-5.38" cy="1.54" r="0.20"/>
             </g>
         </g>
-        <g id="350" class="nad-vl120to180" title="L68-81-1">
+        <g id="468" class="nad-vl120to180" title="L68-81-1">
             <g>
                 <polyline points="1.51,10.13 -2.14,1.62"/>
             </g>
@@ -952,7 +954,7 @@
                 <polyline points="-5.79,-6.89 -2.14,1.62"/>
             </g>
         </g>
-        <g id="351" class="nad-vl120to180" title="L68-116-1">
+        <g id="469" class="nad-vl120to180" title="L68-116-1">
             <g>
                 <polyline points="1.51,10.13 -4.07,4.98"/>
             </g>
@@ -960,7 +962,7 @@
                 <polyline points="-9.66,-0.16 -4.07,4.98"/>
             </g>
         </g>
-        <g id="352" class="nad-vl120to180" title="L69-70-1">
+        <g id="470" class="nad-vl120to180" title="L69-70-1">
             <g>
                 <polyline points="-12.14,-6.89 -6.00,-4.88"/>
             </g>
@@ -968,7 +970,7 @@
                 <polyline points="0.13,-2.86 -6.00,-4.88"/>
             </g>
         </g>
-        <g id="353" class="nad-vl120to180" title="L69-75-1">
+        <g id="471" class="nad-vl120to180" title="L69-75-1">
             <g>
                 <polyline points="-12.14,-6.89 -7.53,-4.48"/>
             </g>
@@ -976,7 +978,7 @@
                 <polyline points="-2.92,-2.06 -7.53,-4.48"/>
             </g>
         </g>
-        <g id="354" class="nad-vl120to180" title="L69-77-1">
+        <g id="472" class="nad-vl120to180" title="L69-77-1">
             <g>
                 <polyline points="-12.14,-6.89 -9.74,-5.63"/>
             </g>
@@ -984,7 +986,7 @@
                 <polyline points="-7.34,-4.37 -9.74,-5.63"/>
             </g>
         </g>
-        <g id="355" class="nad-vl120to180" title="L70-71-1">
+        <g id="473" class="nad-vl120to180" title="L70-71-1">
             <g>
                 <polyline points="0.13,-2.86 1.50,-4.59"/>
             </g>
@@ -992,7 +994,7 @@
                 <polyline points="2.87,-6.32 1.50,-4.59"/>
             </g>
         </g>
-        <g id="356" class="nad-vl120to180" title="L70-74-1">
+        <g id="474" class="nad-vl120to180" title="L70-74-1">
             <g>
                 <polyline points="0.13,-2.86 -0.36,-1.91"/>
             </g>
@@ -1000,7 +1002,7 @@
                 <polyline points="-0.85,-0.96 -0.36,-1.91"/>
             </g>
         </g>
-        <g id="357" class="nad-vl120to180" title="L70-75-1">
+        <g id="475" class="nad-vl120to180" title="L70-75-1">
             <g>
                 <polyline points="0.13,-2.86 -1.40,-2.46"/>
             </g>
@@ -1008,7 +1010,7 @@
                 <polyline points="-2.92,-2.06 -1.40,-2.46"/>
             </g>
         </g>
-        <g id="358" class="nad-vl120to180" title="L71-72-1">
+        <g id="476" class="nad-vl120to180" title="L71-72-1">
             <g>
                 <polyline points="2.87,-6.32 4.11,-6.34"/>
             </g>
@@ -1016,7 +1018,7 @@
                 <polyline points="5.34,-6.36 4.11,-6.34"/>
             </g>
         </g>
-        <g id="359" class="nad-vl120to180" title="L71-73-1">
+        <g id="477" class="nad-vl120to180" title="L71-73-1">
             <g>
                 <polyline points="2.87,-6.32 3.23,-7.85"/>
             </g>
@@ -1024,7 +1026,7 @@
                 <polyline points="3.59,-9.39 3.23,-7.85"/>
             </g>
         </g>
-        <g id="360" class="nad-vl120to180" title="L74-75-1">
+        <g id="478" class="nad-vl120to180" title="L74-75-1">
             <g>
                 <polyline points="-0.85,-0.96 -1.89,-1.51"/>
             </g>
@@ -1032,7 +1034,7 @@
                 <polyline points="-2.92,-2.06 -1.89,-1.51"/>
             </g>
         </g>
-        <g id="361" class="nad-vl120to180" title="L75-77-1">
+        <g id="479" class="nad-vl120to180" title="L75-77-1">
             <g>
                 <polyline points="-2.92,-2.06 -5.13,-3.22"/>
             </g>
@@ -1040,7 +1042,7 @@
                 <polyline points="-7.34,-4.37 -5.13,-3.22"/>
             </g>
         </g>
-        <g id="362" class="nad-vl120to180" title="L75-118-1">
+        <g id="480" class="nad-vl120to180" title="L75-118-1">
             <g>
                 <polyline points="-2.92,-2.06 -2.59,-3.61"/>
             </g>
@@ -1048,7 +1050,7 @@
                 <polyline points="-2.25,-5.16 -2.59,-3.61"/>
             </g>
         </g>
-        <g id="363" class="nad-vl120to180" title="L76-77-1">
+        <g id="481" class="nad-vl120to180" title="L76-77-1">
             <g>
                 <polyline points="-4.13,-2.99 -5.73,-3.68"/>
             </g>
@@ -1056,7 +1058,7 @@
                 <polyline points="-7.34,-4.37 -5.73,-3.68"/>
             </g>
         </g>
-        <g id="364" class="nad-vl120to180" title="L76-118-1">
+        <g id="482" class="nad-vl120to180" title="L76-118-1">
             <g>
                 <polyline points="-4.13,-2.99 -3.19,-4.08"/>
             </g>
@@ -1064,7 +1066,7 @@
                 <polyline points="-2.25,-5.16 -3.19,-4.08"/>
             </g>
         </g>
-        <g id="365" class="nad-vl120to180" title="L77-78-1">
+        <g id="483" class="nad-vl120to180" title="L77-78-1">
             <g>
                 <polyline points="-7.34,-4.37 -8.72,-4.84"/>
             </g>
@@ -1072,7 +1074,7 @@
                 <polyline points="-10.09,-5.31 -8.72,-4.84"/>
             </g>
         </g>
-        <g id="366" class="nad-vl120to180" title="L77-80-1">
+        <g id="484" class="nad-vl120to180" title="L77-80-1">
             <g>
                 <polyline points="-7.34,-4.37 -7.02,-5.10 -7.25,-7.05"/>
             </g>
@@ -1080,7 +1082,7 @@
                 <polyline points="-7.95,-9.65 -7.48,-9.00 -7.25,-7.05"/>
             </g>
         </g>
-        <g id="367" class="nad-vl120to180" title="L77-80-2">
+        <g id="485" class="nad-vl120to180" title="L77-80-2">
             <g>
                 <polyline points="-7.34,-4.37 -7.82,-5.01 -8.04,-6.96"/>
             </g>
@@ -1088,7 +1090,7 @@
                 <polyline points="-7.95,-9.65 -8.27,-8.91 -8.04,-6.96"/>
             </g>
         </g>
-        <g id="368" class="nad-vl120to180" title="L77-82-1">
+        <g id="486" class="nad-vl120to180" title="L77-82-1">
             <g>
                 <polyline points="-7.34,-4.37 -9.94,-6.22"/>
             </g>
@@ -1096,7 +1098,7 @@
                 <polyline points="-12.54,-8.08 -9.94,-6.22"/>
             </g>
         </g>
-        <g id="369" class="nad-vl120to180" title="L78-79-1">
+        <g id="487" class="nad-vl120to180" title="L78-79-1">
             <g>
                 <polyline points="-10.09,-5.31 -10.65,-5.40"/>
             </g>
@@ -1104,7 +1106,7 @@
                 <polyline points="-11.22,-5.48 -10.65,-5.40"/>
             </g>
         </g>
-        <g id="370" class="nad-vl120to180" title="L79-80-1">
+        <g id="488" class="nad-vl120to180" title="L79-80-1">
             <g>
                 <polyline points="-11.22,-5.48 -9.58,-7.56"/>
             </g>
@@ -1112,7 +1114,7 @@
                 <polyline points="-7.95,-9.65 -9.58,-7.56"/>
             </g>
         </g>
-        <g id="371" title="T81-80-1">
+        <g id="489" title="T81-80-1">
             <g class="nad-vl120to180">
                 <polyline points="-5.79,-6.89 -6.87,-8.27"/>
                 <circle cx="-6.81" cy="-8.19" r="0.20"/>
@@ -1122,7 +1124,7 @@
                 <circle cx="-6.93" cy="-8.35" r="0.20"/>
             </g>
         </g>
-        <g id="372" class="nad-vl120to180" title="L80-96-1">
+        <g id="490" class="nad-vl120to180" title="L80-96-1">
             <g>
                 <polyline points="-7.95,-9.65 -9.84,-11.21"/>
             </g>
@@ -1130,7 +1132,7 @@
                 <polyline points="-11.72,-12.77 -9.84,-11.21"/>
             </g>
         </g>
-        <g id="373" class="nad-vl120to180" title="L80-97-1">
+        <g id="491" class="nad-vl120to180" title="L80-97-1">
             <g>
                 <polyline points="-7.95,-9.65 -8.63,-10.15"/>
             </g>
@@ -1138,7 +1140,7 @@
                 <polyline points="-9.30,-10.66 -8.63,-10.15"/>
             </g>
         </g>
-        <g id="374" class="nad-vl120to180" title="L80-98-1">
+        <g id="492" class="nad-vl120to180" title="L80-98-1">
             <g>
                 <polyline points="-7.95,-9.65 -7.04,-11.26"/>
             </g>
@@ -1146,7 +1148,7 @@
                 <polyline points="-6.13,-12.88 -7.04,-11.26"/>
             </g>
         </g>
-        <g id="375" class="nad-vl120to180" title="L80-99-1">
+        <g id="493" class="nad-vl120to180" title="L80-99-1">
             <g>
                 <polyline points="-7.95,-9.65 -7.22,-11.99"/>
             </g>
@@ -1154,7 +1156,7 @@
                 <polyline points="-6.49,-14.34 -7.22,-11.99"/>
             </g>
         </g>
-        <g id="376" class="nad-vl120to180" title="L82-83-1">
+        <g id="494" class="nad-vl120to180" title="L82-83-1">
             <g>
                 <polyline points="-12.54,-8.08 -14.74,-8.70"/>
             </g>
@@ -1162,7 +1164,7 @@
                 <polyline points="-16.93,-9.33 -14.74,-8.70"/>
             </g>
         </g>
-        <g id="377" class="nad-vl120to180" title="L82-96-1">
+        <g id="495" class="nad-vl120to180" title="L82-96-1">
             <g>
                 <polyline points="-12.54,-8.08 -12.13,-10.42"/>
             </g>
@@ -1170,7 +1172,7 @@
                 <polyline points="-11.72,-12.77 -12.13,-10.42"/>
             </g>
         </g>
-        <g id="378" class="nad-vl120to180" title="L83-84-1">
+        <g id="496" class="nad-vl120to180" title="L83-84-1">
             <g>
                 <polyline points="-16.93,-9.33 -18.38,-9.13"/>
             </g>
@@ -1178,7 +1180,7 @@
                 <polyline points="-19.82,-8.93 -18.38,-9.13"/>
             </g>
         </g>
-        <g id="379" class="nad-vl120to180" title="L83-85-1">
+        <g id="497" class="nad-vl120to180" title="L83-85-1">
             <g>
                 <polyline points="-16.93,-9.33 -18.09,-10.36"/>
             </g>
@@ -1186,7 +1188,7 @@
                 <polyline points="-19.24,-11.39 -18.09,-10.36"/>
             </g>
         </g>
-        <g id="380" class="nad-vl120to180" title="L84-85-1">
+        <g id="498" class="nad-vl120to180" title="L84-85-1">
             <g>
                 <polyline points="-19.82,-8.93 -19.53,-10.16"/>
             </g>
@@ -1194,7 +1196,7 @@
                 <polyline points="-19.24,-11.39 -19.53,-10.16"/>
             </g>
         </g>
-        <g id="381" class="nad-vl120to180" title="L85-86-1">
+        <g id="499" class="nad-vl120to180" title="L85-86-1">
             <g>
                 <polyline points="-19.24,-11.39 -21.06,-11.02"/>
             </g>
@@ -1202,7 +1204,7 @@
                 <polyline points="-22.87,-10.65 -21.06,-11.02"/>
             </g>
         </g>
-        <g id="382" class="nad-vl120to180" title="L85-88-1">
+        <g id="500" class="nad-vl120to180" title="L85-88-1">
             <g>
                 <polyline points="-19.24,-11.39 -19.21,-12.77"/>
             </g>
@@ -1210,7 +1212,7 @@
                 <polyline points="-19.17,-14.14 -19.21,-12.77"/>
             </g>
         </g>
-        <g id="383" class="nad-vl120to180" title="L85-89-1">
+        <g id="501" class="nad-vl120to180" title="L85-89-1">
             <g>
                 <polyline points="-19.24,-11.39 -17.85,-12.81"/>
             </g>
@@ -1218,7 +1220,7 @@
                 <polyline points="-16.45,-14.23 -17.85,-12.81"/>
             </g>
         </g>
-        <g id="384" class="nad-vl120to180" title="L86-87-1">
+        <g id="502" class="nad-vl120to180" title="L86-87-1">
             <g>
                 <polyline points="-22.87,-10.65 -24.14,-10.13"/>
             </g>
@@ -1226,7 +1228,7 @@
                 <polyline points="-25.41,-9.61 -24.14,-10.13"/>
             </g>
         </g>
-        <g id="385" class="nad-vl120to180" title="L88-89-1">
+        <g id="503" class="nad-vl120to180" title="L88-89-1">
             <g>
                 <polyline points="-19.17,-14.14 -17.81,-14.19"/>
             </g>
@@ -1234,7 +1236,7 @@
                 <polyline points="-16.45,-14.23 -17.81,-14.19"/>
             </g>
         </g>
-        <g id="386" class="nad-vl120to180" title="L89-90-1">
+        <g id="504" class="nad-vl120to180" title="L89-90-1">
             <g>
                 <polyline points="-16.45,-14.23 -16.12,-14.96 -16.22,-15.92"/>
             </g>
@@ -1242,7 +1244,7 @@
                 <polyline points="-16.78,-17.52 -16.31,-16.87 -16.22,-15.92"/>
             </g>
         </g>
-        <g id="387" class="nad-vl120to180" title="L89-90-2">
+        <g id="505" class="nad-vl120to180" title="L89-90-2">
             <g>
                 <polyline points="-16.45,-14.23 -16.92,-14.88 -17.01,-15.83"/>
             </g>
@@ -1250,7 +1252,7 @@
                 <polyline points="-16.78,-17.52 -17.11,-16.79 -17.01,-15.83"/>
             </g>
         </g>
-        <g id="388" class="nad-vl120to180" title="L89-92-1">
+        <g id="506" class="nad-vl120to180" title="L89-92-1">
             <g>
                 <polyline points="-16.45,-14.23 -15.85,-14.77 -14.98,-17.41"/>
             </g>
@@ -1258,7 +1260,7 @@
                 <polyline points="-14.28,-20.83 -14.11,-20.05 -14.98,-17.41"/>
             </g>
         </g>
-        <g id="389" class="nad-vl120to180" title="L89-92-2">
+        <g id="507" class="nad-vl120to180" title="L89-92-2">
             <g>
                 <polyline points="-16.45,-14.23 -16.61,-15.02 -15.74,-17.66"/>
             </g>
@@ -1266,7 +1268,7 @@
                 <polyline points="-14.28,-20.83 -14.87,-20.30 -15.74,-17.66"/>
             </g>
         </g>
-        <g id="390" class="nad-vl120to180" title="L90-91-1">
+        <g id="508" class="nad-vl120to180" title="L90-91-1">
             <g>
                 <polyline points="-16.78,-17.52 -15.15,-17.36"/>
             </g>
@@ -1274,7 +1276,7 @@
                 <polyline points="-13.52,-17.20 -15.15,-17.36"/>
             </g>
         </g>
-        <g id="391" class="nad-vl120to180" title="L91-92-1">
+        <g id="509" class="nad-vl120to180" title="L91-92-1">
             <g>
                 <polyline points="-13.52,-17.20 -13.90,-19.01"/>
             </g>
@@ -1282,7 +1284,7 @@
                 <polyline points="-14.28,-20.83 -13.90,-19.01"/>
             </g>
         </g>
-        <g id="392" class="nad-vl120to180" title="L92-93-1">
+        <g id="510" class="nad-vl120to180" title="L92-93-1">
             <g>
                 <polyline points="-14.28,-20.83 -11.53,-19.14"/>
             </g>
@@ -1290,7 +1292,7 @@
                 <polyline points="-8.78,-17.46 -11.53,-19.14"/>
             </g>
         </g>
-        <g id="393" class="nad-vl120to180" title="L92-94-1">
+        <g id="511" class="nad-vl120to180" title="L92-94-1">
             <g>
                 <polyline points="-14.28,-20.83 -11.47,-16.43"/>
             </g>
@@ -1298,7 +1300,7 @@
                 <polyline points="-8.67,-12.03 -11.47,-16.43"/>
             </g>
         </g>
-        <g id="394" class="nad-vl120to180" title="L92-100-1">
+        <g id="512" class="nad-vl120to180" title="L92-100-1">
             <g>
                 <polyline points="-14.28,-20.83 -10.04,-19.66"/>
             </g>
@@ -1306,7 +1308,7 @@
                 <polyline points="-5.81,-18.48 -10.04,-19.66"/>
             </g>
         </g>
-        <g id="395" class="nad-vl120to180" title="L92-102-1">
+        <g id="513" class="nad-vl120to180" title="L92-102-1">
             <g>
                 <polyline points="-14.28,-20.83 -12.41,-19.94"/>
             </g>
@@ -1314,7 +1316,7 @@
                 <polyline points="-10.54,-19.05 -12.41,-19.94"/>
             </g>
         </g>
-        <g id="396" class="nad-vl120to180" title="L93-94-1">
+        <g id="514" class="nad-vl120to180" title="L93-94-1">
             <g>
                 <polyline points="-8.78,-17.46 -8.73,-14.74"/>
             </g>
@@ -1322,7 +1324,7 @@
                 <polyline points="-8.67,-12.03 -8.73,-14.74"/>
             </g>
         </g>
-        <g id="397" class="nad-vl120to180" title="L94-95-1">
+        <g id="515" class="nad-vl120to180" title="L94-95-1">
             <g>
                 <polyline points="-8.67,-12.03 -11.44,-13.73"/>
             </g>
@@ -1330,7 +1332,7 @@
                 <polyline points="-14.22,-15.43 -11.44,-13.73"/>
             </g>
         </g>
-        <g id="398" class="nad-vl120to180" title="L94-96-1">
+        <g id="516" class="nad-vl120to180" title="L94-96-1">
             <g>
                 <polyline points="-8.67,-12.03 -10.20,-12.40"/>
             </g>
@@ -1338,7 +1340,7 @@
                 <polyline points="-11.72,-12.77 -10.20,-12.40"/>
             </g>
         </g>
-        <g id="399" class="nad-vl120to180" title="L94-100-1">
+        <g id="517" class="nad-vl120to180" title="L94-100-1">
             <g>
                 <polyline points="-8.67,-12.03 -7.24,-15.25"/>
             </g>
@@ -1346,7 +1348,7 @@
                 <polyline points="-5.81,-18.48 -7.24,-15.25"/>
             </g>
         </g>
-        <g id="400" class="nad-vl120to180" title="L95-96-1">
+        <g id="518" class="nad-vl120to180" title="L95-96-1">
             <g>
                 <polyline points="-14.22,-15.43 -12.97,-14.10"/>
             </g>
@@ -1354,7 +1356,7 @@
                 <polyline points="-11.72,-12.77 -12.97,-14.10"/>
             </g>
         </g>
-        <g id="401" class="nad-vl120to180" title="L96-97-1">
+        <g id="519" class="nad-vl120to180" title="L96-97-1">
             <g>
                 <polyline points="-11.72,-12.77 -10.51,-11.71"/>
             </g>
@@ -1362,7 +1364,7 @@
                 <polyline points="-9.30,-10.66 -10.51,-11.71"/>
             </g>
         </g>
-        <g id="402" class="nad-vl120to180" title="L98-100-1">
+        <g id="520" class="nad-vl120to180" title="L98-100-1">
             <g>
                 <polyline points="-6.13,-12.88 -5.97,-15.68"/>
             </g>
@@ -1370,7 +1372,7 @@
                 <polyline points="-5.81,-18.48 -5.97,-15.68"/>
             </g>
         </g>
-        <g id="403" class="nad-vl120to180" title="L99-100-1">
+        <g id="521" class="nad-vl120to180" title="L99-100-1">
             <g>
                 <polyline points="-6.49,-14.34 -6.15,-16.41"/>
             </g>
@@ -1378,7 +1380,7 @@
                 <polyline points="-5.81,-18.48 -6.15,-16.41"/>
             </g>
         </g>
-        <g id="404" class="nad-vl120to180" title="L100-101-1">
+        <g id="522" class="nad-vl120to180" title="L100-101-1">
             <g>
                 <polyline points="-5.81,-18.48 -7.20,-19.41"/>
             </g>
@@ -1386,7 +1388,7 @@
                 <polyline points="-8.59,-20.33 -7.20,-19.41"/>
             </g>
         </g>
-        <g id="405" class="nad-vl120to180" title="L100-103-1">
+        <g id="523" class="nad-vl120to180" title="L100-103-1">
             <g>
                 <polyline points="-5.81,-18.48 -3.51,-19.00"/>
             </g>
@@ -1394,7 +1396,7 @@
                 <polyline points="-1.20,-19.52 -3.51,-19.00"/>
             </g>
         </g>
-        <g id="406" class="nad-vl120to180" title="L100-104-1">
+        <g id="524" class="nad-vl120to180" title="L100-104-1">
             <g>
                 <polyline points="-5.81,-18.48 -4.63,-18.74"/>
             </g>
@@ -1402,7 +1404,7 @@
                 <polyline points="-3.45,-19.00 -4.63,-18.74"/>
             </g>
         </g>
-        <g id="407" class="nad-vl120to180" title="L100-106-1">
+        <g id="525" class="nad-vl120to180" title="L100-106-1">
             <g>
                 <polyline points="-5.81,-18.48 -5.50,-19.93"/>
             </g>
@@ -1410,7 +1412,7 @@
                 <polyline points="-5.18,-21.38 -5.50,-19.93"/>
             </g>
         </g>
-        <g id="408" class="nad-vl120to180" title="L101-102-1">
+        <g id="526" class="nad-vl120to180" title="L101-102-1">
             <g>
                 <polyline points="-8.59,-20.33 -9.57,-19.69"/>
             </g>
@@ -1418,7 +1420,7 @@
                 <polyline points="-10.54,-19.05 -9.57,-19.69"/>
             </g>
         </g>
-        <g id="409" class="nad-vl120to180" title="L103-104-1">
+        <g id="527" class="nad-vl120to180" title="L103-104-1">
             <g>
                 <polyline points="-1.20,-19.52 -2.32,-19.26"/>
             </g>
@@ -1426,7 +1428,7 @@
                 <polyline points="-3.45,-19.00 -2.32,-19.26"/>
             </g>
         </g>
-        <g id="410" class="nad-vl120to180" title="L103-105-1">
+        <g id="528" class="nad-vl120to180" title="L103-105-1">
             <g>
                 <polyline points="-1.20,-19.52 -1.70,-20.88"/>
             </g>
@@ -1434,7 +1436,7 @@
                 <polyline points="-2.20,-22.23 -1.70,-20.88"/>
             </g>
         </g>
-        <g id="411" class="nad-vl120to180" title="L103-110-1">
+        <g id="529" class="nad-vl120to180" title="L103-110-1">
             <g>
                 <polyline points="-1.20,-19.52 1.09,-20.27"/>
             </g>
@@ -1442,7 +1444,7 @@
                 <polyline points="3.38,-21.02 1.09,-20.27"/>
             </g>
         </g>
-        <g id="412" class="nad-vl120to180" title="L104-105-1">
+        <g id="530" class="nad-vl120to180" title="L104-105-1">
             <g>
                 <polyline points="-3.45,-19.00 -2.83,-20.62"/>
             </g>
@@ -1450,7 +1452,7 @@
                 <polyline points="-2.20,-22.23 -2.83,-20.62"/>
             </g>
         </g>
-        <g id="413" class="nad-vl120to180" title="L105-106-1">
+        <g id="531" class="nad-vl120to180" title="L105-106-1">
             <g>
                 <polyline points="-2.20,-22.23 -3.69,-21.81"/>
             </g>
@@ -1458,7 +1460,7 @@
                 <polyline points="-5.18,-21.38 -3.69,-21.81"/>
             </g>
         </g>
-        <g id="414" class="nad-vl120to180" title="L105-107-1">
+        <g id="532" class="nad-vl120to180" title="L105-107-1">
             <g>
                 <polyline points="-2.20,-22.23 -3.13,-23.17"/>
             </g>
@@ -1466,7 +1468,7 @@
                 <polyline points="-4.06,-24.10 -3.13,-23.17"/>
             </g>
         </g>
-        <g id="415" class="nad-vl120to180" title="L105-108-1">
+        <g id="533" class="nad-vl120to180" title="L105-108-1">
             <g>
                 <polyline points="-2.20,-22.23 -1.02,-23.22"/>
             </g>
@@ -1474,7 +1476,7 @@
                 <polyline points="0.17,-24.21 -1.02,-23.22"/>
             </g>
         </g>
-        <g id="416" class="nad-vl120to180" title="L106-107-1">
+        <g id="534" class="nad-vl120to180" title="L106-107-1">
             <g>
                 <polyline points="-5.18,-21.38 -4.62,-22.74"/>
             </g>
@@ -1482,7 +1484,7 @@
                 <polyline points="-4.06,-24.10 -4.62,-22.74"/>
             </g>
         </g>
-        <g id="417" class="nad-vl120to180" title="L108-109-1">
+        <g id="535" class="nad-vl120to180" title="L108-109-1">
             <g>
                 <polyline points="0.17,-24.21 1.45,-24.01"/>
             </g>
@@ -1490,7 +1492,7 @@
                 <polyline points="2.74,-23.81 1.45,-24.01"/>
             </g>
         </g>
-        <g id="418" class="nad-vl120to180" title="L109-110-1">
+        <g id="536" class="nad-vl120to180" title="L109-110-1">
             <g>
                 <polyline points="2.74,-23.81 3.06,-22.42"/>
             </g>
@@ -1498,7 +1500,7 @@
                 <polyline points="3.38,-21.02 3.06,-22.42"/>
             </g>
         </g>
-        <g id="419" class="nad-vl120to180" title="L110-111-1">
+        <g id="537" class="nad-vl120to180" title="L110-111-1">
             <g>
                 <polyline points="3.38,-21.02 4.79,-21.67"/>
             </g>
@@ -1506,7 +1508,7 @@
                 <polyline points="6.20,-22.32 4.79,-21.67"/>
             </g>
         </g>
-        <g id="420" class="nad-vl120to180" title="L110-112-1">
+        <g id="538" class="nad-vl120to180" title="L110-112-1">
             <g>
                 <polyline points="3.38,-21.02 4.51,-20.09"/>
             </g>
@@ -1514,7 +1516,7 @@
                 <polyline points="5.64,-19.15 4.51,-20.09"/>
             </g>
         </g>
-        <g id="421" class="nad-vl120to180" title="L114-115-1">
+        <g id="539" class="nad-vl120to180" title="L114-115-1">
             <g>
                 <polyline points="13.77,-7.06 14.70,-7.82"/>
             </g>
@@ -1525,476 +1527,1188 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(27.03,10.72)">
-            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(26.15,8.45)">
-            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(23.87,10.22)">
-            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(22.56,13.16)">
-            <circle id="6" class="nad-vl120to180" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(20.26,10.90)">
-            <circle id="8" class="nad-vl120to180" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(20.96,6.22)">
-            <circle id="10" class="nad-vl120to180" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl120to180" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(22.79,4.92)">
-            <circle id="12" class="nad-vl120to180" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl120to180" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(15.05,11.34)">
-            <circle id="14" class="nad-vl120to180" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl120to180" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(15.12,15.94)">
-            <circle id="16" class="nad-vl120to180" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl120to180" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(15.46,18.97)">
-            <circle id="18" class="nad-vl120to180" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl120to180" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(19.91,12.54)">
-            <circle id="20" class="nad-vl120to180" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl120to180" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(22.90,8.56)">
-            <circle id="22" class="nad-vl120to180" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl120to180" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(17.46,12.32)">
-            <circle id="24" class="nad-vl120to180" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl120to180" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(17.73,8.79)">
-            <circle id="26" class="nad-vl120to180" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl120to180" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(13.64,9.63)">
-            <circle id="28" class="nad-vl120to180" title="VL15" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="43" class="nad-vl120to180" title="VL15" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(18.62,5.39)">
-            <circle id="30" class="nad-vl120to180" title="VL16" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="46" class="nad-vl120to180" title="VL16" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(14.65,4.68)">
-            <circle id="32" class="nad-vl120to180" title="VL17" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="49" class="nad-vl120to180" title="VL17" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(12.49,6.90)">
-            <circle id="34" class="nad-vl120to180" title="VL18" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="52" class="nad-vl120to180" title="VL18" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(9.62,9.30)">
-            <circle id="36" class="nad-vl120to180" title="VL19" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="55" class="nad-vl120to180" title="VL19" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(7.39,6.12)">
-            <circle id="38" class="nad-vl120to180" title="VL20" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="58" class="nad-vl120to180" title="VL20" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(7.02,2.80)">
-            <circle id="40" class="nad-vl120to180" title="VL21" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="61" class="nad-vl120to180" title="VL21" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.09,-0.32)">
-            <circle id="42" class="nad-vl120to180" title="VL22" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="64" class="nad-vl120to180" title="VL22" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(9.74,-3.02)">
-            <circle id="44" class="nad-vl120to180" title="VL23" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="67" class="nad-vl120to180" title="VL23" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.43,-3.64)">
-            <circle id="46" class="nad-vl120to180" title="VL24" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="70" class="nad-vl120to180" title="VL24" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(12.21,-2.05)">
-            <circle id="48" class="nad-vl120to180" title="VL25" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="73" class="nad-vl120to180" title="VL25" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(11.13,2.34)">
-            <circle id="50" class="nad-vl120to180" title="VL26" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="76" class="nad-vl120to180" title="VL26" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(15.67,-5.34)">
-            <circle id="52" class="nad-vl120to180" title="VL27" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="79" class="nad-vl120to180" title="VL27" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(18.87,-5.91)">
-            <circle id="54" class="nad-vl120to180" title="VL28" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="82" class="nad-vl120to180" title="VL28" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(19.41,-3.24)">
-            <circle id="56" class="nad-vl120to180" title="VL29" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="85" class="nad-vl120to180" title="VL29" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(10.89,7.10)">
-            <circle id="58" class="nad-vl120to180" title="VL30" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="88" class="nad-vl120to180" title="VL30" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(16.89,-0.57)">
-            <circle id="60" class="nad-vl120to180" title="VL31" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="91" class="nad-vl120to180" title="VL31" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(14.25,-3.21)">
-            <circle id="62" class="nad-vl120to180" title="VL32" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="94" class="nad-vl120to180" title="VL32" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(9.43,12.71)">
-            <circle id="64" class="nad-vl120to180" title="VL33" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="97" class="nad-vl120to180" title="VL33" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.37,12.65)">
-            <circle id="66" class="nad-vl120to180" title="VL34" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="100" class="nad-vl120to180" title="VL34" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.77,17.43)">
-            <circle id="68" class="nad-vl120to180" title="VL35" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="103" class="nad-vl120to180" title="VL35" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(7.48,15.88)">
-            <circle id="70" class="nad-vl120to180" title="VL36" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="106" class="nad-vl120to180" title="VL36" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.76,14.59)">
-            <circle id="72" class="nad-vl120to180" title="VL37" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="109" class="nad-vl120to180" title="VL37" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.22,10.46)">
-            <circle id="74" class="nad-vl120to180" title="VL38" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="112" class="nad-vl120to180" title="VL38" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.38,16.92)">
-            <circle id="76" class="nad-vl120to180" title="VL39" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="115" class="nad-vl120to180" title="VL39" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.12,15.27)">
-            <circle id="78" class="nad-vl120to180" title="VL40" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="118" class="nad-vl120to180" title="VL40" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.56,15.82)">
-            <circle id="80" class="nad-vl120to180" title="VL41" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="121" class="nad-vl120to180" title="VL41" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.05,13.53)">
-            <circle id="82" class="nad-vl120to180" title="VL42" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="124" class="nad-vl120to180" title="VL42" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.89,11.30)">
-            <circle id="84" class="nad-vl120to180" title="VL43" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="127" class="nad-vl120to180" title="VL43" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.88,7.40)">
-            <circle id="86" class="nad-vl120to180" title="VL44" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="130" class="nad-vl120to180" title="VL44" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.32,6.02)">
-            <circle id="88" class="nad-vl120to180" title="VL45" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="133" class="nad-vl120to180" title="VL45" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.37,7.34)">
-            <circle id="90" class="nad-vl120to180" title="VL46" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="136" class="nad-vl120to180" title="VL46" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.66,4.90)">
-            <circle id="92" class="nad-vl120to180" title="VL47" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="139" class="nad-vl120to180" title="VL47" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-11.75,13.24)">
-            <circle id="94" class="nad-vl120to180" title="VL48" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="142" class="nad-vl120to180" title="VL48" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.20,5.75)">
-            <circle id="96" class="nad-vl120to180" title="VL49" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="145" class="nad-vl120to180" title="VL49" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-11.45,-0.04)">
-            <circle id="98" class="nad-vl120to180" title="VL50" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="148" class="nad-vl120to180" title="VL50" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-13.42,6.08)">
-            <circle id="100" class="nad-vl120to180" title="VL51" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="151" class="nad-vl120to180" title="VL51" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-17.07,7.21)">
-            <circle id="102" class="nad-vl120to180" title="VL52" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="154" class="nad-vl120to180" title="VL52" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-16.25,9.46)">
-            <circle id="104" class="nad-vl120to180" title="VL53" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="157" class="nad-vl120to180" title="VL53" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.92,16.19)">
-            <circle id="106" class="nad-vl120to180" title="VL54" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="160" class="nad-vl120to180" title="VL54" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.98,16.47)">
-            <circle id="108" class="nad-vl120to180" title="VL55" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="163" class="nad-vl120to180" title="VL55" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.51,15.65)">
-            <circle id="110" class="nad-vl120to180" title="VL56" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="166" class="nad-vl120to180" title="VL56" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-14.14,5.51)">
-            <circle id="112" class="nad-vl120to180" title="VL57" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="169" class="nad-vl120to180" title="VL57" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-13.58,8.12)">
-            <circle id="114" class="nad-vl120to180" title="VL58" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="172" class="nad-vl120to180" title="VL58" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.53,14.64)">
-            <circle id="116" class="nad-vl120to180" title="VL59" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="175" class="nad-vl120to180" title="VL59" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-7.01,18.61)">
-            <circle id="118" class="nad-vl120to180" title="VL60" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="178" class="nad-vl120to180" title="VL60" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-14.43,13.95)">
-            <circle id="120" class="nad-vl120to180" title="VL61" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="181" class="nad-vl120to180" title="VL61" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-24.05,3.01)">
-            <circle id="122" class="nad-vl120to180" title="VL62" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="184" class="nad-vl120to180" title="VL62" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.93,22.99)">
-            <circle id="124" class="nad-vl120to180" title="VL63" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="187" class="nad-vl120to180" title="VL63" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.38,15.01)">
-            <circle id="126" class="nad-vl120to180" title="VL64" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="190" class="nad-vl120to180" title="VL64" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.73,9.08)">
-            <circle id="128" class="nad-vl120to180" title="VL65" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="193" class="nad-vl120to180" title="VL65" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-14.81,6.82)">
-            <circle id="130" class="nad-vl120to180" title="VL66" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="196" class="nad-vl120to180" title="VL66" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-18.92,8.69)">
-            <circle id="132" class="nad-vl120to180" title="VL67" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="199" class="nad-vl120to180" title="VL67" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.51,10.13)">
-            <circle id="134" class="nad-vl120to180" title="VL68" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="202" class="nad-vl120to180" title="VL68" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-12.14,-6.89)">
-            <circle id="136" class="nad-vl120to180" title="VL69" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="205" class="nad-vl120to180" title="VL69" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.13,-2.86)">
-            <circle id="138" class="nad-vl120to180" title="VL70" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="208" class="nad-vl120to180" title="VL70" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.87,-6.32)">
-            <circle id="140" class="nad-vl120to180" title="VL71" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="211" class="nad-vl120to180" title="VL71" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.34,-6.36)">
-            <circle id="142" class="nad-vl120to180" title="VL72" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="214" class="nad-vl120to180" title="VL72" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.59,-9.39)">
-            <circle id="144" class="nad-vl120to180" title="VL73" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="217" class="nad-vl120to180" title="VL73" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.85,-0.96)">
-            <circle id="146" class="nad-vl120to180" title="VL74" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="220" class="nad-vl120to180" title="VL74" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.92,-2.06)">
-            <circle id="148" class="nad-vl120to180" title="VL75" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="223" class="nad-vl120to180" title="VL75" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.13,-2.99)">
-            <circle id="150" class="nad-vl120to180" title="VL76" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="226" class="nad-vl120to180" title="VL76" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-7.34,-4.37)">
-            <circle id="152" class="nad-vl120to180" title="VL77" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="229" class="nad-vl120to180" title="VL77" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.09,-5.31)">
-            <circle id="154" class="nad-vl120to180" title="VL78" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="232" class="nad-vl120to180" title="VL78" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-11.22,-5.48)">
-            <circle id="156" class="nad-vl120to180" title="VL79" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="235" class="nad-vl120to180" title="VL79" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-7.95,-9.65)">
-            <circle id="158" class="nad-vl120to180" title="VL80" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="238" class="nad-vl120to180" title="VL80" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.79,-6.89)">
-            <circle id="160" class="nad-vl120to180" title="VL81" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="241" class="nad-vl120to180" title="VL81" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-12.54,-8.08)">
-            <circle id="162" class="nad-vl120to180" title="VL82" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="244" class="nad-vl120to180" title="VL82" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-16.93,-9.33)">
-            <circle id="164" class="nad-vl120to180" title="VL83" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="247" class="nad-vl120to180" title="VL83" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-19.82,-8.93)">
-            <circle id="166" class="nad-vl120to180" title="VL84" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="250" class="nad-vl120to180" title="VL84" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-19.24,-11.39)">
-            <circle id="168" class="nad-vl120to180" title="VL85" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="253" class="nad-vl120to180" title="VL85" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-22.87,-10.65)">
-            <circle id="170" class="nad-vl120to180" title="VL86" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="256" class="nad-vl120to180" title="VL86" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-25.41,-9.61)">
-            <circle id="172" class="nad-vl300to500" title="VL87" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="259" class="nad-vl300to500" title="VL87" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-19.17,-14.14)">
-            <circle id="174" class="nad-vl120to180" title="VL88" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="262" class="nad-vl120to180" title="VL88" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-16.45,-14.23)">
-            <circle id="176" class="nad-vl120to180" title="VL89" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="265" class="nad-vl120to180" title="VL89" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-16.78,-17.52)">
-            <circle id="178" class="nad-vl120to180" title="VL90" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="268" class="nad-vl120to180" title="VL90" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-13.52,-17.20)">
-            <circle id="180" class="nad-vl120to180" title="VL91" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="271" class="nad-vl120to180" title="VL91" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-14.28,-20.83)">
-            <circle id="182" class="nad-vl120to180" title="VL92" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="274" class="nad-vl120to180" title="VL92" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.78,-17.46)">
-            <circle id="184" class="nad-vl120to180" title="VL93" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="277" class="nad-vl120to180" title="VL93" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.67,-12.03)">
-            <circle id="186" class="nad-vl120to180" title="VL94" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="280" class="nad-vl120to180" title="VL94" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-14.22,-15.43)">
-            <circle id="188" class="nad-vl120to180" title="VL95" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="283" class="nad-vl120to180" title="VL95" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-11.72,-12.77)">
-            <circle id="190" class="nad-vl120to180" title="VL96" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="286" class="nad-vl120to180" title="VL96" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.30,-10.66)">
-            <circle id="192" class="nad-vl120to180" title="VL97" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="289" class="nad-vl120to180" title="VL97" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.13,-12.88)">
-            <circle id="194" class="nad-vl120to180" title="VL98" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="292" class="nad-vl120to180" title="VL98" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.49,-14.34)">
-            <circle id="196" class="nad-vl120to180" title="VL99" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="295" class="nad-vl120to180" title="VL99" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.81,-18.48)">
-            <circle id="198" class="nad-vl120to180" title="VL100" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="298" class="nad-vl120to180" title="VL100" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.59,-20.33)">
-            <circle id="200" class="nad-vl120to180" title="VL101" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="301" class="nad-vl120to180" title="VL101" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.54,-19.05)">
-            <circle id="202" class="nad-vl120to180" title="VL102" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="304" class="nad-vl120to180" title="VL102" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.20,-19.52)">
-            <circle id="204" class="nad-vl120to180" title="VL103" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="307" class="nad-vl120to180" title="VL103" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.45,-19.00)">
-            <circle id="206" class="nad-vl120to180" title="VL104" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="310" class="nad-vl120to180" title="VL104" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.20,-22.23)">
-            <circle id="208" class="nad-vl120to180" title="VL105" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="313" class="nad-vl120to180" title="VL105" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.18,-21.38)">
-            <circle id="210" class="nad-vl120to180" title="VL106" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="316" class="nad-vl120to180" title="VL106" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.06,-24.10)">
-            <circle id="212" class="nad-vl120to180" title="VL107" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="319" class="nad-vl120to180" title="VL107" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.17,-24.21)">
-            <circle id="214" class="nad-vl120to180" title="VL108" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="322" class="nad-vl120to180" title="VL108" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.74,-23.81)">
-            <circle id="216" class="nad-vl120to180" title="VL109" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="325" class="nad-vl120to180" title="VL109" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.38,-21.02)">
-            <circle id="218" class="nad-vl120to180" title="VL110" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="328" class="nad-vl120to180" title="VL110" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.20,-22.32)">
-            <circle id="220" class="nad-vl120to180" title="VL111" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="331" class="nad-vl120to180" title="VL111" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.64,-19.15)">
-            <circle id="222" class="nad-vl120to180" title="VL112" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="334" class="nad-vl120to180" title="VL112" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(14.70,0.80)">
-            <circle id="224" class="nad-vl120to180" title="VL113" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="337" class="nad-vl120to180" title="VL113" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(13.77,-7.06)">
-            <circle id="226" class="nad-vl120to180" title="VL114" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="340" class="nad-vl120to180" title="VL114" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(15.63,-8.59)">
-            <circle id="228" class="nad-vl120to180" title="VL115" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="343" class="nad-vl120to180" title="VL115" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.66,-0.16)">
-            <circle id="230" class="nad-vl120to180" title="VL116" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="346" class="nad-vl120to180" title="VL116" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(25.75,5.39)">
-            <circle id="232" class="nad-vl120to180" title="VL117" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="349" class="nad-vl120to180" title="VL117" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.25,-5.16)">
-            <circle id="234" class="nad-vl120to180" title="VL118" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="352" class="nad-vl120to180" title="VL118" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="27.63,10.72 28.03,10.72"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="26.75,8.45 27.15,8.45"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="24.47,10.22 24.87,10.22"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="23.16,13.16 23.56,13.16"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="20.86,10.90 21.26,10.90"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="21.56,6.22 21.96,6.22"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="23.39,4.92 23.79,4.92"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="15.65,11.34 16.05,11.34"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="15.72,15.94 16.12,15.94"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="16.06,18.97 16.46,18.97"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="20.51,12.54 20.91,12.54"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="23.50,8.56 23.90,8.56"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="18.06,12.32 18.46,12.32"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="18.33,8.79 18.73,8.79"/>
+            </g>
+        </g>
+        <g id="42_edge">
+            <g>
+                <polyline points="14.24,9.63 14.64,9.63"/>
+            </g>
+        </g>
+        <g id="45_edge">
+            <g>
+                <polyline points="19.22,5.39 19.62,5.39"/>
+            </g>
+        </g>
+        <g id="48_edge">
+            <g>
+                <polyline points="15.25,4.68 15.65,4.68"/>
+            </g>
+        </g>
+        <g id="51_edge">
+            <g>
+                <polyline points="13.09,6.90 13.49,6.90"/>
+            </g>
+        </g>
+        <g id="54_edge">
+            <g>
+                <polyline points="10.22,9.30 10.62,9.30"/>
+            </g>
+        </g>
+        <g id="57_edge">
+            <g>
+                <polyline points="7.99,6.12 8.39,6.12"/>
+            </g>
+        </g>
+        <g id="60_edge">
+            <g>
+                <polyline points="7.62,2.80 8.02,2.80"/>
+            </g>
+        </g>
+        <g id="63_edge">
+            <g>
+                <polyline points="8.69,-0.32 9.09,-0.32"/>
+            </g>
+        </g>
+        <g id="66_edge">
+            <g>
+                <polyline points="10.34,-3.02 10.74,-3.02"/>
+            </g>
+        </g>
+        <g id="69_edge">
+            <g>
+                <polyline points="6.03,-3.64 6.43,-3.64"/>
+            </g>
+        </g>
+        <g id="72_edge">
+            <g>
+                <polyline points="12.81,-2.05 13.21,-2.05"/>
+            </g>
+        </g>
+        <g id="75_edge">
+            <g>
+                <polyline points="11.73,2.34 12.13,2.34"/>
+            </g>
+        </g>
+        <g id="78_edge">
+            <g>
+                <polyline points="16.27,-5.34 16.67,-5.34"/>
+            </g>
+        </g>
+        <g id="81_edge">
+            <g>
+                <polyline points="19.47,-5.91 19.87,-5.91"/>
+            </g>
+        </g>
+        <g id="84_edge">
+            <g>
+                <polyline points="20.01,-3.24 20.41,-3.24"/>
+            </g>
+        </g>
+        <g id="87_edge">
+            <g>
+                <polyline points="11.49,7.10 11.89,7.10"/>
+            </g>
+        </g>
+        <g id="90_edge">
+            <g>
+                <polyline points="17.49,-0.57 17.89,-0.57"/>
+            </g>
+        </g>
+        <g id="93_edge">
+            <g>
+                <polyline points="14.85,-3.21 15.25,-3.21"/>
+            </g>
+        </g>
+        <g id="96_edge">
+            <g>
+                <polyline points="10.03,12.71 10.43,12.71"/>
+            </g>
+        </g>
+        <g id="99_edge">
+            <g>
+                <polyline points="6.97,12.65 7.37,12.65"/>
+            </g>
+        </g>
+        <g id="102_edge">
+            <g>
+                <polyline points="6.37,17.43 6.77,17.43"/>
+            </g>
+        </g>
+        <g id="105_edge">
+            <g>
+                <polyline points="8.08,15.88 8.48,15.88"/>
+            </g>
+        </g>
+        <g id="108_edge">
+            <g>
+                <polyline points="5.36,14.59 5.76,14.59"/>
+            </g>
+        </g>
+        <g id="111_edge">
+            <g>
+                <polyline points="5.82,10.46 6.22,10.46"/>
+            </g>
+        </g>
+        <g id="114_edge">
+            <g>
+                <polyline points="2.98,16.92 3.38,16.92"/>
+            </g>
+        </g>
+        <g id="117_edge">
+            <g>
+                <polyline points="0.72,15.27 1.12,15.27"/>
+            </g>
+        </g>
+        <g id="120_edge">
+            <g>
+                <polyline points="-1.96,15.82 -1.56,15.82"/>
+            </g>
+        </g>
+        <g id="123_edge">
+            <g>
+                <polyline points="-3.45,13.53 -3.05,13.53"/>
+            </g>
+        </g>
+        <g id="126_edge">
+            <g>
+                <polyline points="2.49,11.30 2.89,11.30"/>
+            </g>
+        </g>
+        <g id="129_edge">
+            <g>
+                <polyline points="-2.28,7.40 -1.88,7.40"/>
+            </g>
+        </g>
+        <g id="132_edge">
+            <g>
+                <polyline points="-5.72,6.02 -5.32,6.02"/>
+            </g>
+        </g>
+        <g id="135_edge">
+            <g>
+                <polyline points="-5.77,7.34 -5.37,7.34"/>
+            </g>
+        </g>
+        <g id="138_edge">
+            <g>
+                <polyline points="-4.06,4.90 -3.66,4.90"/>
+            </g>
+        </g>
+        <g id="141_edge">
+            <g>
+                <polyline points="-11.15,13.24 -10.75,13.24"/>
+            </g>
+        </g>
+        <g id="144_edge">
+            <g>
+                <polyline points="-7.60,5.75 -7.20,5.75"/>
+            </g>
+        </g>
+        <g id="147_edge">
+            <g>
+                <polyline points="-10.85,-0.04 -10.45,-0.04"/>
+            </g>
+        </g>
+        <g id="150_edge">
+            <g>
+                <polyline points="-12.82,6.08 -12.42,6.08"/>
+            </g>
+        </g>
+        <g id="153_edge">
+            <g>
+                <polyline points="-16.47,7.21 -16.07,7.21"/>
+            </g>
+        </g>
+        <g id="156_edge">
+            <g>
+                <polyline points="-15.65,9.46 -15.25,9.46"/>
+            </g>
+        </g>
+        <g id="159_edge">
+            <g>
+                <polyline points="-4.32,16.19 -3.92,16.19"/>
+            </g>
+        </g>
+        <g id="162_edge">
+            <g>
+                <polyline points="-6.38,16.47 -5.98,16.47"/>
+            </g>
+        </g>
+        <g id="165_edge">
+            <g>
+                <polyline points="-8.91,15.65 -8.51,15.65"/>
+            </g>
+        </g>
+        <g id="168_edge">
+            <g>
+                <polyline points="-13.54,5.51 -13.14,5.51"/>
+            </g>
+        </g>
+        <g id="171_edge">
+            <g>
+                <polyline points="-12.98,8.12 -12.58,8.12"/>
+            </g>
+        </g>
+        <g id="174_edge">
+            <g>
+                <polyline points="-9.93,14.64 -9.53,14.64"/>
+            </g>
+        </g>
+        <g id="177_edge">
+            <g>
+                <polyline points="-6.41,18.61 -6.01,18.61"/>
+            </g>
+        </g>
+        <g id="180_edge">
+            <g>
+                <polyline points="-13.83,13.95 -13.43,13.95"/>
+            </g>
+        </g>
+        <g id="183_edge">
+            <g>
+                <polyline points="-23.45,3.01 -23.05,3.01"/>
+            </g>
+        </g>
+        <g id="186_edge">
+            <g>
+                <polyline points="-3.33,22.99 -2.93,22.99"/>
+            </g>
+        </g>
+        <g id="189_edge">
+            <g>
+                <polyline points="-8.78,15.01 -8.38,15.01"/>
+            </g>
+        </g>
+        <g id="192_edge">
+            <g>
+                <polyline points="-4.13,9.08 -3.73,9.08"/>
+            </g>
+        </g>
+        <g id="195_edge">
+            <g>
+                <polyline points="-14.21,6.82 -13.81,6.82"/>
+            </g>
+        </g>
+        <g id="198_edge">
+            <g>
+                <polyline points="-18.32,8.69 -17.92,8.69"/>
+            </g>
+        </g>
+        <g id="201_edge">
+            <g>
+                <polyline points="2.11,10.13 2.51,10.13"/>
+            </g>
+        </g>
+        <g id="204_edge">
+            <g>
+                <polyline points="-11.54,-6.89 -11.14,-6.89"/>
+            </g>
+        </g>
+        <g id="207_edge">
+            <g>
+                <polyline points="0.73,-2.86 1.13,-2.86"/>
+            </g>
+        </g>
+        <g id="210_edge">
+            <g>
+                <polyline points="3.47,-6.32 3.87,-6.32"/>
+            </g>
+        </g>
+        <g id="213_edge">
+            <g>
+                <polyline points="5.94,-6.36 6.34,-6.36"/>
+            </g>
+        </g>
+        <g id="216_edge">
+            <g>
+                <polyline points="4.19,-9.39 4.59,-9.39"/>
+            </g>
+        </g>
+        <g id="219_edge">
+            <g>
+                <polyline points="-0.25,-0.96 0.15,-0.96"/>
+            </g>
+        </g>
+        <g id="222_edge">
+            <g>
+                <polyline points="-2.32,-2.06 -1.92,-2.06"/>
+            </g>
+        </g>
+        <g id="225_edge">
+            <g>
+                <polyline points="-3.53,-2.99 -3.13,-2.99"/>
+            </g>
+        </g>
+        <g id="228_edge">
+            <g>
+                <polyline points="-6.74,-4.37 -6.34,-4.37"/>
+            </g>
+        </g>
+        <g id="231_edge">
+            <g>
+                <polyline points="-9.49,-5.31 -9.09,-5.31"/>
+            </g>
+        </g>
+        <g id="234_edge">
+            <g>
+                <polyline points="-10.62,-5.48 -10.22,-5.48"/>
+            </g>
+        </g>
+        <g id="237_edge">
+            <g>
+                <polyline points="-7.35,-9.65 -6.95,-9.65"/>
+            </g>
+        </g>
+        <g id="240_edge">
+            <g>
+                <polyline points="-5.19,-6.89 -4.79,-6.89"/>
+            </g>
+        </g>
+        <g id="243_edge">
+            <g>
+                <polyline points="-11.94,-8.08 -11.54,-8.08"/>
+            </g>
+        </g>
+        <g id="246_edge">
+            <g>
+                <polyline points="-16.33,-9.33 -15.93,-9.33"/>
+            </g>
+        </g>
+        <g id="249_edge">
+            <g>
+                <polyline points="-19.22,-8.93 -18.82,-8.93"/>
+            </g>
+        </g>
+        <g id="252_edge">
+            <g>
+                <polyline points="-18.64,-11.39 -18.24,-11.39"/>
+            </g>
+        </g>
+        <g id="255_edge">
+            <g>
+                <polyline points="-22.27,-10.65 -21.87,-10.65"/>
+            </g>
+        </g>
+        <g id="258_edge">
+            <g>
+                <polyline points="-24.81,-9.61 -24.41,-9.61"/>
+            </g>
+        </g>
+        <g id="261_edge">
+            <g>
+                <polyline points="-18.57,-14.14 -18.17,-14.14"/>
+            </g>
+        </g>
+        <g id="264_edge">
+            <g>
+                <polyline points="-15.85,-14.23 -15.45,-14.23"/>
+            </g>
+        </g>
+        <g id="267_edge">
+            <g>
+                <polyline points="-16.18,-17.52 -15.78,-17.52"/>
+            </g>
+        </g>
+        <g id="270_edge">
+            <g>
+                <polyline points="-12.92,-17.20 -12.52,-17.20"/>
+            </g>
+        </g>
+        <g id="273_edge">
+            <g>
+                <polyline points="-13.68,-20.83 -13.28,-20.83"/>
+            </g>
+        </g>
+        <g id="276_edge">
+            <g>
+                <polyline points="-8.18,-17.46 -7.78,-17.46"/>
+            </g>
+        </g>
+        <g id="279_edge">
+            <g>
+                <polyline points="-8.07,-12.03 -7.67,-12.03"/>
+            </g>
+        </g>
+        <g id="282_edge">
+            <g>
+                <polyline points="-13.62,-15.43 -13.22,-15.43"/>
+            </g>
+        </g>
+        <g id="285_edge">
+            <g>
+                <polyline points="-11.12,-12.77 -10.72,-12.77"/>
+            </g>
+        </g>
+        <g id="288_edge">
+            <g>
+                <polyline points="-8.70,-10.66 -8.30,-10.66"/>
+            </g>
+        </g>
+        <g id="291_edge">
+            <g>
+                <polyline points="-5.53,-12.88 -5.13,-12.88"/>
+            </g>
+        </g>
+        <g id="294_edge">
+            <g>
+                <polyline points="-5.89,-14.34 -5.49,-14.34"/>
+            </g>
+        </g>
+        <g id="297_edge">
+            <g>
+                <polyline points="-5.21,-18.48 -4.81,-18.48"/>
+            </g>
+        </g>
+        <g id="300_edge">
+            <g>
+                <polyline points="-7.99,-20.33 -7.59,-20.33"/>
+            </g>
+        </g>
+        <g id="303_edge">
+            <g>
+                <polyline points="-9.94,-19.05 -9.54,-19.05"/>
+            </g>
+        </g>
+        <g id="306_edge">
+            <g>
+                <polyline points="-0.60,-19.52 -0.20,-19.52"/>
+            </g>
+        </g>
+        <g id="309_edge">
+            <g>
+                <polyline points="-2.85,-19.00 -2.45,-19.00"/>
+            </g>
+        </g>
+        <g id="312_edge">
+            <g>
+                <polyline points="-1.60,-22.23 -1.20,-22.23"/>
+            </g>
+        </g>
+        <g id="315_edge">
+            <g>
+                <polyline points="-4.58,-21.38 -4.18,-21.38"/>
+            </g>
+        </g>
+        <g id="318_edge">
+            <g>
+                <polyline points="-3.46,-24.10 -3.06,-24.10"/>
+            </g>
+        </g>
+        <g id="321_edge">
+            <g>
+                <polyline points="0.77,-24.21 1.17,-24.21"/>
+            </g>
+        </g>
+        <g id="324_edge">
+            <g>
+                <polyline points="3.34,-23.81 3.74,-23.81"/>
+            </g>
+        </g>
+        <g id="327_edge">
+            <g>
+                <polyline points="3.98,-21.02 4.38,-21.02"/>
+            </g>
+        </g>
+        <g id="330_edge">
+            <g>
+                <polyline points="6.80,-22.32 7.20,-22.32"/>
+            </g>
+        </g>
+        <g id="333_edge">
+            <g>
+                <polyline points="6.24,-19.15 6.64,-19.15"/>
+            </g>
+        </g>
+        <g id="336_edge">
+            <g>
+                <polyline points="15.30,0.80 15.70,0.80"/>
+            </g>
+        </g>
+        <g id="339_edge">
+            <g>
+                <polyline points="14.37,-7.06 14.77,-7.06"/>
+            </g>
+        </g>
+        <g id="342_edge">
+            <g>
+                <polyline points="16.23,-8.59 16.63,-8.59"/>
+            </g>
+        </g>
+        <g id="345_edge">
+            <g>
+                <polyline points="-9.06,-0.16 -8.66,-0.16"/>
+            </g>
+        </g>
+        <g id="348_edge">
+            <g>
+                <polyline points="26.35,5.39 26.75,5.39"/>
+            </g>
+        </g>
+        <g id="351_edge">
+            <g>
+                <polyline points="-1.65,-5.16 -1.25,-5.16"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(28.03,10.72)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(27.15,8.45)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(24.87,10.22)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(23.56,13.16)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(21.26,10.90)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(21.96,6.22)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(23.79,4.92)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(16.05,11.34)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(16.12,15.94)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(16.46,18.97)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(20.91,12.54)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(23.90,8.56)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(18.46,12.32)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(18.73,8.79)" style="dominant-baseline:middle">VL14</text>
+        <text transform="translate(14.64,9.63)" style="dominant-baseline:middle">VL15</text>
+        <text transform="translate(19.62,5.39)" style="dominant-baseline:middle">VL16</text>
+        <text transform="translate(15.65,4.68)" style="dominant-baseline:middle">VL17</text>
+        <text transform="translate(13.49,6.90)" style="dominant-baseline:middle">VL18</text>
+        <text transform="translate(10.62,9.30)" style="dominant-baseline:middle">VL19</text>
+        <text transform="translate(8.39,6.12)" style="dominant-baseline:middle">VL20</text>
+        <text transform="translate(8.02,2.80)" style="dominant-baseline:middle">VL21</text>
+        <text transform="translate(9.09,-0.32)" style="dominant-baseline:middle">VL22</text>
+        <text transform="translate(10.74,-3.02)" style="dominant-baseline:middle">VL23</text>
+        <text transform="translate(6.43,-3.64)" style="dominant-baseline:middle">VL24</text>
+        <text transform="translate(13.21,-2.05)" style="dominant-baseline:middle">VL25</text>
+        <text transform="translate(12.13,2.34)" style="dominant-baseline:middle">VL26</text>
+        <text transform="translate(16.67,-5.34)" style="dominant-baseline:middle">VL27</text>
+        <text transform="translate(19.87,-5.91)" style="dominant-baseline:middle">VL28</text>
+        <text transform="translate(20.41,-3.24)" style="dominant-baseline:middle">VL29</text>
+        <text transform="translate(11.89,7.10)" style="dominant-baseline:middle">VL30</text>
+        <text transform="translate(17.89,-0.57)" style="dominant-baseline:middle">VL31</text>
+        <text transform="translate(15.25,-3.21)" style="dominant-baseline:middle">VL32</text>
+        <text transform="translate(10.43,12.71)" style="dominant-baseline:middle">VL33</text>
+        <text transform="translate(7.37,12.65)" style="dominant-baseline:middle">VL34</text>
+        <text transform="translate(6.77,17.43)" style="dominant-baseline:middle">VL35</text>
+        <text transform="translate(8.48,15.88)" style="dominant-baseline:middle">VL36</text>
+        <text transform="translate(5.76,14.59)" style="dominant-baseline:middle">VL37</text>
+        <text transform="translate(6.22,10.46)" style="dominant-baseline:middle">VL38</text>
+        <text transform="translate(3.38,16.92)" style="dominant-baseline:middle">VL39</text>
+        <text transform="translate(1.12,15.27)" style="dominant-baseline:middle">VL40</text>
+        <text transform="translate(-1.56,15.82)" style="dominant-baseline:middle">VL41</text>
+        <text transform="translate(-3.05,13.53)" style="dominant-baseline:middle">VL42</text>
+        <text transform="translate(2.89,11.30)" style="dominant-baseline:middle">VL43</text>
+        <text transform="translate(-1.88,7.40)" style="dominant-baseline:middle">VL44</text>
+        <text transform="translate(-5.32,6.02)" style="dominant-baseline:middle">VL45</text>
+        <text transform="translate(-5.37,7.34)" style="dominant-baseline:middle">VL46</text>
+        <text transform="translate(-3.66,4.90)" style="dominant-baseline:middle">VL47</text>
+        <text transform="translate(-10.75,13.24)" style="dominant-baseline:middle">VL48</text>
+        <text transform="translate(-7.20,5.75)" style="dominant-baseline:middle">VL49</text>
+        <text transform="translate(-10.45,-0.04)" style="dominant-baseline:middle">VL50</text>
+        <text transform="translate(-12.42,6.08)" style="dominant-baseline:middle">VL51</text>
+        <text transform="translate(-16.07,7.21)" style="dominant-baseline:middle">VL52</text>
+        <text transform="translate(-15.25,9.46)" style="dominant-baseline:middle">VL53</text>
+        <text transform="translate(-3.92,16.19)" style="dominant-baseline:middle">VL54</text>
+        <text transform="translate(-5.98,16.47)" style="dominant-baseline:middle">VL55</text>
+        <text transform="translate(-8.51,15.65)" style="dominant-baseline:middle">VL56</text>
+        <text transform="translate(-13.14,5.51)" style="dominant-baseline:middle">VL57</text>
+        <text transform="translate(-12.58,8.12)" style="dominant-baseline:middle">VL58</text>
+        <text transform="translate(-9.53,14.64)" style="dominant-baseline:middle">VL59</text>
+        <text transform="translate(-6.01,18.61)" style="dominant-baseline:middle">VL60</text>
+        <text transform="translate(-13.43,13.95)" style="dominant-baseline:middle">VL61</text>
+        <text transform="translate(-23.05,3.01)" style="dominant-baseline:middle">VL62</text>
+        <text transform="translate(-2.93,22.99)" style="dominant-baseline:middle">VL63</text>
+        <text transform="translate(-8.38,15.01)" style="dominant-baseline:middle">VL64</text>
+        <text transform="translate(-3.73,9.08)" style="dominant-baseline:middle">VL65</text>
+        <text transform="translate(-13.81,6.82)" style="dominant-baseline:middle">VL66</text>
+        <text transform="translate(-17.92,8.69)" style="dominant-baseline:middle">VL67</text>
+        <text transform="translate(2.51,10.13)" style="dominant-baseline:middle">VL68</text>
+        <text transform="translate(-11.14,-6.89)" style="dominant-baseline:middle">VL69</text>
+        <text transform="translate(1.13,-2.86)" style="dominant-baseline:middle">VL70</text>
+        <text transform="translate(3.87,-6.32)" style="dominant-baseline:middle">VL71</text>
+        <text transform="translate(6.34,-6.36)" style="dominant-baseline:middle">VL72</text>
+        <text transform="translate(4.59,-9.39)" style="dominant-baseline:middle">VL73</text>
+        <text transform="translate(0.15,-0.96)" style="dominant-baseline:middle">VL74</text>
+        <text transform="translate(-1.92,-2.06)" style="dominant-baseline:middle">VL75</text>
+        <text transform="translate(-3.13,-2.99)" style="dominant-baseline:middle">VL76</text>
+        <text transform="translate(-6.34,-4.37)" style="dominant-baseline:middle">VL77</text>
+        <text transform="translate(-9.09,-5.31)" style="dominant-baseline:middle">VL78</text>
+        <text transform="translate(-10.22,-5.48)" style="dominant-baseline:middle">VL79</text>
+        <text transform="translate(-6.95,-9.65)" style="dominant-baseline:middle">VL80</text>
+        <text transform="translate(-4.79,-6.89)" style="dominant-baseline:middle">VL81</text>
+        <text transform="translate(-11.54,-8.08)" style="dominant-baseline:middle">VL82</text>
+        <text transform="translate(-15.93,-9.33)" style="dominant-baseline:middle">VL83</text>
+        <text transform="translate(-18.82,-8.93)" style="dominant-baseline:middle">VL84</text>
+        <text transform="translate(-18.24,-11.39)" style="dominant-baseline:middle">VL85</text>
+        <text transform="translate(-21.87,-10.65)" style="dominant-baseline:middle">VL86</text>
+        <text transform="translate(-24.41,-9.61)" style="dominant-baseline:middle">VL87</text>
+        <text transform="translate(-18.17,-14.14)" style="dominant-baseline:middle">VL88</text>
+        <text transform="translate(-15.45,-14.23)" style="dominant-baseline:middle">VL89</text>
+        <text transform="translate(-15.78,-17.52)" style="dominant-baseline:middle">VL90</text>
+        <text transform="translate(-12.52,-17.20)" style="dominant-baseline:middle">VL91</text>
+        <text transform="translate(-13.28,-20.83)" style="dominant-baseline:middle">VL92</text>
+        <text transform="translate(-7.78,-17.46)" style="dominant-baseline:middle">VL93</text>
+        <text transform="translate(-7.67,-12.03)" style="dominant-baseline:middle">VL94</text>
+        <text transform="translate(-13.22,-15.43)" style="dominant-baseline:middle">VL95</text>
+        <text transform="translate(-10.72,-12.77)" style="dominant-baseline:middle">VL96</text>
+        <text transform="translate(-8.30,-10.66)" style="dominant-baseline:middle">VL97</text>
+        <text transform="translate(-5.13,-12.88)" style="dominant-baseline:middle">VL98</text>
+        <text transform="translate(-5.49,-14.34)" style="dominant-baseline:middle">VL99</text>
+        <text transform="translate(-4.81,-18.48)" style="dominant-baseline:middle">VL100</text>
+        <text transform="translate(-7.59,-20.33)" style="dominant-baseline:middle">VL101</text>
+        <text transform="translate(-9.54,-19.05)" style="dominant-baseline:middle">VL102</text>
+        <text transform="translate(-0.20,-19.52)" style="dominant-baseline:middle">VL103</text>
+        <text transform="translate(-2.45,-19.00)" style="dominant-baseline:middle">VL104</text>
+        <text transform="translate(-1.20,-22.23)" style="dominant-baseline:middle">VL105</text>
+        <text transform="translate(-4.18,-21.38)" style="dominant-baseline:middle">VL106</text>
+        <text transform="translate(-3.06,-24.10)" style="dominant-baseline:middle">VL107</text>
+        <text transform="translate(1.17,-24.21)" style="dominant-baseline:middle">VL108</text>
+        <text transform="translate(3.74,-23.81)" style="dominant-baseline:middle">VL109</text>
+        <text transform="translate(4.38,-21.02)" style="dominant-baseline:middle">VL110</text>
+        <text transform="translate(7.20,-22.32)" style="dominant-baseline:middle">VL111</text>
+        <text transform="translate(6.64,-19.15)" style="dominant-baseline:middle">VL112</text>
+        <text transform="translate(15.70,0.80)" style="dominant-baseline:middle">VL113</text>
+        <text transform="translate(14.77,-7.06)" style="dominant-baseline:middle">VL114</text>
+        <text transform="translate(16.63,-8.59)" style="dominant-baseline:middle">VL115</text>
+        <text transform="translate(-8.66,-0.16)" style="dominant-baseline:middle">VL116</text>
+        <text transform="translate(26.75,5.39)" style="dominant-baseline:middle">VL117</text>
+        <text transform="translate(-1.25,-5.16)" style="dominant-baseline:middle">VL118</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -316,19 +316,19 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(4.84,-3.02)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(2.37,-3.57)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(0.46,-5.19)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(-0.12,-2.35)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(2.88,-0.91)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(2.76,3.74)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(-3.25,-1.90)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(-5.95,-2.90)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(-1.59,0.50)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(-2.34,3.67)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(-0.08,5.40)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(5.12,5.30)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(4.56,2.95)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(1.26,1.77)" style="dominant-baseline:middle">VL14</text>
+        <text x="4.84" y="-3.02" style="dominant-baseline:middle">VL1</text>
+        <text x="2.37" y="-3.57" style="dominant-baseline:middle">VL2</text>
+        <text x="0.46" y="-5.19" style="dominant-baseline:middle">VL3</text>
+        <text x="-0.12" y="-2.35" style="dominant-baseline:middle">VL4</text>
+        <text x="2.88" y="-0.91" style="dominant-baseline:middle">VL5</text>
+        <text x="2.76" y="3.74" style="dominant-baseline:middle">VL6</text>
+        <text x="-3.25" y="-1.90" style="dominant-baseline:middle">VL7</text>
+        <text x="-5.95" y="-2.90" style="dominant-baseline:middle">VL8</text>
+        <text x="-1.59" y="0.50" style="dominant-baseline:middle">VL9</text>
+        <text x="-2.34" y="3.67" style="dominant-baseline:middle">VL10</text>
+        <text x="-0.08" y="5.40" style="dominant-baseline:middle">VL11</text>
+        <text x="5.12" y="5.30" style="dominant-baseline:middle">VL12</text>
+        <text x="4.56" y="2.95" style="dominant-baseline:middle">VL13</text>
+        <text x="1.26" y="1.77" style="dominant-baseline:middle">VL14</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="774.21" viewBox="-8.95 -7.19 15.08 14.59" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="726.06" viewBox="-8.95 -7.19 16.08 14.59" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="28" class="nad-vl120to180" title="L1-2-1">
+    <g class="nad-branch-edges">
+        <g id="42" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.84,-3.02 2.61,-3.29"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="1.37,-3.57 2.61,-3.29"/>
             </g>
         </g>
-        <g id="29" class="nad-vl120to180" title="L1-5-1">
+        <g id="43" class="nad-vl120to180" title="L1-5-1">
             <g>
                 <polyline points="3.84,-3.02 2.86,-1.96"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="1.88,-0.91 2.86,-1.96"/>
             </g>
         </g>
-        <g id="30" class="nad-vl120to180" title="L2-3-1">
+        <g id="44" class="nad-vl120to180" title="L2-3-1">
             <g>
                 <polyline points="1.37,-3.57 0.42,-4.38"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="-0.54,-5.19 0.42,-4.38"/>
             </g>
         </g>
-        <g id="31" class="nad-vl120to180" title="L2-4-1">
+        <g id="45" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="1.37,-3.57 0.13,-2.96"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="-1.12,-2.35 0.13,-2.96"/>
             </g>
         </g>
-        <g id="32" class="nad-vl120to180" title="L2-5-1">
+        <g id="46" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="1.37,-3.57 1.63,-2.24"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="1.88,-0.91 1.63,-2.24"/>
             </g>
         </g>
-        <g id="33" class="nad-vl120to180" title="L3-4-1">
+        <g id="47" class="nad-vl120to180" title="L3-4-1">
             <g>
                 <polyline points="-0.54,-5.19 -0.83,-3.77"/>
             </g>
@@ -64,7 +66,7 @@
                 <polyline points="-1.12,-2.35 -0.83,-3.77"/>
             </g>
         </g>
-        <g id="34" class="nad-vl120to180" title="L4-5-1">
+        <g id="48" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="-1.12,-2.35 0.38,-1.63"/>
             </g>
@@ -72,7 +74,7 @@
                 <polyline points="1.88,-0.91 0.38,-1.63"/>
             </g>
         </g>
-        <g id="35" title="T4-7-1">
+        <g id="49" title="T4-7-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -2.69,-2.12"/>
                 <circle cx="-2.59" cy="-2.14" r="0.20"/>
@@ -82,7 +84,7 @@
                 <circle cx="-2.78" cy="-2.11" r="0.20"/>
             </g>
         </g>
-        <g id="36" title="T4-9-1">
+        <g id="50" title="T4-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -1.85,-0.92"/>
                 <circle cx="-1.81" cy="-1.01" r="0.20"/>
@@ -92,7 +94,7 @@
                 <circle cx="-1.90" cy="-0.83" r="0.20"/>
             </g>
         </g>
-        <g id="37" title="T5-6-1">
+        <g id="51" title="T5-6-1">
             <g class="nad-vl120to180">
                 <polyline points="1.88,-0.91 1.82,1.42"/>
                 <circle cx="1.82" cy="1.32" r="0.20"/>
@@ -102,7 +104,7 @@
                 <circle cx="1.82" cy="1.52" r="0.20"/>
             </g>
         </g>
-        <g id="38" class="nad-vl0to30" title="L6-11-1">
+        <g id="52" class="nad-vl0to30" title="L6-11-1">
             <g>
                 <polyline points="1.76,3.74 0.34,4.57"/>
             </g>
@@ -110,7 +112,7 @@
                 <polyline points="-1.08,5.40 0.34,4.57"/>
             </g>
         </g>
-        <g id="39" class="nad-vl0to30" title="L6-12-1">
+        <g id="53" class="nad-vl0to30" title="L6-12-1">
             <g>
                 <polyline points="1.76,3.74 2.94,4.52"/>
             </g>
@@ -118,7 +120,7 @@
                 <polyline points="4.12,5.30 2.94,4.52"/>
             </g>
         </g>
-        <g id="40" class="nad-vl0to30" title="L6-13-1">
+        <g id="54" class="nad-vl0to30" title="L6-13-1">
             <g>
                 <polyline points="1.76,3.74 2.66,3.35"/>
             </g>
@@ -126,7 +128,7 @@
                 <polyline points="3.56,2.95 2.66,3.35"/>
             </g>
         </g>
-        <g id="41" class="nad-vl0to30" title="L7-8-1">
+        <g id="55" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="-4.25,-1.90 -5.60,-2.40"/>
             </g>
@@ -134,7 +136,7 @@
                 <polyline points="-6.95,-2.90 -5.60,-2.40"/>
             </g>
         </g>
-        <g id="42" class="nad-vl0to30" title="L7-9-1">
+        <g id="56" class="nad-vl0to30" title="L7-9-1">
             <g>
                 <polyline points="-4.25,-1.90 -3.42,-0.70"/>
             </g>
@@ -142,7 +144,7 @@
                 <polyline points="-2.59,0.50 -3.42,-0.70"/>
             </g>
         </g>
-        <g id="43" class="nad-vl0to30" title="L9-10-1">
+        <g id="57" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-2.59,0.50 -2.97,2.08"/>
             </g>
@@ -150,7 +152,7 @@
                 <polyline points="-3.34,3.67 -2.97,2.08"/>
             </g>
         </g>
-        <g id="44" class="nad-vl0to30" title="L9-14-1">
+        <g id="58" class="nad-vl0to30" title="L9-14-1">
             <g>
                 <polyline points="-2.59,0.50 -1.17,1.14"/>
             </g>
@@ -158,7 +160,7 @@
                 <polyline points="0.26,1.77 -1.17,1.14"/>
             </g>
         </g>
-        <g id="45" class="nad-vl0to30" title="L10-11-1">
+        <g id="59" class="nad-vl0to30" title="L10-11-1">
             <g>
                 <polyline points="-3.34,3.67 -2.21,4.53"/>
             </g>
@@ -166,7 +168,7 @@
                 <polyline points="-1.08,5.40 -2.21,4.53"/>
             </g>
         </g>
-        <g id="46" class="nad-vl0to30" title="L12-13-1">
+        <g id="60" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="4.12,5.30 3.84,4.13"/>
             </g>
@@ -174,7 +176,7 @@
                 <polyline points="3.56,2.95 3.84,4.13"/>
             </g>
         </g>
-        <g id="47" class="nad-vl0to30" title="L13-14-1">
+        <g id="61" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="3.56,2.95 1.91,2.36"/>
             </g>
@@ -185,60 +187,148 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(3.84,-3.02)">
-            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.37,-3.57)">
-            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.54,-5.19)">
-            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.12,-2.35)">
-            <circle id="6" class="nad-vl120to180" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.88,-0.91)">
-            <circle id="8" class="nad-vl120to180" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.76,3.74)">
-            <circle id="10" class="nad-vl0to30" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl0to30" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.25,-1.90)">
-            <circle id="12" class="nad-vl0to30" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl0to30" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.95,-2.90)">
-            <circle id="14" class="nad-vl0to30" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl0to30" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.59,0.50)">
-            <circle id="16" class="nad-vl0to30" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.34,3.67)">
-            <circle id="18" class="nad-vl0to30" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl0to30" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.08,5.40)">
-            <circle id="20" class="nad-vl0to30" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.12,5.30)">
-            <circle id="22" class="nad-vl0to30" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl0to30" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.56,2.95)">
-            <circle id="24" class="nad-vl0to30" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.26,1.77)">
-            <circle id="26" class="nad-vl0to30" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl0to30" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="4.44,-3.02 4.84,-3.02"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="1.97,-3.57 2.37,-3.57"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="0.06,-5.19 0.46,-5.19"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="-0.52,-2.35 -0.12,-2.35"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="2.48,-0.91 2.88,-0.91"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="2.36,3.74 2.76,3.74"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="-3.65,-1.90 -3.25,-1.90"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="-6.35,-2.90 -5.95,-2.90"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="-1.99,0.50 -1.59,0.50"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="-2.74,3.67 -2.34,3.67"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="-0.48,5.40 -0.08,5.40"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="4.72,5.30 5.12,5.30"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="4.16,2.95 4.56,2.95"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="0.86,1.77 1.26,1.77"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(4.84,-3.02)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(2.37,-3.57)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(0.46,-5.19)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(-0.12,-2.35)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(2.88,-0.91)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(2.76,3.74)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(-3.25,-1.90)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(-5.95,-2.90)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(-1.59,0.50)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(-2.34,3.67)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(-0.08,5.40)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(5.12,5.30)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(4.56,2.95)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(1.26,1.77)" style="dominant-baseline:middle">VL14</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="774.21" viewBox="-8.95 -7.19 15.08 14.59" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="726.06" viewBox="-8.95 -7.19 16.08 14.59" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="28" class="nad-vl120to180" title="L1-2-1">
+    <g class="nad-branch-edges">
+        <g id="42" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.84,-3.02 2.61,-3.29"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="1.37,-3.57 2.61,-3.29"/>
             </g>
         </g>
-        <g id="29" class="nad-vl120to180" title="L1-5-1">
+        <g id="43" class="nad-vl120to180" title="L1-5-1">
             <g>
                 <polyline points="3.84,-3.02 2.86,-1.96"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="1.88,-0.91 2.86,-1.96"/>
             </g>
         </g>
-        <g id="30" class="nad-vl120to180" title="L2-3-1">
+        <g id="44" class="nad-vl120to180" title="L2-3-1">
             <g>
                 <polyline points="1.37,-3.57 0.42,-4.38"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="-0.54,-5.19 0.42,-4.38"/>
             </g>
         </g>
-        <g id="31" class="nad-vl120to180" title="L2-4-1">
+        <g id="45" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="1.37,-3.57 0.13,-2.96"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="-1.12,-2.35 0.13,-2.96"/>
             </g>
         </g>
-        <g id="32" class="nad-vl120to180" title="L2-5-1">
+        <g id="46" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="1.37,-3.57 1.63,-2.24"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="1.88,-0.91 1.63,-2.24"/>
             </g>
         </g>
-        <g id="33" class="nad-vl120to180" title="L3-4-1">
+        <g id="47" class="nad-vl120to180" title="L3-4-1">
             <g class="nad-disconnected">
                 <polyline points="-0.54,-5.19 -0.83,-3.77"/>
             </g>
@@ -64,7 +66,7 @@
                 <polyline points="-1.12,-2.35 -0.83,-3.77"/>
             </g>
         </g>
-        <g id="34" class="nad-vl120to180" title="L4-5-1">
+        <g id="48" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="-1.12,-2.35 0.38,-1.63"/>
             </g>
@@ -72,7 +74,7 @@
                 <polyline points="1.88,-0.91 0.38,-1.63"/>
             </g>
         </g>
-        <g id="35" title="T4-7-1">
+        <g id="49" title="T4-7-1">
             <g class="nad-disconnected nad-vl120to180">
                 <polyline points="-1.12,-2.35 -2.69,-2.12"/>
                 <circle cx="-2.59" cy="-2.14" r="0.20"/>
@@ -82,7 +84,7 @@
                 <circle cx="-2.78" cy="-2.11" r="0.20"/>
             </g>
         </g>
-        <g id="36" title="T4-9-1">
+        <g id="50" title="T4-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -1.85,-0.92"/>
                 <circle cx="-1.81" cy="-1.01" r="0.20"/>
@@ -92,7 +94,7 @@
                 <circle cx="-1.90" cy="-0.83" r="0.20"/>
             </g>
         </g>
-        <g id="37" title="T5-6-1">
+        <g id="51" title="T5-6-1">
             <g class="nad-vl120to180">
                 <polyline points="1.88,-0.91 1.82,1.42"/>
                 <circle cx="1.82" cy="1.32" r="0.20"/>
@@ -102,7 +104,7 @@
                 <circle cx="1.82" cy="1.52" r="0.20"/>
             </g>
         </g>
-        <g id="38" class="nad-vl0to30" title="L6-11-1">
+        <g id="52" class="nad-vl0to30" title="L6-11-1">
             <g>
                 <polyline points="1.76,3.74 0.34,4.57"/>
             </g>
@@ -110,7 +112,7 @@
                 <polyline points="-1.08,5.40 0.34,4.57"/>
             </g>
         </g>
-        <g id="39" class="nad-vl0to30" title="L6-12-1">
+        <g id="53" class="nad-vl0to30" title="L6-12-1">
             <g>
                 <polyline points="1.76,3.74 2.94,4.52"/>
             </g>
@@ -118,7 +120,7 @@
                 <polyline points="4.12,5.30 2.94,4.52"/>
             </g>
         </g>
-        <g id="40" class="nad-vl0to30" title="L6-13-1">
+        <g id="54" class="nad-vl0to30" title="L6-13-1">
             <g>
                 <polyline points="1.76,3.74 2.66,3.35"/>
             </g>
@@ -126,7 +128,7 @@
                 <polyline points="3.56,2.95 2.66,3.35"/>
             </g>
         </g>
-        <g id="41" class="nad-vl0to30" title="L7-8-1">
+        <g id="55" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="-4.25,-1.90 -5.60,-2.40"/>
             </g>
@@ -134,7 +136,7 @@
                 <polyline points="-6.95,-2.90 -5.60,-2.40"/>
             </g>
         </g>
-        <g id="42" class="nad-vl0to30" title="L7-9-1">
+        <g id="56" class="nad-vl0to30" title="L7-9-1">
             <g>
                 <polyline points="-4.25,-1.90 -3.42,-0.70"/>
             </g>
@@ -142,7 +144,7 @@
                 <polyline points="-2.59,0.50 -3.42,-0.70"/>
             </g>
         </g>
-        <g id="43" class="nad-vl0to30" title="L9-10-1">
+        <g id="57" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-2.59,0.50 -2.97,2.08"/>
             </g>
@@ -150,7 +152,7 @@
                 <polyline points="-3.34,3.67 -2.97,2.08"/>
             </g>
         </g>
-        <g id="44" class="nad-vl0to30" title="L9-14-1">
+        <g id="58" class="nad-vl0to30" title="L9-14-1">
             <g>
                 <polyline points="-2.59,0.50 -1.17,1.14"/>
             </g>
@@ -158,7 +160,7 @@
                 <polyline points="0.26,1.77 -1.17,1.14"/>
             </g>
         </g>
-        <g id="45" class="nad-vl0to30" title="L10-11-1">
+        <g id="59" class="nad-vl0to30" title="L10-11-1">
             <g>
                 <polyline points="-3.34,3.67 -2.21,4.53"/>
             </g>
@@ -166,7 +168,7 @@
                 <polyline points="-1.08,5.40 -2.21,4.53"/>
             </g>
         </g>
-        <g id="46" class="nad-vl0to30" title="L12-13-1">
+        <g id="60" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="4.12,5.30 3.84,4.13"/>
             </g>
@@ -174,7 +176,7 @@
                 <polyline points="3.56,2.95 3.84,4.13"/>
             </g>
         </g>
-        <g id="47" class="nad-vl0to30" title="L13-14-1">
+        <g id="61" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="3.56,2.95 1.91,2.36"/>
             </g>
@@ -185,60 +187,148 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(3.84,-3.02)">
-            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.37,-3.57)">
-            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.54,-5.19)">
-            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.12,-2.35)">
-            <circle id="6" class="nad-vl120to180" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.88,-0.91)">
-            <circle id="8" class="nad-vl120to180" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.76,3.74)">
-            <circle id="10" class="nad-vl0to30" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl0to30" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.25,-1.90)">
-            <circle id="12" class="nad-vl0to30" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl0to30" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.95,-2.90)">
-            <circle id="14" class="nad-vl0to30" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl0to30" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.59,0.50)">
-            <circle id="16" class="nad-vl0to30" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.34,3.67)">
-            <circle id="18" class="nad-vl0to30" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl0to30" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.08,5.40)">
-            <circle id="20" class="nad-vl0to30" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.12,5.30)">
-            <circle id="22" class="nad-vl0to30" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl0to30" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.56,2.95)">
-            <circle id="24" class="nad-vl0to30" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.26,1.77)">
-            <circle id="26" class="nad-vl0to30" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl0to30" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="4.44,-3.02 4.84,-3.02"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="1.97,-3.57 2.37,-3.57"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="0.06,-5.19 0.46,-5.19"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="-0.52,-2.35 -0.12,-2.35"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="2.48,-0.91 2.88,-0.91"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="2.36,3.74 2.76,3.74"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="-3.65,-1.90 -3.25,-1.90"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="-6.35,-2.90 -5.95,-2.90"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="-1.99,0.50 -1.59,0.50"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="-2.74,3.67 -2.34,3.67"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="-0.48,5.40 -0.08,5.40"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="4.72,5.30 5.12,5.30"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="4.16,2.95 4.56,2.95"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="0.86,1.77 1.26,1.77"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(4.84,-3.02)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(2.37,-3.57)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(0.46,-5.19)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(-0.12,-2.35)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(2.88,-0.91)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(2.76,3.74)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(-3.25,-1.90)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(-5.95,-2.90)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(-1.59,0.50)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(-2.34,3.67)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(-0.08,5.40)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(5.12,5.30)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(4.56,2.95)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(1.26,1.77)" style="dominant-baseline:middle">VL14</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -316,19 +316,19 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(4.84,-3.02)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(2.37,-3.57)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(0.46,-5.19)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(-0.12,-2.35)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(2.88,-0.91)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(2.76,3.74)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(-3.25,-1.90)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(-5.95,-2.90)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(-1.59,0.50)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(-2.34,3.67)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(-0.08,5.40)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(5.12,5.30)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(4.56,2.95)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(1.26,1.77)" style="dominant-baseline:middle">VL14</text>
+        <text x="4.84" y="-3.02" style="dominant-baseline:middle">VL1</text>
+        <text x="2.37" y="-3.57" style="dominant-baseline:middle">VL2</text>
+        <text x="0.46" y="-5.19" style="dominant-baseline:middle">VL3</text>
+        <text x="-0.12" y="-2.35" style="dominant-baseline:middle">VL4</text>
+        <text x="2.88" y="-0.91" style="dominant-baseline:middle">VL5</text>
+        <text x="2.76" y="3.74" style="dominant-baseline:middle">VL6</text>
+        <text x="-3.25" y="-1.90" style="dominant-baseline:middle">VL7</text>
+        <text x="-5.95" y="-2.90" style="dominant-baseline:middle">VL8</text>
+        <text x="-1.59" y="0.50" style="dominant-baseline:middle">VL9</text>
+        <text x="-2.34" y="3.67" style="dominant-baseline:middle">VL10</text>
+        <text x="-0.08" y="5.40" style="dominant-baseline:middle">VL11</text>
+        <text x="5.12" y="5.30" style="dominant-baseline:middle">VL12</text>
+        <text x="4.56" y="2.95" style="dominant-baseline:middle">VL13</text>
+        <text x="1.26" y="1.77" style="dominant-baseline:middle">VL14</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -1,0 +1,334 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="819.37" viewBox="-8.96 -10.80 22.70 23.25" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
+.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+]]></style>
+    <metadata></metadata>
+    <g class="nad-branch-edges">
+        <g id="42" class="nad-vl120to180" title="L1-2-1">
+            <g>
+                <polyline points="-4.23,-6.18 -2.91,-5.73"/>
+            </g>
+            <g>
+                <polyline points="-1.59,-5.28 -2.91,-5.73"/>
+            </g>
+        </g>
+        <g id="43" class="nad-vl120to180" title="L1-5-1">
+            <g>
+                <polyline points="-4.23,-6.18 -3.56,-3.98"/>
+            </g>
+            <g>
+                <polyline points="-2.89,-1.79 -3.56,-3.98"/>
+            </g>
+        </g>
+        <g id="44" class="nad-vl120to180" title="L2-3-1">
+            <g>
+                <polyline points="-1.59,-5.28 -2.42,-4.66"/>
+            </g>
+            <g>
+                <polyline points="-3.24,-4.04 -2.42,-4.66"/>
+            </g>
+        </g>
+        <g id="45" class="nad-vl120to180" title="L2-4-1">
+            <g>
+                <polyline points="-1.59,-5.28 -0.39,-4.18"/>
+            </g>
+            <g>
+                <polyline points="0.80,-3.09 -0.39,-4.18"/>
+            </g>
+        </g>
+        <g id="46" class="nad-vl120to180" title="L2-5-1">
+            <g>
+                <polyline points="-1.59,-5.28 -2.24,-3.53"/>
+            </g>
+            <g>
+                <polyline points="-2.89,-1.79 -2.24,-3.53"/>
+            </g>
+        </g>
+        <g id="47" class="nad-vl120to180" title="L3-4-1">
+            <g>
+                <polyline points="-3.24,-4.04 -1.22,-3.56"/>
+            </g>
+            <g>
+                <polyline points="0.80,-3.09 -1.22,-3.56"/>
+            </g>
+        </g>
+        <g id="48" class="nad-vl120to180" title="L4-5-1">
+            <g>
+                <polyline points="0.80,-3.09 -1.05,-2.44"/>
+            </g>
+            <g>
+                <polyline points="-2.89,-1.79 -1.05,-2.44"/>
+            </g>
+        </g>
+        <g id="49" title="T4-7-1">
+            <g class="nad-vl120to180">
+                <polyline points="0.80,-3.09 3.00,-3.00"/>
+                <circle cx="2.90" cy="-3.00" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="5.21,-2.91 3.00,-3.00"/>
+                <circle cx="3.10" cy="-2.99" r="0.20"/>
+            </g>
+        </g>
+        <g id="50" title="T4-9-1">
+            <g class="nad-vl120to180">
+                <polyline points="0.80,-3.09 2.32,-1.29"/>
+                <circle cx="2.26" cy="-1.37" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="3.84,0.51 2.32,-1.29"/>
+                <circle cx="2.38" cy="-1.22" r="0.20"/>
+            </g>
+        </g>
+        <g id="51" title="T5-6-1">
+            <g class="nad-vl120to180">
+                <polyline points="-2.89,-1.79 -3.08,1.13"/>
+                <circle cx="-3.07" cy="1.03" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-3.27,4.05 -3.08,1.13"/>
+                <circle cx="-3.09" cy="1.23" r="0.20"/>
+            </g>
+        </g>
+        <g id="52" class="nad-vl0to30" title="L6-11-1">
+            <g>
+                <polyline points="-3.27,4.05 -1.59,4.61"/>
+            </g>
+            <g>
+                <polyline points="0.09,5.16 -1.59,4.61"/>
+            </g>
+        </g>
+        <g id="53" class="nad-vl0to30" title="L6-12-1">
+            <g>
+                <polyline points="-3.27,4.05 -3.91,5.63"/>
+            </g>
+            <g>
+                <polyline points="-4.56,7.21 -3.91,5.63"/>
+            </g>
+        </g>
+        <g id="54" class="nad-vl0to30" title="L6-13-1">
+            <g>
+                <polyline points="-3.27,4.05 -2.40,5.61"/>
+            </g>
+            <g>
+                <polyline points="-1.53,7.18 -2.40,5.61"/>
+            </g>
+        </g>
+        <g id="55" class="nad-vl0to30" title="L7-8-1">
+            <g>
+                <polyline points="5.21,-2.91 7.09,-3.09"/>
+            </g>
+            <g>
+                <polyline points="8.98,-3.27 7.09,-3.09"/>
+            </g>
+        </g>
+        <g id="56" class="nad-vl0to30" title="L7-9-1">
+            <g>
+                <polyline points="5.21,-2.91 4.52,-1.20"/>
+            </g>
+            <g>
+                <polyline points="3.84,0.51 4.52,-1.20"/>
+            </g>
+        </g>
+        <g id="57" class="nad-vl0to30" title="L9-10-1">
+            <g>
+                <polyline points="3.84,0.51 2.87,1.56"/>
+            </g>
+            <g>
+                <polyline points="1.89,2.61 2.87,1.56"/>
+            </g>
+        </g>
+        <g id="58" class="nad-vl0to30" title="L9-14-1">
+            <g>
+                <polyline points="3.84,0.51 3.56,2.87"/>
+            </g>
+            <g>
+                <polyline points="3.29,5.23 3.56,2.87"/>
+            </g>
+        </g>
+        <g id="59" class="nad-vl0to30" title="L10-11-1">
+            <g>
+                <polyline points="1.89,2.61 0.99,3.89"/>
+            </g>
+            <g>
+                <polyline points="0.09,5.16 0.99,3.89"/>
+            </g>
+        </g>
+        <g id="60" class="nad-vl0to30" title="L12-13-1">
+            <g>
+                <polyline points="-4.56,7.21 -3.05,7.19"/>
+            </g>
+            <g>
+                <polyline points="-1.53,7.18 -3.05,7.19"/>
+            </g>
+        </g>
+        <g id="61" class="nad-vl0to30" title="L13-14-1">
+            <g>
+                <polyline points="-1.53,7.18 0.88,6.20"/>
+            </g>
+            <g>
+                <polyline points="3.29,5.23 0.88,6.20"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-4.23,-6.18)">
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-1.59,-5.28)">
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-3.24,-4.04)">
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(0.80,-3.09)">
+            <circle id="10" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-2.89,-1.79)">
+            <circle id="13" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-3.27,4.05)">
+            <circle id="16" class="nad-vl0to30" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(5.21,-2.91)">
+            <circle id="19" class="nad-vl0to30" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(8.98,-3.27)">
+            <circle id="22" class="nad-vl0to30" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(3.84,0.51)">
+            <circle id="25" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(1.89,2.61)">
+            <circle id="28" class="nad-vl0to30" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(0.09,5.16)">
+            <circle id="31" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-4.56,7.21)">
+            <circle id="34" class="nad-vl0to30" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(-1.53,7.18)">
+            <circle id="37" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+        <g transform="translate(3.29,5.23)">
+            <circle id="40" class="nad-vl0to30" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="-4.57,-6.67 -6.07,-8.80"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="-1.48,-5.87 -0.97,-8.60"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="-3.84,-4.10 -6.82,-4.44"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="1.09,-3.61 2.28,-5.75"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="-3.46,-1.60 -5.88,-0.82"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="-3.87,4.03 -6.42,3.94"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="5.47,-3.45 6.54,-5.67"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="9.57,-3.37 11.75,-3.75"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="4.41,0.68 6.83,1.41"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="1.40,2.27 0.01,1.29"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="0.36,5.70 1.63,8.25"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="-5.03,7.58 -6.96,9.09"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="-1.57,7.77 -1.76,10.46"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="3.78,5.57 5.94,7.05"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(-6.07,-8.80)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(-0.97,-8.60)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(-6.82,-4.44)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(2.28,-5.75)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(-5.88,-0.82)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(-6.42,3.94)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(6.54,-5.67)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(11.75,-3.75)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(6.83,1.41)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(0.01,1.29)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(1.63,8.25)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(-6.96,9.09)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(-1.76,10.46)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(5.94,7.05)" style="dominant-baseline:middle">VL14</text>
+    </g>
+</svg>

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -316,19 +316,19 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(-6.07,-8.80)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(-0.97,-8.60)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(-6.82,-4.44)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(2.28,-5.75)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(-5.88,-0.82)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(-6.42,3.94)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(6.54,-5.67)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(11.75,-3.75)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(6.83,1.41)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(0.01,1.29)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(1.63,8.25)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(-6.96,9.09)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(-1.76,10.46)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(5.94,7.05)" style="dominant-baseline:middle">VL14</text>
+        <text x="-6.07" y="-8.80" style="dominant-baseline:middle">VL1</text>
+        <text x="-0.97" y="-8.60" style="dominant-baseline:middle">VL2</text>
+        <text x="-6.82" y="-4.44" style="dominant-baseline:middle">VL3</text>
+        <text x="2.28" y="-5.75" style="dominant-baseline:middle">VL4</text>
+        <text x="-5.88" y="-0.82" style="dominant-baseline:middle">VL5</text>
+        <text x="-6.42" y="3.94" style="dominant-baseline:middle">VL6</text>
+        <text x="6.54" y="-5.67" style="dominant-baseline:middle">VL7</text>
+        <text x="11.75" y="-3.75" style="dominant-baseline:middle">VL8</text>
+        <text x="6.83" y="1.41" style="dominant-baseline:middle">VL9</text>
+        <text x="0.01" y="1.29" style="dominant-baseline:middle">VL10</text>
+        <text x="1.63" y="8.25" style="dominant-baseline:middle">VL11</text>
+        <text x="-6.96" y="9.09" style="dominant-baseline:middle">VL12</text>
+        <text x="-1.76" y="10.46" style="dominant-baseline:middle">VL13</text>
+        <text x="5.94" y="7.05" style="dominant-baseline:middle">VL14</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="852.54" viewBox="-9.85 -10.79 20.23 21.56" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="812.38" viewBox="-9.85 -10.79 21.23 21.56" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="48" class="nad-vl120to180" title="L-1-2-1 ">
+    <g class="nad-branch-edges">
+        <g id="72" class="nad-vl120to180" title="L-1-2-1 ">
             <g>
                 <polyline points="-2.56,6.78 -1.68,7.75"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="-0.81,8.72 -1.68,7.75"/>
             </g>
         </g>
-        <g id="49" class="nad-vl120to180" title="L-3-1-1 ">
+        <g id="73" class="nad-vl120to180" title="L-3-1-1 ">
             <g>
                 <polyline points="-2.74,3.22 -2.65,5.00"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="-2.56,6.78 -2.65,5.00"/>
             </g>
         </g>
-        <g id="50" class="nad-vl120to180" title="L-1-5-1 ">
+        <g id="74" class="nad-vl120to180" title="L-1-5-1 ">
             <g>
                 <polyline points="-2.56,6.78 -0.83,6.84"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="0.89,6.90 -0.83,6.84"/>
             </g>
         </g>
-        <g id="51" class="nad-vl120to180" title="L-2-4-1 ">
+        <g id="75" class="nad-vl120to180" title="L-2-4-1 ">
             <g>
                 <polyline points="-0.81,8.72 -0.72,7.10"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="-0.63,5.48 -0.72,7.10"/>
             </g>
         </g>
-        <g id="52" class="nad-vl120to180" title="L-2-6-1 ">
+        <g id="76" class="nad-vl120to180" title="L-2-6-1 ">
             <g>
                 <polyline points="-0.81,8.72 0.81,8.74"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="2.43,8.76 0.81,8.74"/>
             </g>
         </g>
-        <g id="53" title="T-24-3-1 ">
+        <g id="77" title="T-24-3-1 ">
             <g class="nad-vl180to300">
                 <polyline points="-4.85,0.21 -3.80,1.72"/>
                 <circle cx="-3.85" cy="1.64" r="0.20"/>
@@ -66,7 +68,7 @@
                 <circle cx="-3.74" cy="1.80" r="0.20"/>
             </g>
         </g>
-        <g id="54" class="nad-vl120to180" title="L-3-9-1 ">
+        <g id="78" class="nad-vl120to180" title="L-3-9-1 ">
             <g>
                 <polyline points="-2.74,3.22 -0.61,3.25"/>
             </g>
@@ -74,7 +76,7 @@
                 <polyline points="1.52,3.27 -0.61,3.25"/>
             </g>
         </g>
-        <g id="55" class="nad-vl180to300" title="L-15-24-1 ">
+        <g id="79" class="nad-vl180to300" title="L-15-24-1 ">
             <g>
                 <polyline points="-4.99,-3.40 -4.92,-1.59"/>
             </g>
@@ -82,7 +84,7 @@
                 <polyline points="-4.85,0.21 -4.92,-1.59"/>
             </g>
         </g>
-        <g id="56" class="nad-vl120to180" title="L-4-9-1 ">
+        <g id="80" class="nad-vl120to180" title="L-4-9-1 ">
             <g>
                 <polyline points="-0.63,5.48 0.45,4.38"/>
             </g>
@@ -90,7 +92,7 @@
                 <polyline points="1.52,3.27 0.45,4.38"/>
             </g>
         </g>
-        <g id="57" title="T-5-10-1 ">
+        <g id="81" title="T-5-10-1 ">
             <g class="nad-vl120to180">
                 <polyline points="0.89,6.90 2.08,5.90"/>
                 <circle cx="2.00" cy="5.97" r="0.20"/>
@@ -100,7 +102,7 @@
                 <circle cx="2.16" cy="5.84" r="0.20"/>
             </g>
         </g>
-        <g id="58" title="T-11-9-1 ">
+        <g id="82" title="T-11-9-1 ">
             <g class="nad-vl180to300">
                 <polyline points="1.98,0.84 1.75,2.06"/>
                 <circle cx="1.77" cy="1.96" r="0.20"/>
@@ -110,7 +112,7 @@
                 <circle cx="1.73" cy="2.16" r="0.20"/>
             </g>
         </g>
-        <g id="59" title="T-9-12-1 ">
+        <g id="83" title="T-9-12-1 ">
             <g class="nad-vl120to180">
                 <polyline points="1.52,3.27 3.07,2.47"/>
                 <circle cx="2.98" cy="2.51" r="0.20"/>
@@ -120,7 +122,7 @@
                 <circle cx="3.16" cy="2.42" r="0.20"/>
             </g>
         </g>
-        <g id="60" class="nad-vl180to300" title="L-8-9-1 ">
+        <g id="84" class="nad-vl180to300" title="L-8-9-1 ">
             <g>
                 <polyline points="5.53,5.20 3.53,4.24"/>
             </g>
@@ -128,7 +130,7 @@
                 <polyline points="1.52,3.27 3.53,4.24"/>
             </g>
         </g>
-        <g id="61" title="T-11-10-1 ">
+        <g id="85" title="T-11-10-1 ">
             <g class="nad-vl180to300">
                 <polyline points="1.98,0.84 2.62,2.87"/>
                 <circle cx="2.59" cy="2.78" r="0.20"/>
@@ -138,7 +140,7 @@
                 <circle cx="2.65" cy="2.97" r="0.20"/>
             </g>
         </g>
-        <g id="62" title="T-12-10-1 ">
+        <g id="86" title="T-12-10-1 ">
             <g class="nad-vl180to300">
                 <polyline points="4.61,1.66 3.94,3.28"/>
                 <circle cx="3.98" cy="3.19" r="0.20"/>
@@ -148,7 +150,7 @@
                 <circle cx="3.90" cy="3.38" r="0.20"/>
             </g>
         </g>
-        <g id="63" class="nad-vl120to180" title="L-10-6-1 ">
+        <g id="87" class="nad-vl120to180" title="L-10-6-1 ">
             <g>
                 <polyline points="3.27,4.91 2.85,6.83"/>
             </g>
@@ -156,7 +158,7 @@
                 <polyline points="2.43,8.76 2.85,6.83"/>
             </g>
         </g>
-        <g id="64" class="nad-vl180to300" title="L-8-10-1 ">
+        <g id="88" class="nad-vl180to300" title="L-8-10-1 ">
             <g>
                 <polyline points="5.53,5.20 4.40,5.05"/>
             </g>
@@ -164,7 +166,7 @@
                 <polyline points="3.27,4.91 4.40,5.05"/>
             </g>
         </g>
-        <g id="65" class="nad-vl180to300" title="L-11-13-1 ">
+        <g id="89" class="nad-vl180to300" title="L-11-13-1 ">
             <g>
                 <polyline points="1.98,0.84 3.25,0.16"/>
             </g>
@@ -172,7 +174,7 @@
                 <polyline points="4.52,-0.53 3.25,0.16"/>
             </g>
         </g>
-        <g id="66" class="nad-vl180to300" title="L-11-14-1 ">
+        <g id="90" class="nad-vl180to300" title="L-11-14-1 ">
             <g>
                 <polyline points="1.98,0.84 0.99,-0.76"/>
             </g>
@@ -180,7 +182,7 @@
                 <polyline points="0.00,-2.36 0.99,-0.76"/>
             </g>
         </g>
-        <g id="67" class="nad-vl180to300" title="L-12-13-1 ">
+        <g id="91" class="nad-vl180to300" title="L-12-13-1 ">
             <g>
                 <polyline points="4.61,1.66 4.56,0.57"/>
             </g>
@@ -188,7 +190,7 @@
                 <polyline points="4.52,-0.53 4.56,0.57"/>
             </g>
         </g>
-        <g id="68" class="nad-vl180to300" title="L-12-23-1 ">
+        <g id="92" class="nad-vl180to300" title="L-12-23-1 ">
             <g>
                 <polyline points="4.61,1.66 5.23,-0.29"/>
             </g>
@@ -196,7 +198,7 @@
                 <polyline points="5.84,-2.24 5.23,-0.29"/>
             </g>
         </g>
-        <g id="69" class="nad-vl120to180" title="L-7-8-1 ">
+        <g id="93" class="nad-vl120to180" title="L-7-8-1 ">
             <g>
                 <polyline points="8.37,6.37 6.95,5.78"/>
             </g>
@@ -204,7 +206,7 @@
                 <polyline points="5.53,5.20 6.95,5.78"/>
             </g>
         </g>
-        <g id="70" class="nad-vl180to300" title="L-23-13-1 ">
+        <g id="94" class="nad-vl180to300" title="L-23-13-1 ">
             <g>
                 <polyline points="5.84,-2.24 5.18,-1.38"/>
             </g>
@@ -212,7 +214,7 @@
                 <polyline points="4.52,-0.53 5.18,-1.38"/>
             </g>
         </g>
-        <g id="71" class="nad-vl180to300" title="L-14-16-1 ">
+        <g id="95" class="nad-vl180to300" title="L-14-16-1 ">
             <g>
                 <polyline points="0.00,-2.36 -0.92,-3.79"/>
             </g>
@@ -220,7 +222,7 @@
                 <polyline points="-1.85,-5.21 -0.92,-3.79"/>
             </g>
         </g>
-        <g id="72" class="nad-vl180to300" title="L-16-15-1 ">
+        <g id="96" class="nad-vl180to300" title="L-16-15-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -3.42,-4.31"/>
             </g>
@@ -228,7 +230,7 @@
                 <polyline points="-4.99,-3.40 -3.42,-4.31"/>
             </g>
         </g>
-        <g id="73" class="nad-vl180to300" title="L-15-21-1 ">
+        <g id="97" class="nad-vl180to300" title="L-15-21-1 ">
             <g>
                 <polyline points="-4.99,-3.40 -5.10,-4.19 -5.45,-4.64"/>
             </g>
@@ -236,7 +238,7 @@
                 <polyline points="-6.54,-5.38 -5.80,-5.08 -5.45,-4.64"/>
             </g>
         </g>
-        <g id="74" class="nad-vl180to300" title="L-21-15-2 ">
+        <g id="98" class="nad-vl180to300" title="L-21-15-2 ">
             <g>
                 <polyline points="-4.99,-3.40 -5.74,-3.70 -6.08,-4.15"/>
             </g>
@@ -244,7 +246,7 @@
                 <polyline points="-6.54,-5.38 -6.43,-4.59 -6.08,-4.15"/>
             </g>
         </g>
-        <g id="75" class="nad-vl180to300" title="L-16-17-1 ">
+        <g id="99" class="nad-vl180to300" title="L-16-17-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -3.14,-6.34"/>
             </g>
@@ -252,7 +254,7 @@
                 <polyline points="-4.44,-7.47 -3.14,-6.34"/>
             </g>
         </g>
-        <g id="76" class="nad-vl180to300" title="L-16-19-1 ">
+        <g id="100" class="nad-vl180to300" title="L-16-19-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -0.13,-5.83"/>
             </g>
@@ -260,7 +262,7 @@
                 <polyline points="1.59,-6.46 -0.13,-5.83"/>
             </g>
         </g>
-        <g id="77" class="nad-vl180to300" title="L-17-18-1 ">
+        <g id="101" class="nad-vl180to300" title="L-17-18-1 ">
             <g>
                 <polyline points="-4.44,-7.47 -6.15,-7.32"/>
             </g>
@@ -268,7 +270,7 @@
                 <polyline points="-7.85,-7.16 -6.15,-7.32"/>
             </g>
         </g>
-        <g id="78" class="nad-vl180to300" title="L-17-22-1 ">
+        <g id="102" class="nad-vl180to300" title="L-17-22-1 ">
             <g>
                 <polyline points="-4.44,-7.47 -5.31,-8.13"/>
             </g>
@@ -276,7 +278,7 @@
                 <polyline points="-6.18,-8.79 -5.31,-8.13"/>
             </g>
         </g>
-        <g id="79" class="nad-vl180to300" title="L-18-21-1 ">
+        <g id="103" class="nad-vl180to300" title="L-18-21-1 ">
             <g>
                 <polyline points="-7.85,-7.16 -7.76,-6.37 -7.52,-6.04"/>
             </g>
@@ -284,7 +286,7 @@
                 <polyline points="-6.54,-5.38 -7.27,-5.70 -7.52,-6.04"/>
             </g>
         </g>
-        <g id="80" class="nad-vl180to300" title="L-18-21-2 ">
+        <g id="104" class="nad-vl180to300" title="L-18-21-2 ">
             <g>
                 <polyline points="-7.85,-7.16 -7.12,-6.85 -6.87,-6.51"/>
             </g>
@@ -292,7 +294,7 @@
                 <polyline points="-6.54,-5.38 -6.63,-6.18 -6.87,-6.51"/>
             </g>
         </g>
-        <g id="81" class="nad-vl180to300" title="L-19-20-1 ">
+        <g id="105" class="nad-vl180to300" title="L-19-20-1 ">
             <g>
                 <polyline points="1.59,-6.46 2.11,-5.85 2.98,-5.54"/>
             </g>
@@ -300,7 +302,7 @@
                 <polyline points="4.64,-5.38 3.85,-5.23 2.98,-5.54"/>
             </g>
         </g>
-        <g id="82" class="nad-vl180to300" title="L-19-20-2 ">
+        <g id="106" class="nad-vl180to300" title="L-19-20-2 ">
             <g>
                 <polyline points="1.59,-6.46 2.38,-6.60 3.25,-6.29"/>
             </g>
@@ -308,7 +310,7 @@
                 <polyline points="4.64,-5.38 4.12,-5.99 3.25,-6.29"/>
             </g>
         </g>
-        <g id="83" class="nad-vl180to300" title="L-20-23-1 ">
+        <g id="107" class="nad-vl180to300" title="L-20-23-1 ">
             <g>
                 <polyline points="4.64,-5.38 4.51,-4.59 4.86,-3.67"/>
             </g>
@@ -316,7 +318,7 @@
                 <polyline points="5.84,-2.24 5.22,-2.75 4.86,-3.67"/>
             </g>
         </g>
-        <g id="84" class="nad-vl180to300" title="L-20-23-2 ">
+        <g id="108" class="nad-vl180to300" title="L-20-23-2 ">
             <g>
                 <polyline points="4.64,-5.38 5.26,-4.88 5.61,-3.95"/>
             </g>
@@ -324,7 +326,7 @@
                 <polyline points="5.84,-2.24 5.96,-3.03 5.61,-3.95"/>
             </g>
         </g>
-        <g id="85" class="nad-vl180to300" title="L-21-22-1 ">
+        <g id="109" class="nad-vl180to300" title="L-21-22-1 ">
             <g>
                 <polyline points="-6.54,-5.38 -6.36,-7.09"/>
             </g>
@@ -335,100 +337,248 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(-2.56,6.78)">
-            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.81,8.72)">
-            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.74,3.22)">
-            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.85,0.21)">
-            <circle id="6" class="nad-vl180to300" title="VL24" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl180to300" title="VL24" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.63,5.48)">
-            <circle id="8" class="nad-vl120to180" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.89,6.90)">
-            <circle id="10" class="nad-vl120to180" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.52,3.27)">
-            <circle id="12" class="nad-vl120to180" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl120to180" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.27,4.91)">
-            <circle id="14" class="nad-vl120to180" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl120to180" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.98,0.84)">
-            <circle id="16" class="nad-vl180to300" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl180to300" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.61,1.66)">
-            <circle id="18" class="nad-vl180to300" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl180to300" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.43,8.76)">
-            <circle id="20" class="nad-vl120to180" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl120to180" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.37,6.37)">
-            <circle id="22" class="nad-vl120to180" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl120to180" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.53,5.20)">
-            <circle id="24" class="nad-vl180to300" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl180to300" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.52,-0.53)">
-            <circle id="26" class="nad-vl180to300" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl180to300" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.00,-2.36)">
-            <circle id="28" class="nad-vl180to300" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="43" class="nad-vl180to300" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.99,-3.40)">
-            <circle id="30" class="nad-vl180to300" title="VL15" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="46" class="nad-vl180to300" title="VL15" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.85,-5.21)">
-            <circle id="32" class="nad-vl180to300" title="VL16" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="49" class="nad-vl180to300" title="VL16" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.44,-7.47)">
-            <circle id="34" class="nad-vl180to300" title="VL17" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="52" class="nad-vl180to300" title="VL17" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-7.85,-7.16)">
-            <circle id="36" class="nad-vl180to300" title="VL18" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="55" class="nad-vl180to300" title="VL18" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.59,-6.46)">
-            <circle id="38" class="nad-vl180to300" title="VL19" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="58" class="nad-vl180to300" title="VL19" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.64,-5.38)">
-            <circle id="40" class="nad-vl180to300" title="VL20" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="61" class="nad-vl180to300" title="VL20" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.54,-5.38)">
-            <circle id="42" class="nad-vl180to300" title="VL21" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="64" class="nad-vl180to300" title="VL21" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.18,-8.79)">
-            <circle id="44" class="nad-vl180to300" title="VL22" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="67" class="nad-vl180to300" title="VL22" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.84,-2.24)">
-            <circle id="46" class="nad-vl180to300" title="VL23" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="70" class="nad-vl180to300" title="VL23" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="-1.96,6.78 -1.56,6.78"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="-0.21,8.72 0.19,8.72"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="-2.14,3.22 -1.74,3.22"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="-4.25,0.21 -3.85,0.21"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="-0.03,5.48 0.37,5.48"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="1.49,6.90 1.89,6.90"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="2.12,3.27 2.52,3.27"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="3.87,4.91 4.27,4.91"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="2.58,0.84 2.98,0.84"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="5.21,1.66 5.61,1.66"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="3.03,8.76 3.43,8.76"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="8.97,6.37 9.37,6.37"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="6.13,5.20 6.53,5.20"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="5.12,-0.53 5.52,-0.53"/>
+            </g>
+        </g>
+        <g id="42_edge">
+            <g>
+                <polyline points="0.60,-2.36 1.00,-2.36"/>
+            </g>
+        </g>
+        <g id="45_edge">
+            <g>
+                <polyline points="-4.39,-3.40 -3.99,-3.40"/>
+            </g>
+        </g>
+        <g id="48_edge">
+            <g>
+                <polyline points="-1.25,-5.21 -0.85,-5.21"/>
+            </g>
+        </g>
+        <g id="51_edge">
+            <g>
+                <polyline points="-3.84,-7.47 -3.44,-7.47"/>
+            </g>
+        </g>
+        <g id="54_edge">
+            <g>
+                <polyline points="-7.25,-7.16 -6.85,-7.16"/>
+            </g>
+        </g>
+        <g id="57_edge">
+            <g>
+                <polyline points="2.19,-6.46 2.59,-6.46"/>
+            </g>
+        </g>
+        <g id="60_edge">
+            <g>
+                <polyline points="5.24,-5.38 5.64,-5.38"/>
+            </g>
+        </g>
+        <g id="63_edge">
+            <g>
+                <polyline points="-5.94,-5.38 -5.54,-5.38"/>
+            </g>
+        </g>
+        <g id="66_edge">
+            <g>
+                <polyline points="-5.58,-8.79 -5.18,-8.79"/>
+            </g>
+        </g>
+        <g id="69_edge">
+            <g>
+                <polyline points="6.44,-2.24 6.84,-2.24"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(-1.56,6.78)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(0.19,8.72)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(-1.74,3.22)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(-3.85,0.21)" style="dominant-baseline:middle">VL24</text>
+        <text transform="translate(0.37,5.48)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(1.89,6.90)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(2.52,3.27)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(4.27,4.91)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(2.98,0.84)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(5.61,1.66)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(3.43,8.76)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(9.37,6.37)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(6.53,5.20)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(5.52,-0.53)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(1.00,-2.36)" style="dominant-baseline:middle">VL14</text>
+        <text transform="translate(-3.99,-3.40)" style="dominant-baseline:middle">VL15</text>
+        <text transform="translate(-0.85,-5.21)" style="dominant-baseline:middle">VL16</text>
+        <text transform="translate(-3.44,-7.47)" style="dominant-baseline:middle">VL17</text>
+        <text transform="translate(-6.85,-7.16)" style="dominant-baseline:middle">VL18</text>
+        <text transform="translate(2.59,-6.46)" style="dominant-baseline:middle">VL19</text>
+        <text transform="translate(5.64,-5.38)" style="dominant-baseline:middle">VL20</text>
+        <text transform="translate(-5.54,-5.38)" style="dominant-baseline:middle">VL21</text>
+        <text transform="translate(-5.18,-8.79)" style="dominant-baseline:middle">VL22</text>
+        <text transform="translate(6.84,-2.24)" style="dominant-baseline:middle">VL23</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -556,29 +556,29 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(-1.56,6.78)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(0.19,8.72)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(-1.74,3.22)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(-3.85,0.21)" style="dominant-baseline:middle">VL24</text>
-        <text transform="translate(0.37,5.48)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(1.89,6.90)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(2.52,3.27)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(4.27,4.91)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(2.98,0.84)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(5.61,1.66)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(3.43,8.76)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(9.37,6.37)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(6.53,5.20)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(5.52,-0.53)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(1.00,-2.36)" style="dominant-baseline:middle">VL14</text>
-        <text transform="translate(-3.99,-3.40)" style="dominant-baseline:middle">VL15</text>
-        <text transform="translate(-0.85,-5.21)" style="dominant-baseline:middle">VL16</text>
-        <text transform="translate(-3.44,-7.47)" style="dominant-baseline:middle">VL17</text>
-        <text transform="translate(-6.85,-7.16)" style="dominant-baseline:middle">VL18</text>
-        <text transform="translate(2.59,-6.46)" style="dominant-baseline:middle">VL19</text>
-        <text transform="translate(5.64,-5.38)" style="dominant-baseline:middle">VL20</text>
-        <text transform="translate(-5.54,-5.38)" style="dominant-baseline:middle">VL21</text>
-        <text transform="translate(-5.18,-8.79)" style="dominant-baseline:middle">VL22</text>
-        <text transform="translate(6.84,-2.24)" style="dominant-baseline:middle">VL23</text>
+        <text x="-1.56" y="6.78" style="dominant-baseline:middle">VL1</text>
+        <text x="0.19" y="8.72" style="dominant-baseline:middle">VL2</text>
+        <text x="-1.74" y="3.22" style="dominant-baseline:middle">VL3</text>
+        <text x="-3.85" y="0.21" style="dominant-baseline:middle">VL24</text>
+        <text x="0.37" y="5.48" style="dominant-baseline:middle">VL4</text>
+        <text x="1.89" y="6.90" style="dominant-baseline:middle">VL5</text>
+        <text x="2.52" y="3.27" style="dominant-baseline:middle">VL9</text>
+        <text x="4.27" y="4.91" style="dominant-baseline:middle">VL10</text>
+        <text x="2.98" y="0.84" style="dominant-baseline:middle">VL11</text>
+        <text x="5.61" y="1.66" style="dominant-baseline:middle">VL12</text>
+        <text x="3.43" y="8.76" style="dominant-baseline:middle">VL6</text>
+        <text x="9.37" y="6.37" style="dominant-baseline:middle">VL7</text>
+        <text x="6.53" y="5.20" style="dominant-baseline:middle">VL8</text>
+        <text x="5.52" y="-0.53" style="dominant-baseline:middle">VL13</text>
+        <text x="1.00" y="-2.36" style="dominant-baseline:middle">VL14</text>
+        <text x="-3.99" y="-3.40" style="dominant-baseline:middle">VL15</text>
+        <text x="-0.85" y="-5.21" style="dominant-baseline:middle">VL16</text>
+        <text x="-3.44" y="-7.47" style="dominant-baseline:middle">VL17</text>
+        <text x="-6.85" y="-7.16" style="dominant-baseline:middle">VL18</text>
+        <text x="2.59" y="-6.46" style="dominant-baseline:middle">VL19</text>
+        <text x="5.64" y="-5.38" style="dominant-baseline:middle">VL20</text>
+        <text x="-5.54" y="-5.38" style="dominant-baseline:middle">VL21</text>
+        <text x="-5.18" y="-8.79" style="dominant-baseline:middle">VL22</text>
+        <text x="6.84" y="-2.24" style="dominant-baseline:middle">VL23</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -630,35 +630,35 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(4.43,-8.61)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(1.99,-6.56)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(5.78,-6.52)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(3.76,-3.75)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(0.37,-9.21)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(-0.77,-3.65)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(-1.32,-7.33)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(-4.17,-2.35)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(-2.83,-4.28)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(0.41,-0.81)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(-5.64,-6.25)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(7.15,1.89)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(9.28,5.88)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(9.90,3.36)" style="dominant-baseline:middle">VL14</text>
-        <text transform="translate(7.58,4.09)" style="dominant-baseline:middle">VL15</text>
-        <text transform="translate(4.66,2.54)" style="dominant-baseline:middle">VL16</text>
-        <text transform="translate(2.50,1.13)" style="dominant-baseline:middle">VL17</text>
-        <text transform="translate(9.99,0.72)" style="dominant-baseline:middle">VL18</text>
-        <text transform="translate(8.55,-1.71)" style="dominant-baseline:middle">VL19</text>
-        <text transform="translate(4.99,-1.46)" style="dominant-baseline:middle">VL20</text>
-        <text transform="translate(-1.26,1.32)" style="dominant-baseline:middle">VL21</text>
-        <text transform="translate(-0.28,3.32)" style="dominant-baseline:middle">VL22</text>
-        <text transform="translate(4.00,6.66)" style="dominant-baseline:middle">VL23</text>
-        <text transform="translate(-0.01,6.59)" style="dominant-baseline:middle">VL24</text>
-        <text transform="translate(-3.86,7.02)" style="dominant-baseline:middle">VL25</text>
-        <text transform="translate(-4.57,9.86)" style="dominant-baseline:middle">VL26</text>
-        <text transform="translate(-6.57,3.96)" style="dominant-baseline:middle">VL27</text>
-        <text transform="translate(-4.67,-0.09)" style="dominant-baseline:middle">VL28</text>
-        <text transform="translate(-9.47,3.51)" style="dominant-baseline:middle">VL29</text>
-        <text transform="translate(-8.99,5.61)" style="dominant-baseline:middle">VL30</text>
+        <text x="4.43" y="-8.61" style="dominant-baseline:middle">VL1</text>
+        <text x="1.99" y="-6.56" style="dominant-baseline:middle">VL2</text>
+        <text x="5.78" y="-6.52" style="dominant-baseline:middle">VL3</text>
+        <text x="3.76" y="-3.75" style="dominant-baseline:middle">VL4</text>
+        <text x="0.37" y="-9.21" style="dominant-baseline:middle">VL5</text>
+        <text x="-0.77" y="-3.65" style="dominant-baseline:middle">VL6</text>
+        <text x="-1.32" y="-7.33" style="dominant-baseline:middle">VL7</text>
+        <text x="-4.17" y="-2.35" style="dominant-baseline:middle">VL8</text>
+        <text x="-2.83" y="-4.28" style="dominant-baseline:middle">VL9</text>
+        <text x="0.41" y="-0.81" style="dominant-baseline:middle">VL10</text>
+        <text x="-5.64" y="-6.25" style="dominant-baseline:middle">VL11</text>
+        <text x="7.15" y="1.89" style="dominant-baseline:middle">VL12</text>
+        <text x="9.28" y="5.88" style="dominant-baseline:middle">VL13</text>
+        <text x="9.90" y="3.36" style="dominant-baseline:middle">VL14</text>
+        <text x="7.58" y="4.09" style="dominant-baseline:middle">VL15</text>
+        <text x="4.66" y="2.54" style="dominant-baseline:middle">VL16</text>
+        <text x="2.50" y="1.13" style="dominant-baseline:middle">VL17</text>
+        <text x="9.99" y="0.72" style="dominant-baseline:middle">VL18</text>
+        <text x="8.55" y="-1.71" style="dominant-baseline:middle">VL19</text>
+        <text x="4.99" y="-1.46" style="dominant-baseline:middle">VL20</text>
+        <text x="-1.26" y="1.32" style="dominant-baseline:middle">VL21</text>
+        <text x="-0.28" y="3.32" style="dominant-baseline:middle">VL22</text>
+        <text x="4.00" y="6.66" style="dominant-baseline:middle">VL23</text>
+        <text x="-0.01" y="6.59" style="dominant-baseline:middle">VL24</text>
+        <text x="-3.86" y="7.02" style="dominant-baseline:middle">VL25</text>
+        <text x="-4.57" y="9.86" style="dominant-baseline:middle">VL26</text>
+        <text x="-6.57" y="3.96" style="dominant-baseline:middle">VL27</text>
+        <text x="-4.67" y="-0.09" style="dominant-baseline:middle">VL28</text>
+        <text x="-9.47" y="3.51" style="dominant-baseline:middle">VL29</text>
+        <text x="-8.99" y="5.61" style="dominant-baseline:middle">VL30</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="786.81" viewBox="-12.47 -11.21 23.46 23.08" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="754.64" viewBox="-12.47 -11.21 24.46 23.08" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="60" class="nad-vl120to180" title="L1-2-1">
+    <g class="nad-branch-edges">
+        <g id="90" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.43,-8.61 2.21,-7.58"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="0.99,-6.56 2.21,-7.58"/>
             </g>
         </g>
-        <g id="61" class="nad-vl120to180" title="L1-3-1">
+        <g id="91" class="nad-vl120to180" title="L1-3-1">
             <g>
                 <polyline points="3.43,-8.61 4.11,-7.56"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="4.78,-6.52 4.11,-7.56"/>
             </g>
         </g>
-        <g id="62" class="nad-vl120to180" title="L2-4-1">
+        <g id="92" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="0.99,-6.56 1.87,-5.15"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="2.76,-3.75 1.87,-5.15"/>
             </g>
         </g>
-        <g id="63" class="nad-vl120to180" title="L2-5-1">
+        <g id="93" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="0.99,-6.56 0.18,-7.89"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="-0.63,-9.21 0.18,-7.89"/>
             </g>
         </g>
-        <g id="64" class="nad-vl120to180" title="L2-6-1">
+        <g id="94" class="nad-vl120to180" title="L2-6-1">
             <g>
                 <polyline points="0.99,-6.56 -0.39,-5.11"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="-1.77,-3.65 -0.39,-5.11"/>
             </g>
         </g>
-        <g id="65" class="nad-vl120to180" title="L3-4-1">
+        <g id="95" class="nad-vl120to180" title="L3-4-1">
             <g>
                 <polyline points="4.78,-6.52 3.77,-5.13"/>
             </g>
@@ -64,7 +66,7 @@
                 <polyline points="2.76,-3.75 3.77,-5.13"/>
             </g>
         </g>
-        <g id="66" class="nad-vl120to180" title="L4-6-1">
+        <g id="96" class="nad-vl120to180" title="L4-6-1">
             <g>
                 <polyline points="2.76,-3.75 0.50,-3.70"/>
             </g>
@@ -72,7 +74,7 @@
                 <polyline points="-1.77,-3.65 0.50,-3.70"/>
             </g>
         </g>
-        <g id="67" title="T4-12-1">
+        <g id="97" title="T4-12-1">
             <g class="nad-vl120to180">
                 <polyline points="2.76,-3.75 4.46,-0.93"/>
                 <circle cx="4.40" cy="-1.01" r="0.20"/>
@@ -82,7 +84,7 @@
                 <circle cx="4.51" cy="-0.84" r="0.20"/>
             </g>
         </g>
-        <g id="68" class="nad-vl120to180" title="L5-7-1">
+        <g id="98" class="nad-vl120to180" title="L5-7-1">
             <g>
                 <polyline points="-0.63,-9.21 -1.48,-8.27"/>
             </g>
@@ -90,7 +92,7 @@
                 <polyline points="-2.32,-7.33 -1.48,-8.27"/>
             </g>
         </g>
-        <g id="69" class="nad-vl120to180" title="L6-7-1">
+        <g id="99" class="nad-vl120to180" title="L6-7-1">
             <g>
                 <polyline points="-1.77,-3.65 -2.04,-5.49"/>
             </g>
@@ -98,7 +100,7 @@
                 <polyline points="-2.32,-7.33 -2.04,-5.49"/>
             </g>
         </g>
-        <g id="70" class="nad-vl120to180" title="L6-8-1">
+        <g id="100" class="nad-vl120to180" title="L6-8-1">
             <g>
                 <polyline points="-1.77,-3.65 -3.47,-3.00"/>
             </g>
@@ -106,7 +108,7 @@
                 <polyline points="-5.17,-2.35 -3.47,-3.00"/>
             </g>
         </g>
-        <g id="71" title="T6-9-1">
+        <g id="101" title="T6-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.77,-3.65 -2.80,-3.96"/>
                 <circle cx="-2.70" cy="-3.94" r="0.20"/>
@@ -116,7 +118,7 @@
                 <circle cx="-2.90" cy="-3.99" r="0.20"/>
             </g>
         </g>
-        <g id="72" title="T6-10-1">
+        <g id="102" title="T6-10-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.77,-3.65 -1.18,-2.23"/>
                 <circle cx="-1.22" cy="-2.32" r="0.20"/>
@@ -126,7 +128,7 @@
                 <circle cx="-1.14" cy="-2.14" r="0.20"/>
             </g>
         </g>
-        <g id="73" class="nad-vl120to180" title="L6-28-1">
+        <g id="103" class="nad-vl120to180" title="L6-28-1">
             <g>
                 <polyline points="-1.77,-3.65 -3.72,-1.87"/>
             </g>
@@ -134,7 +136,7 @@
                 <polyline points="-5.67,-0.09 -3.72,-1.87"/>
             </g>
         </g>
-        <g id="74" class="nad-vl120to180" title="L8-28-1">
+        <g id="104" class="nad-vl120to180" title="L8-28-1">
             <g>
                 <polyline points="-5.17,-2.35 -5.42,-1.22"/>
             </g>
@@ -142,7 +144,7 @@
                 <polyline points="-5.67,-0.09 -5.42,-1.22"/>
             </g>
         </g>
-        <g id="75" class="nad-vl0to30" title="L9-11-1">
+        <g id="105" class="nad-vl0to30" title="L9-11-1">
             <g>
                 <polyline points="-3.83,-4.28 -5.24,-5.26"/>
             </g>
@@ -150,7 +152,7 @@
                 <polyline points="-6.64,-6.25 -5.24,-5.26"/>
             </g>
         </g>
-        <g id="76" class="nad-vl0to30" title="L9-10-1">
+        <g id="106" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-3.83,-4.28 -2.21,-2.54"/>
             </g>
@@ -158,7 +160,7 @@
                 <polyline points="-0.59,-0.81 -2.21,-2.54"/>
             </g>
         </g>
-        <g id="77" class="nad-vl30to50" title="L10-20-1">
+        <g id="107" class="nad-vl30to50" title="L10-20-1">
             <g>
                 <polyline points="-0.59,-0.81 1.70,-1.13"/>
             </g>
@@ -166,7 +168,7 @@
                 <polyline points="3.99,-1.46 1.70,-1.13"/>
             </g>
         </g>
-        <g id="78" class="nad-vl30to50" title="L10-17-1">
+        <g id="108" class="nad-vl30to50" title="L10-17-1">
             <g>
                 <polyline points="-0.59,-0.81 0.45,0.16"/>
             </g>
@@ -174,7 +176,7 @@
                 <polyline points="1.50,1.13 0.45,0.16"/>
             </g>
         </g>
-        <g id="79" class="nad-vl30to50" title="L10-21-1">
+        <g id="109" class="nad-vl30to50" title="L10-21-1">
             <g>
                 <polyline points="-0.59,-0.81 -1.43,0.26"/>
             </g>
@@ -182,7 +184,7 @@
                 <polyline points="-2.26,1.32 -1.43,0.26"/>
             </g>
         </g>
-        <g id="80" class="nad-vl30to50" title="L10-22-1">
+        <g id="110" class="nad-vl30to50" title="L10-22-1">
             <g>
                 <polyline points="-0.59,-0.81 -0.94,1.26"/>
             </g>
@@ -190,7 +192,7 @@
                 <polyline points="-1.28,3.32 -0.94,1.26"/>
             </g>
         </g>
-        <g id="81" class="nad-vl30to50" title="L12-13-1">
+        <g id="111" class="nad-vl30to50" title="L12-13-1">
             <g>
                 <polyline points="6.15,1.89 7.22,3.88"/>
             </g>
@@ -198,7 +200,7 @@
                 <polyline points="8.28,5.88 7.22,3.88"/>
             </g>
         </g>
-        <g id="82" class="nad-vl30to50" title="L12-14-1">
+        <g id="112" class="nad-vl30to50" title="L12-14-1">
             <g>
                 <polyline points="6.15,1.89 7.52,2.62"/>
             </g>
@@ -206,7 +208,7 @@
                 <polyline points="8.90,3.36 7.52,2.62"/>
             </g>
         </g>
-        <g id="83" class="nad-vl30to50" title="L12-15-1">
+        <g id="113" class="nad-vl30to50" title="L12-15-1">
             <g>
                 <polyline points="6.15,1.89 6.37,2.99"/>
             </g>
@@ -214,7 +216,7 @@
                 <polyline points="6.58,4.09 6.37,2.99"/>
             </g>
         </g>
-        <g id="84" class="nad-vl30to50" title="L12-16-1">
+        <g id="114" class="nad-vl30to50" title="L12-16-1">
             <g>
                 <polyline points="6.15,1.89 4.91,2.22"/>
             </g>
@@ -222,7 +224,7 @@
                 <polyline points="3.66,2.54 4.91,2.22"/>
             </g>
         </g>
-        <g id="85" class="nad-vl30to50" title="L14-15-1">
+        <g id="115" class="nad-vl30to50" title="L14-15-1">
             <g>
                 <polyline points="8.90,3.36 7.74,3.72"/>
             </g>
@@ -230,7 +232,7 @@
                 <polyline points="6.58,4.09 7.74,3.72"/>
             </g>
         </g>
-        <g id="86" class="nad-vl30to50" title="L15-18-1">
+        <g id="116" class="nad-vl30to50" title="L15-18-1">
             <g>
                 <polyline points="6.58,4.09 7.79,2.40"/>
             </g>
@@ -238,7 +240,7 @@
                 <polyline points="8.99,0.72 7.79,2.40"/>
             </g>
         </g>
-        <g id="87" class="nad-vl30to50" title="L15-23-1">
+        <g id="117" class="nad-vl30to50" title="L15-23-1">
             <g>
                 <polyline points="6.58,4.09 4.79,5.37"/>
             </g>
@@ -246,7 +248,7 @@
                 <polyline points="3.00,6.66 4.79,5.37"/>
             </g>
         </g>
-        <g id="88" class="nad-vl30to50" title="L16-17-1">
+        <g id="118" class="nad-vl30to50" title="L16-17-1">
             <g>
                 <polyline points="3.66,2.54 2.58,1.83"/>
             </g>
@@ -254,7 +256,7 @@
                 <polyline points="1.50,1.13 2.58,1.83"/>
             </g>
         </g>
-        <g id="89" class="nad-vl30to50" title="L18-19-1">
+        <g id="119" class="nad-vl30to50" title="L18-19-1">
             <g>
                 <polyline points="8.99,0.72 8.27,-0.49"/>
             </g>
@@ -262,7 +264,7 @@
                 <polyline points="7.55,-1.71 8.27,-0.49"/>
             </g>
         </g>
-        <g id="90" class="nad-vl30to50" title="L19-20-1">
+        <g id="120" class="nad-vl30to50" title="L19-20-1">
             <g>
                 <polyline points="7.55,-1.71 5.77,-1.58"/>
             </g>
@@ -270,7 +272,7 @@
                 <polyline points="3.99,-1.46 5.77,-1.58"/>
             </g>
         </g>
-        <g id="91" class="nad-vl30to50" title="L21-22-1">
+        <g id="121" class="nad-vl30to50" title="L21-22-1">
             <g>
                 <polyline points="-2.26,1.32 -1.77,2.32"/>
             </g>
@@ -278,7 +280,7 @@
                 <polyline points="-1.28,3.32 -1.77,2.32"/>
             </g>
         </g>
-        <g id="92" class="nad-vl30to50" title="L22-24-1">
+        <g id="122" class="nad-vl30to50" title="L22-24-1">
             <g>
                 <polyline points="-1.28,3.32 -1.14,4.96"/>
             </g>
@@ -286,7 +288,7 @@
                 <polyline points="-1.01,6.59 -1.14,4.96"/>
             </g>
         </g>
-        <g id="93" class="nad-vl30to50" title="L23-24-1">
+        <g id="123" class="nad-vl30to50" title="L23-24-1">
             <g>
                 <polyline points="3.00,6.66 1.00,6.62"/>
             </g>
@@ -294,7 +296,7 @@
                 <polyline points="-1.01,6.59 1.00,6.62"/>
             </g>
         </g>
-        <g id="94" class="nad-vl30to50" title="L24-25-1">
+        <g id="124" class="nad-vl30to50" title="L24-25-1">
             <g>
                 <polyline points="-1.01,6.59 -2.93,6.80"/>
             </g>
@@ -302,7 +304,7 @@
                 <polyline points="-4.86,7.02 -2.93,6.80"/>
             </g>
         </g>
-        <g id="95" class="nad-vl30to50" title="L25-26-1">
+        <g id="125" class="nad-vl30to50" title="L25-26-1">
             <g>
                 <polyline points="-4.86,7.02 -5.22,8.44"/>
             </g>
@@ -310,7 +312,7 @@
                 <polyline points="-5.57,9.86 -5.22,8.44"/>
             </g>
         </g>
-        <g id="96" class="nad-vl30to50" title="L25-27-1">
+        <g id="126" class="nad-vl30to50" title="L25-27-1">
             <g>
                 <polyline points="-4.86,7.02 -6.22,5.49"/>
             </g>
@@ -318,7 +320,7 @@
                 <polyline points="-7.57,3.96 -6.22,5.49"/>
             </g>
         </g>
-        <g id="97" title="T28-27-1">
+        <g id="127" title="T28-27-1">
             <g class="nad-vl120to180">
                 <polyline points="-5.67,-0.09 -6.62,1.94"/>
                 <circle cx="-6.58" cy="1.85" r="0.20"/>
@@ -328,7 +330,7 @@
                 <circle cx="-6.66" cy="2.03" r="0.20"/>
             </g>
         </g>
-        <g id="98" class="nad-vl30to50" title="L27-29-1">
+        <g id="128" class="nad-vl30to50" title="L27-29-1">
             <g>
                 <polyline points="-7.57,3.96 -9.02,3.74"/>
             </g>
@@ -336,7 +338,7 @@
                 <polyline points="-10.47,3.51 -9.02,3.74"/>
             </g>
         </g>
-        <g id="99" class="nad-vl30to50" title="L27-30-1">
+        <g id="129" class="nad-vl30to50" title="L27-30-1">
             <g>
                 <polyline points="-7.57,3.96 -8.78,4.79"/>
             </g>
@@ -344,7 +346,7 @@
                 <polyline points="-9.99,5.61 -8.78,4.79"/>
             </g>
         </g>
-        <g id="100" class="nad-vl30to50" title="L29-30-1">
+        <g id="130" class="nad-vl30to50" title="L29-30-1">
             <g>
                 <polyline points="-10.47,3.51 -10.23,4.56"/>
             </g>
@@ -355,124 +357,308 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(3.43,-8.61)">
-            <circle id="0" class="nad-vl120to180" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl120to180" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.99,-6.56)">
-            <circle id="2" class="nad-vl120to180" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl120to180" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.78,-6.52)">
-            <circle id="4" class="nad-vl120to180" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl120to180" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.76,-3.75)">
-            <circle id="6" class="nad-vl120to180" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl120to180" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.63,-9.21)">
-            <circle id="8" class="nad-vl120to180" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl120to180" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.77,-3.65)">
-            <circle id="10" class="nad-vl120to180" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl120to180" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.32,-7.33)">
-            <circle id="12" class="nad-vl120to180" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl120to180" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.17,-2.35)">
-            <circle id="14" class="nad-vl120to180" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl120to180" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.83,-4.28)">
-            <circle id="16" class="nad-vl0to30" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.59,-0.81)">
-            <circle id="18" class="nad-vl30to50" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl30to50" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.64,-6.25)">
-            <circle id="20" class="nad-vl0to30" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.15,1.89)">
-            <circle id="22" class="nad-vl30to50" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl30to50" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.28,5.88)">
-            <circle id="24" class="nad-vl0to30" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.90,3.36)">
-            <circle id="26" class="nad-vl30to50" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl30to50" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.58,4.09)">
-            <circle id="28" class="nad-vl30to50" title="VL15" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="43" class="nad-vl30to50" title="VL15" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.66,2.54)">
-            <circle id="30" class="nad-vl30to50" title="VL16" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="46" class="nad-vl30to50" title="VL16" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.50,1.13)">
-            <circle id="32" class="nad-vl30to50" title="VL17" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="49" class="nad-vl30to50" title="VL17" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.99,0.72)">
-            <circle id="34" class="nad-vl30to50" title="VL18" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="52" class="nad-vl30to50" title="VL18" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(7.55,-1.71)">
-            <circle id="36" class="nad-vl30to50" title="VL19" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="55" class="nad-vl30to50" title="VL19" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.99,-1.46)">
-            <circle id="38" class="nad-vl30to50" title="VL20" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="58" class="nad-vl30to50" title="VL20" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.26,1.32)">
-            <circle id="40" class="nad-vl30to50" title="VL21" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="61" class="nad-vl30to50" title="VL21" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.28,3.32)">
-            <circle id="42" class="nad-vl30to50" title="VL22" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="64" class="nad-vl30to50" title="VL22" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.00,6.66)">
-            <circle id="44" class="nad-vl30to50" title="VL23" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="67" class="nad-vl30to50" title="VL23" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.01,6.59)">
-            <circle id="46" class="nad-vl30to50" title="VL24" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="70" class="nad-vl30to50" title="VL24" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.86,7.02)">
-            <circle id="48" class="nad-vl30to50" title="VL25" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="73" class="nad-vl30to50" title="VL25" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.57,9.86)">
-            <circle id="50" class="nad-vl30to50" title="VL26" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="76" class="nad-vl30to50" title="VL26" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-7.57,3.96)">
-            <circle id="52" class="nad-vl30to50" title="VL27" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="79" class="nad-vl30to50" title="VL27" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.67,-0.09)">
-            <circle id="54" class="nad-vl120to180" title="VL28" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="82" class="nad-vl120to180" title="VL28" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.47,3.51)">
-            <circle id="56" class="nad-vl30to50" title="VL29" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="85" class="nad-vl30to50" title="VL29" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.99,5.61)">
-            <circle id="58" class="nad-vl30to50" title="VL30" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="88" class="nad-vl30to50" title="VL30" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="4.03,-8.61 4.43,-8.61"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="1.59,-6.56 1.99,-6.56"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="5.38,-6.52 5.78,-6.52"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="3.36,-3.75 3.76,-3.75"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="-0.03,-9.21 0.37,-9.21"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="-1.17,-3.65 -0.77,-3.65"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="-1.72,-7.33 -1.32,-7.33"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="-4.57,-2.35 -4.17,-2.35"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="-3.23,-4.28 -2.83,-4.28"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="0.01,-0.81 0.41,-0.81"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="-6.04,-6.25 -5.64,-6.25"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="6.75,1.89 7.15,1.89"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="8.88,5.88 9.28,5.88"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="9.50,3.36 9.90,3.36"/>
+            </g>
+        </g>
+        <g id="42_edge">
+            <g>
+                <polyline points="7.18,4.09 7.58,4.09"/>
+            </g>
+        </g>
+        <g id="45_edge">
+            <g>
+                <polyline points="4.26,2.54 4.66,2.54"/>
+            </g>
+        </g>
+        <g id="48_edge">
+            <g>
+                <polyline points="2.10,1.13 2.50,1.13"/>
+            </g>
+        </g>
+        <g id="51_edge">
+            <g>
+                <polyline points="9.59,0.72 9.99,0.72"/>
+            </g>
+        </g>
+        <g id="54_edge">
+            <g>
+                <polyline points="8.15,-1.71 8.55,-1.71"/>
+            </g>
+        </g>
+        <g id="57_edge">
+            <g>
+                <polyline points="4.59,-1.46 4.99,-1.46"/>
+            </g>
+        </g>
+        <g id="60_edge">
+            <g>
+                <polyline points="-1.66,1.32 -1.26,1.32"/>
+            </g>
+        </g>
+        <g id="63_edge">
+            <g>
+                <polyline points="-0.68,3.32 -0.28,3.32"/>
+            </g>
+        </g>
+        <g id="66_edge">
+            <g>
+                <polyline points="3.60,6.66 4.00,6.66"/>
+            </g>
+        </g>
+        <g id="69_edge">
+            <g>
+                <polyline points="-0.41,6.59 -0.01,6.59"/>
+            </g>
+        </g>
+        <g id="72_edge">
+            <g>
+                <polyline points="-4.26,7.02 -3.86,7.02"/>
+            </g>
+        </g>
+        <g id="75_edge">
+            <g>
+                <polyline points="-4.97,9.86 -4.57,9.86"/>
+            </g>
+        </g>
+        <g id="78_edge">
+            <g>
+                <polyline points="-6.97,3.96 -6.57,3.96"/>
+            </g>
+        </g>
+        <g id="81_edge">
+            <g>
+                <polyline points="-5.07,-0.09 -4.67,-0.09"/>
+            </g>
+        </g>
+        <g id="84_edge">
+            <g>
+                <polyline points="-9.87,3.51 -9.47,3.51"/>
+            </g>
+        </g>
+        <g id="87_edge">
+            <g>
+                <polyline points="-9.39,5.61 -8.99,5.61"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(4.43,-8.61)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(1.99,-6.56)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(5.78,-6.52)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(3.76,-3.75)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(0.37,-9.21)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(-0.77,-3.65)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(-1.32,-7.33)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(-4.17,-2.35)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(-2.83,-4.28)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(0.41,-0.81)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(-5.64,-6.25)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(7.15,1.89)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(9.28,5.88)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(9.90,3.36)" style="dominant-baseline:middle">VL14</text>
+        <text transform="translate(7.58,4.09)" style="dominant-baseline:middle">VL15</text>
+        <text transform="translate(4.66,2.54)" style="dominant-baseline:middle">VL16</text>
+        <text transform="translate(2.50,1.13)" style="dominant-baseline:middle">VL17</text>
+        <text transform="translate(9.99,0.72)" style="dominant-baseline:middle">VL18</text>
+        <text transform="translate(8.55,-1.71)" style="dominant-baseline:middle">VL19</text>
+        <text transform="translate(4.99,-1.46)" style="dominant-baseline:middle">VL20</text>
+        <text transform="translate(-1.26,1.32)" style="dominant-baseline:middle">VL21</text>
+        <text transform="translate(-0.28,3.32)" style="dominant-baseline:middle">VL22</text>
+        <text transform="translate(4.00,6.66)" style="dominant-baseline:middle">VL23</text>
+        <text transform="translate(-0.01,6.59)" style="dominant-baseline:middle">VL24</text>
+        <text transform="translate(-3.86,7.02)" style="dominant-baseline:middle">VL25</text>
+        <text transform="translate(-4.57,9.86)" style="dominant-baseline:middle">VL26</text>
+        <text transform="translate(-6.57,3.96)" style="dominant-baseline:middle">VL27</text>
+        <text transform="translate(-4.67,-0.09)" style="dominant-baseline:middle">VL28</text>
+        <text transform="translate(-9.47,3.51)" style="dominant-baseline:middle">VL29</text>
+        <text transform="translate(-8.99,5.61)" style="dominant-baseline:middle">VL30</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="977.06" viewBox="-14.64 -20.78 30.77 37.59" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="946.31" viewBox="-14.64 -20.78 31.77 37.59" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
-.nad-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
+.nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
-.nad-vl-nodes text {font: 0.6px "Verdana"; fill: white}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -15,8 +17,8 @@
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
 ]]></style>
     <metadata></metadata>
-    <g class="nad-edges">
-        <g id="114" class="nad-vl0to30" title="L1-2-1">
+    <g class="nad-branch-edges">
+        <g id="171" class="nad-vl0to30" title="L1-2-1">
             <g>
                 <polyline points="-7.03,10.20 -6.09,11.46"/>
             </g>
@@ -24,7 +26,7 @@
                 <polyline points="-5.14,12.72 -6.09,11.46"/>
             </g>
         </g>
-        <g id="115" class="nad-vl0to30" title="L1-15-1">
+        <g id="172" class="nad-vl0to30" title="L1-15-1">
             <g>
                 <polyline points="-7.03,10.20 -5.68,8.52"/>
             </g>
@@ -32,7 +34,7 @@
                 <polyline points="-4.33,6.84 -5.68,8.52"/>
             </g>
         </g>
-        <g id="116" class="nad-vl0to30" title="L1-16-1">
+        <g id="173" class="nad-vl0to30" title="L1-16-1">
             <g>
                 <polyline points="-7.03,10.20 -8.18,10.49"/>
             </g>
@@ -40,7 +42,7 @@
                 <polyline points="-9.33,10.78 -8.18,10.49"/>
             </g>
         </g>
-        <g id="117" class="nad-vl0to30" title="L1-17-1">
+        <g id="174" class="nad-vl0to30" title="L1-17-1">
             <g>
                 <polyline points="-7.03,10.20 -8.66,9.60"/>
             </g>
@@ -48,7 +50,7 @@
                 <polyline points="-10.30,8.99 -8.66,9.60"/>
             </g>
         </g>
-        <g id="118" class="nad-vl0to30" title="L2-3-1">
+        <g id="175" class="nad-vl0to30" title="L2-3-1">
             <g>
                 <polyline points="-5.14,12.72 -3.77,12.13"/>
             </g>
@@ -56,7 +58,7 @@
                 <polyline points="-2.40,11.54 -3.77,12.13"/>
             </g>
         </g>
-        <g id="119" class="nad-vl0to30" title="L3-4-1">
+        <g id="176" class="nad-vl0to30" title="L3-4-1">
             <g>
                 <polyline points="-2.40,11.54 -0.28,12.41"/>
             </g>
@@ -64,7 +66,7 @@
                 <polyline points="1.83,13.29 -0.28,12.41"/>
             </g>
         </g>
-        <g id="120" class="nad-vl0to30" title="L3-15-1">
+        <g id="177" class="nad-vl0to30" title="L3-15-1">
             <g>
                 <polyline points="-2.40,11.54 -3.37,9.19"/>
             </g>
@@ -72,7 +74,7 @@
                 <polyline points="-4.33,6.84 -3.37,9.19"/>
             </g>
         </g>
-        <g id="121" class="nad-vl0to30" title="L4-5-1">
+        <g id="178" class="nad-vl0to30" title="L4-5-1">
             <g>
                 <polyline points="1.83,13.29 2.52,14.04"/>
             </g>
@@ -80,7 +82,7 @@
                 <polyline points="3.21,14.80 2.52,14.04"/>
             </g>
         </g>
-        <g id="122" class="nad-vl0to30" title="L4-6-1">
+        <g id="179" class="nad-vl0to30" title="L4-6-1">
             <g>
                 <polyline points="1.83,13.29 2.15,12.30"/>
             </g>
@@ -88,7 +90,7 @@
                 <polyline points="2.46,11.32 2.15,12.30"/>
             </g>
         </g>
-        <g id="123" title="T4-18-1">
+        <g id="180" title="T4-18-1">
             <g class="nad-vl0to30">
                 <polyline points="1.83,13.29 2.57,13.60 4.21,13.41"/>
                 <circle cx="4.11" cy="13.42" r="0.20"/>
@@ -98,7 +100,7 @@
                 <circle cx="4.31" cy="13.40" r="0.20"/>
             </g>
         </g>
-        <g id="124" title="T4-18-2">
+        <g id="181" title="T4-18-2">
             <g class="nad-vl0to30">
                 <polyline points="1.83,13.29 2.48,12.81 4.11,12.62"/>
                 <circle cx="4.02" cy="12.63" r="0.20"/>
@@ -108,7 +110,7 @@
                 <circle cx="4.21" cy="12.60" r="0.20"/>
             </g>
         </g>
-        <g id="125" class="nad-vl0to30" title="L5-6-1">
+        <g id="182" class="nad-vl0to30" title="L5-6-1">
             <g>
                 <polyline points="3.21,14.80 2.83,13.06"/>
             </g>
@@ -116,7 +118,7 @@
                 <polyline points="2.46,11.32 2.83,13.06"/>
             </g>
         </g>
-        <g id="126" class="nad-vl0to30" title="L6-7-1">
+        <g id="183" class="nad-vl0to30" title="L6-7-1">
             <g>
                 <polyline points="2.46,11.32 3.27,10.08"/>
             </g>
@@ -124,7 +126,7 @@
                 <polyline points="4.08,8.85 3.27,10.08"/>
             </g>
         </g>
-        <g id="127" class="nad-vl0to30" title="L6-8-1">
+        <g id="184" class="nad-vl0to30" title="L6-8-1">
             <g>
                 <polyline points="2.46,11.32 1.18,10.00"/>
             </g>
@@ -132,7 +134,7 @@
                 <polyline points="-0.09,8.68 1.18,10.00"/>
             </g>
         </g>
-        <g id="128" class="nad-vl0to30" title="L7-8-1">
+        <g id="185" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="4.08,8.85 1.99,8.76"/>
             </g>
@@ -140,7 +142,7 @@
                 <polyline points="-0.09,8.68 1.99,8.76"/>
             </g>
         </g>
-        <g id="129" title="T7-29-1">
+        <g id="186" title="T7-29-1">
             <g class="nad-vl0to30">
                 <polyline points="4.08,8.85 6.09,7.68"/>
                 <circle cx="6.00" cy="7.73" r="0.20"/>
@@ -150,7 +152,7 @@
                 <circle cx="6.18" cy="7.63" r="0.20"/>
             </g>
         </g>
-        <g id="130" class="nad-vl0to30" title="L8-9-1">
+        <g id="187" class="nad-vl0to30" title="L8-9-1">
             <g>
                 <polyline points="-0.09,8.68 -3.14,6.94"/>
             </g>
@@ -158,7 +160,7 @@
                 <polyline points="-6.18,5.19 -3.14,6.94"/>
             </g>
         </g>
-        <g id="131" class="nad-vl0to30" title="L9-10-1">
+        <g id="188" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-6.18,5.19 -8.25,5.01"/>
             </g>
@@ -166,7 +168,7 @@
                 <polyline points="-10.33,4.82 -8.25,5.01"/>
             </g>
         </g>
-        <g id="132" class="nad-vl0to30" title="L9-11-1">
+        <g id="189" class="nad-vl0to30" title="L9-11-1">
             <g>
                 <polyline points="-6.18,5.19 -7.37,2.48"/>
             </g>
@@ -174,7 +176,7 @@
                 <polyline points="-8.56,-0.23 -7.37,2.48"/>
             </g>
         </g>
-        <g id="133" class="nad-vl0to30" title="L9-12-1">
+        <g id="190" class="nad-vl0to30" title="L9-12-1">
             <g>
                 <polyline points="-6.18,5.19 -7.51,6.00"/>
             </g>
@@ -182,7 +184,7 @@
                 <polyline points="-8.83,6.82 -7.51,6.00"/>
             </g>
         </g>
-        <g id="134" class="nad-vl0to30" title="L9-13-1">
+        <g id="191" class="nad-vl0to30" title="L9-13-1">
             <g>
                 <polyline points="-6.18,5.19 -6.53,4.13"/>
             </g>
@@ -190,7 +192,7 @@
                 <polyline points="-6.88,3.07 -6.53,4.13"/>
             </g>
         </g>
-        <g id="135" title="T9-55-1">
+        <g id="192" title="T9-55-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.18,5.19 -4.04,5.46"/>
                 <circle cx="-4.14" cy="5.45" r="0.20"/>
@@ -200,7 +202,7 @@
                 <circle cx="-3.94" cy="5.47" r="0.20"/>
             </g>
         </g>
-        <g id="136" class="nad-vl0to30" title="L10-12-1">
+        <g id="193" class="nad-vl0to30" title="L10-12-1">
             <g>
                 <polyline points="-10.33,4.82 -9.58,5.82"/>
             </g>
@@ -208,7 +210,7 @@
                 <polyline points="-8.83,6.82 -9.58,5.82"/>
             </g>
         </g>
-        <g id="137" title="T10-51-1">
+        <g id="194" title="T10-51-1">
             <g class="nad-vl0to30">
                 <polyline points="-10.33,4.82 -11.48,3.76"/>
                 <circle cx="-11.41" cy="3.83" r="0.20"/>
@@ -218,7 +220,7 @@
                 <circle cx="-11.56" cy="3.69" r="0.20"/>
             </g>
         </g>
-        <g id="138" class="nad-vl0to30" title="L11-13-1">
+        <g id="195" class="nad-vl0to30" title="L11-13-1">
             <g>
                 <polyline points="-8.56,-0.23 -7.72,1.42"/>
             </g>
@@ -226,7 +228,7 @@
                 <polyline points="-6.88,3.07 -7.72,1.42"/>
             </g>
         </g>
-        <g id="139" title="T11-41-1">
+        <g id="196" title="T11-41-1">
             <g class="nad-vl0to30">
                 <polyline points="-8.56,-0.23 -9.34,-2.82"/>
                 <circle cx="-9.31" cy="-2.72" r="0.20"/>
@@ -236,7 +238,7 @@
                 <circle cx="-9.37" cy="-2.91" r="0.20"/>
             </g>
         </g>
-        <g id="140" title="T11-43-1">
+        <g id="197" title="T11-43-1">
             <g class="nad-vl0to30">
                 <polyline points="-8.56,-0.23 -9.68,-1.59"/>
                 <circle cx="-9.61" cy="-1.51" r="0.20"/>
@@ -246,7 +248,7 @@
                 <circle cx="-9.74" cy="-1.66" r="0.20"/>
             </g>
         </g>
-        <g id="141" class="nad-vl0to30" title="L12-13-1">
+        <g id="198" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="-8.83,6.82 -7.85,4.94"/>
             </g>
@@ -254,7 +256,7 @@
                 <polyline points="-6.88,3.07 -7.85,4.94"/>
             </g>
         </g>
-        <g id="142" class="nad-vl0to30" title="L12-16-1">
+        <g id="199" class="nad-vl0to30" title="L12-16-1">
             <g>
                 <polyline points="-8.83,6.82 -9.08,8.80"/>
             </g>
@@ -262,7 +264,7 @@
                 <polyline points="-9.33,10.78 -9.08,8.80"/>
             </g>
         </g>
-        <g id="143" class="nad-vl0to30" title="L12-17-1">
+        <g id="200" class="nad-vl0to30" title="L12-17-1">
             <g>
                 <polyline points="-8.83,6.82 -9.57,7.91"/>
             </g>
@@ -270,7 +272,7 @@
                 <polyline points="-10.30,8.99 -9.57,7.91"/>
             </g>
         </g>
-        <g id="144" class="nad-vl0to30" title="L13-14-1">
+        <g id="201" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="-6.88,3.07 -5.67,3.26"/>
             </g>
@@ -278,7 +280,7 @@
                 <polyline points="-4.46,3.45 -5.67,3.26"/>
             </g>
         </g>
-        <g id="145" class="nad-vl0to30" title="L13-15-1">
+        <g id="202" class="nad-vl0to30" title="L13-15-1">
             <g>
                 <polyline points="-6.88,3.07 -5.60,4.95"/>
             </g>
@@ -286,7 +288,7 @@
                 <polyline points="-4.33,6.84 -5.60,4.95"/>
             </g>
         </g>
-        <g id="146" title="T13-49-1">
+        <g id="203" title="T13-49-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.88,3.07 -6.29,0.80"/>
                 <circle cx="-6.31" cy="0.90" r="0.20"/>
@@ -296,7 +298,7 @@
                 <circle cx="-6.26" cy="0.70" r="0.20"/>
             </g>
         </g>
-        <g id="147" class="nad-vl0to30" title="L14-15-1">
+        <g id="204" class="nad-vl0to30" title="L14-15-1">
             <g>
                 <polyline points="-4.46,3.45 -4.39,5.15"/>
             </g>
@@ -304,7 +306,7 @@
                 <polyline points="-4.33,6.84 -4.39,5.15"/>
             </g>
         </g>
-        <g id="148" title="T14-46-1">
+        <g id="205" title="T14-46-1">
             <g class="nad-vl0to30">
                 <polyline points="-4.46,3.45 -3.97,2.08"/>
                 <circle cx="-4.00" cy="2.18" r="0.20"/>
@@ -314,7 +316,7 @@
                 <circle cx="-3.93" cy="1.99" r="0.20"/>
             </g>
         </g>
-        <g id="149" title="T15-45-1">
+        <g id="206" title="T15-45-1">
             <g class="nad-vl0to30">
                 <polyline points="-4.33,6.84 -2.73,4.86"/>
                 <circle cx="-2.79" cy="4.94" r="0.20"/>
@@ -324,7 +326,7 @@
                 <circle cx="-2.66" cy="4.78" r="0.20"/>
             </g>
         </g>
-        <g id="150" class="nad-vl0to30" title="L18-19-1">
+        <g id="207" class="nad-vl0to30" title="L18-19-1">
             <g>
                 <polyline points="6.49,12.74 8.01,11.50"/>
             </g>
@@ -332,7 +334,7 @@
                 <polyline points="9.54,10.26 8.01,11.50"/>
             </g>
         </g>
-        <g id="151" class="nad-vl0to30" title="L19-20-1">
+        <g id="208" class="nad-vl0to30" title="L19-20-1">
             <g>
                 <polyline points="9.54,10.26 10.01,8.22"/>
             </g>
@@ -340,7 +342,7 @@
                 <polyline points="10.49,6.18 10.01,8.22"/>
             </g>
         </g>
-        <g id="152" title="T21-20-1">
+        <g id="209" title="T21-20-1">
             <g class="nad-vl0to30">
                 <polyline points="8.54,1.31 9.52,3.74"/>
                 <circle cx="9.48" cy="3.65" r="0.20"/>
@@ -350,7 +352,7 @@
                 <circle cx="9.55" cy="3.84" r="0.20"/>
             </g>
         </g>
-        <g id="153" class="nad-vl0to30" title="L21-22-1">
+        <g id="210" class="nad-vl0to30" title="L21-22-1">
             <g>
                 <polyline points="8.54,1.31 7.08,-0.63"/>
             </g>
@@ -358,7 +360,7 @@
                 <polyline points="5.62,-2.58 7.08,-0.63"/>
             </g>
         </g>
-        <g id="154" class="nad-vl0to30" title="L22-23-1">
+        <g id="211" class="nad-vl0to30" title="L22-23-1">
             <g>
                 <polyline points="5.62,-2.58 7.28,-3.46"/>
             </g>
@@ -366,7 +368,7 @@
                 <polyline points="8.93,-4.35 7.28,-3.46"/>
             </g>
         </g>
-        <g id="155" class="nad-vl0to30" title="L22-38-1">
+        <g id="212" class="nad-vl0to30" title="L22-38-1">
             <g>
                 <polyline points="5.62,-2.58 2.65,-3.25"/>
             </g>
@@ -374,7 +376,7 @@
                 <polyline points="-0.32,-3.93 2.65,-3.25"/>
             </g>
         </g>
-        <g id="156" class="nad-vl0to30" title="L23-24-1">
+        <g id="213" class="nad-vl0to30" title="L23-24-1">
             <g>
                 <polyline points="8.93,-4.35 10.58,-4.86"/>
             </g>
@@ -382,7 +384,7 @@
                 <polyline points="12.23,-5.38 10.58,-4.86"/>
             </g>
         </g>
-        <g id="157" title="T24-25-1">
+        <g id="214" title="T24-25-1">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 12.69,-6.03 12.78,-7.03"/>
                 <circle cx="12.77" cy="-6.93" r="0.20"/>
@@ -392,7 +394,7 @@
                 <circle cx="12.79" cy="-7.13" r="0.20"/>
             </g>
         </g>
-        <g id="158" title="T24-25-2">
+        <g id="215" title="T24-25-2">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 11.90,-6.10 11.99,-7.10"/>
                 <circle cx="11.98" cy="-7.00" r="0.20"/>
@@ -402,7 +404,7 @@
                 <circle cx="12.00" cy="-7.20" r="0.20"/>
             </g>
         </g>
-        <g id="159" title="T24-26-1">
+        <g id="216" title="T24-26-1">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 13.18,-3.94"/>
                 <circle cx="13.12" cy="-4.02" r="0.20"/>
@@ -412,7 +414,7 @@
                 <circle cx="13.23" cy="-3.86" r="0.20"/>
             </g>
         </g>
-        <g id="160" class="nad-vl0to30" title="L25-30-1">
+        <g id="217" class="nad-vl0to30" title="L25-30-1">
             <g>
                 <polyline points="12.54,-8.75 12.06,-10.26"/>
             </g>
@@ -420,7 +422,7 @@
                 <polyline points="11.58,-11.77 12.06,-10.26"/>
             </g>
         </g>
-        <g id="161" class="nad-vl0to30" title="L26-27-1">
+        <g id="218" class="nad-vl0to30" title="L26-27-1">
             <g>
                 <polyline points="14.12,-2.50 14.13,-0.85"/>
             </g>
@@ -428,7 +430,7 @@
                 <polyline points="14.13,0.81 14.13,-0.85"/>
             </g>
         </g>
-        <g id="162" class="nad-vl0to30" title="L27-28-1">
+        <g id="219" class="nad-vl0to30" title="L27-28-1">
             <g>
                 <polyline points="14.13,0.81 13.13,2.29"/>
             </g>
@@ -436,7 +438,7 @@
                 <polyline points="12.13,3.77 13.13,2.29"/>
             </g>
         </g>
-        <g id="163" class="nad-vl0to30" title="L28-29-1">
+        <g id="220" class="nad-vl0to30" title="L28-29-1">
             <g>
                 <polyline points="12.13,3.77 10.11,5.14"/>
             </g>
@@ -444,7 +446,7 @@
                 <polyline points="8.10,6.52 10.11,5.14"/>
             </g>
         </g>
-        <g id="164" class="nad-vl0to30" title="L29-52-1">
+        <g id="221" class="nad-vl0to30" title="L29-52-1">
             <g>
                 <polyline points="8.10,6.52 7.41,5.59"/>
             </g>
@@ -452,7 +454,7 @@
                 <polyline points="6.72,4.66 7.41,5.59"/>
             </g>
         </g>
-        <g id="165" class="nad-vl0to30" title="L30-31-1">
+        <g id="222" class="nad-vl0to30" title="L30-31-1">
             <g>
                 <polyline points="11.58,-11.77 10.57,-13.00"/>
             </g>
@@ -460,7 +462,7 @@
                 <polyline points="9.57,-14.22 10.57,-13.00"/>
             </g>
         </g>
-        <g id="166" class="nad-vl0to30" title="L31-32-1">
+        <g id="223" class="nad-vl0to30" title="L31-32-1">
             <g>
                 <polyline points="9.57,-14.22 8.24,-15.21"/>
             </g>
@@ -468,7 +470,7 @@
                 <polyline points="6.90,-16.19 8.24,-15.21"/>
             </g>
         </g>
-        <g id="167" class="nad-vl0to30" title="L32-33-1">
+        <g id="224" class="nad-vl0to30" title="L32-33-1">
             <g>
                 <polyline points="6.90,-16.19 7.26,-17.49"/>
             </g>
@@ -476,7 +478,7 @@
                 <polyline points="7.62,-18.78 7.26,-17.49"/>
             </g>
         </g>
-        <g id="168" title="T34-32-1">
+        <g id="225" title="T34-32-1">
             <g class="nad-vl0to30">
                 <polyline points="3.58,-15.95 5.24,-16.07"/>
                 <circle cx="5.14" cy="-16.06" r="0.20"/>
@@ -486,7 +488,7 @@
                 <circle cx="5.34" cy="-16.08" r="0.20"/>
             </g>
         </g>
-        <g id="169" class="nad-vl0to30" title="L34-35-1">
+        <g id="226" class="nad-vl0to30" title="L34-35-1">
             <g>
                 <polyline points="3.58,-15.95 2.04,-15.41"/>
             </g>
@@ -494,7 +496,7 @@
                 <polyline points="0.50,-14.87 2.04,-15.41"/>
             </g>
         </g>
-        <g id="170" class="nad-vl0to30" title="L35-36-1">
+        <g id="227" class="nad-vl0to30" title="L35-36-1">
             <g>
                 <polyline points="0.50,-14.87 -0.87,-13.75"/>
             </g>
@@ -502,7 +504,7 @@
                 <polyline points="-2.25,-12.64 -0.87,-13.75"/>
             </g>
         </g>
-        <g id="171" class="nad-vl0to30" title="L36-37-1">
+        <g id="228" class="nad-vl0to30" title="L36-37-1">
             <g>
                 <polyline points="-2.25,-12.64 -1.80,-10.68"/>
             </g>
@@ -510,7 +512,7 @@
                 <polyline points="-1.36,-8.72 -1.80,-10.68"/>
             </g>
         </g>
-        <g id="172" class="nad-vl0to30" title="L36-40-1">
+        <g id="229" class="nad-vl0to30" title="L36-40-1">
             <g>
                 <polyline points="-2.25,-12.64 -4.22,-12.63"/>
             </g>
@@ -518,7 +520,7 @@
                 <polyline points="-6.20,-12.61 -4.22,-12.63"/>
             </g>
         </g>
-        <g id="173" class="nad-vl0to30" title="L37-38-1">
+        <g id="230" class="nad-vl0to30" title="L37-38-1">
             <g>
                 <polyline points="-1.36,-8.72 -0.84,-6.32"/>
             </g>
@@ -526,7 +528,7 @@
                 <polyline points="-0.32,-3.93 -0.84,-6.32"/>
             </g>
         </g>
-        <g id="174" class="nad-vl0to30" title="L37-39-1">
+        <g id="231" class="nad-vl0to30" title="L37-39-1">
             <g>
                 <polyline points="-1.36,-8.72 -2.66,-9.16"/>
             </g>
@@ -534,7 +536,7 @@
                 <polyline points="-3.95,-9.60 -2.66,-9.16"/>
             </g>
         </g>
-        <g id="175" class="nad-vl0to30" title="L38-44-1">
+        <g id="232" class="nad-vl0to30" title="L38-44-1">
             <g>
                 <polyline points="-0.32,-3.93 0.10,-2.31"/>
             </g>
@@ -542,7 +544,7 @@
                 <polyline points="0.52,-0.69 0.10,-2.31"/>
             </g>
         </g>
-        <g id="176" class="nad-vl0to30" title="L38-49-1">
+        <g id="233" class="nad-vl0to30" title="L38-49-1">
             <g>
                 <polyline points="-0.32,-3.93 -3.01,-2.70"/>
             </g>
@@ -550,7 +552,7 @@
                 <polyline points="-5.70,-1.46 -3.01,-2.70"/>
             </g>
         </g>
-        <g id="177" class="nad-vl0to30" title="L38-48-1">
+        <g id="234" class="nad-vl0to30" title="L38-48-1">
             <g>
                 <polyline points="-0.32,-3.93 -1.81,-3.88"/>
             </g>
@@ -558,7 +560,7 @@
                 <polyline points="-3.31,-3.83 -1.81,-3.88"/>
             </g>
         </g>
-        <g id="178" title="T39-57-1">
+        <g id="235" title="T39-57-1">
             <g class="nad-vl0to30">
                 <polyline points="-3.95,-9.60 -5.34,-9.75"/>
                 <circle cx="-5.24" cy="-9.74" r="0.20"/>
@@ -568,7 +570,7 @@
                 <circle cx="-5.44" cy="-9.76" r="0.20"/>
             </g>
         </g>
-        <g id="179" title="T40-56-1">
+        <g id="236" title="T40-56-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.20,-12.61 -7.66,-11.02"/>
                 <circle cx="-7.59" cy="-11.10" r="0.20"/>
@@ -578,7 +580,7 @@
                 <circle cx="-7.73" cy="-10.95" r="0.20"/>
             </g>
         </g>
-        <g id="180" class="nad-vl0to30" title="L41-42-1">
+        <g id="237" class="nad-vl0to30" title="L41-42-1">
             <g>
                 <polyline points="-10.12,-5.40 -10.79,-6.74"/>
             </g>
@@ -586,7 +588,7 @@
                 <polyline points="-11.47,-8.07 -10.79,-6.74"/>
             </g>
         </g>
-        <g id="181" class="nad-vl0to30" title="L41-43-1">
+        <g id="238" class="nad-vl0to30" title="L41-43-1">
             <g>
                 <polyline points="-10.12,-5.40 -10.46,-4.17"/>
             </g>
@@ -594,7 +596,7 @@
                 <polyline points="-10.79,-2.94 -10.46,-4.17"/>
             </g>
         </g>
-        <g id="182" class="nad-vl0to30" title="L56-41-1">
+        <g id="239" class="nad-vl0to30" title="L56-41-1">
             <g>
                 <polyline points="-9.12,-9.43 -9.62,-7.41"/>
             </g>
@@ -602,7 +604,7 @@
                 <polyline points="-10.12,-5.40 -9.62,-7.41"/>
             </g>
         </g>
-        <g id="183" class="nad-vl0to30" title="L56-42-1">
+        <g id="240" class="nad-vl0to30" title="L56-42-1">
             <g>
                 <polyline points="-9.12,-9.43 -10.29,-8.75"/>
             </g>
@@ -610,7 +612,7 @@
                 <polyline points="-11.47,-8.07 -10.29,-8.75"/>
             </g>
         </g>
-        <g id="184" class="nad-vl0to30" title="L44-45-1">
+        <g id="241" class="nad-vl0to30" title="L44-45-1">
             <g>
                 <polyline points="0.52,-0.69 -0.30,1.09"/>
             </g>
@@ -618,7 +620,7 @@
                 <polyline points="-1.12,2.87 -0.30,1.09"/>
             </g>
         </g>
-        <g id="185" class="nad-vl0to30" title="L46-47-1">
+        <g id="242" class="nad-vl0to30" title="L46-47-1">
             <g>
                 <polyline points="-3.48,0.72 -3.08,-0.52"/>
             </g>
@@ -626,7 +628,7 @@
                 <polyline points="-2.69,-1.76 -3.08,-0.52"/>
             </g>
         </g>
-        <g id="186" class="nad-vl0to30" title="L47-48-1">
+        <g id="243" class="nad-vl0to30" title="L47-48-1">
             <g>
                 <polyline points="-2.69,-1.76 -3.00,-2.80"/>
             </g>
@@ -634,7 +636,7 @@
                 <polyline points="-3.31,-3.83 -3.00,-2.80"/>
             </g>
         </g>
-        <g id="187" class="nad-vl0to30" title="L48-49-1">
+        <g id="244" class="nad-vl0to30" title="L48-49-1">
             <g>
                 <polyline points="-3.31,-3.83 -4.50,-2.65"/>
             </g>
@@ -642,7 +644,7 @@
                 <polyline points="-5.70,-1.46 -4.50,-2.65"/>
             </g>
         </g>
-        <g id="188" class="nad-vl0to30" title="L49-50-1">
+        <g id="245" class="nad-vl0to30" title="L49-50-1">
             <g>
                 <polyline points="-5.70,-1.46 -8.20,-0.58"/>
             </g>
@@ -650,7 +652,7 @@
                 <polyline points="-10.70,0.31 -8.20,-0.58"/>
             </g>
         </g>
-        <g id="189" class="nad-vl0to30" title="L50-51-1">
+        <g id="246" class="nad-vl0to30" title="L50-51-1">
             <g>
                 <polyline points="-10.70,0.31 -11.67,1.50"/>
             </g>
@@ -658,7 +660,7 @@
                 <polyline points="-12.64,2.69 -11.67,1.50"/>
             </g>
         </g>
-        <g id="190" class="nad-vl0to30" title="L52-53-1">
+        <g id="247" class="nad-vl0to30" title="L52-53-1">
             <g>
                 <polyline points="6.72,4.66 5.48,4.48"/>
             </g>
@@ -666,7 +668,7 @@
                 <polyline points="4.24,4.30 5.48,4.48"/>
             </g>
         </g>
-        <g id="191" class="nad-vl0to30" title="L53-54-1">
+        <g id="248" class="nad-vl0to30" title="L53-54-1">
             <g>
                 <polyline points="4.24,4.30 2.88,4.72"/>
             </g>
@@ -674,7 +676,7 @@
                 <polyline points="1.52,5.13 2.88,4.72"/>
             </g>
         </g>
-        <g id="192" class="nad-vl0to30" title="L54-55-1">
+        <g id="249" class="nad-vl0to30" title="L54-55-1">
             <g>
                 <polyline points="1.52,5.13 -0.19,5.43"/>
             </g>
@@ -682,7 +684,7 @@
                 <polyline points="-1.90,5.73 -0.19,5.43"/>
             </g>
         </g>
-        <g id="193" class="nad-vl0to30" title="L57-56-1">
+        <g id="250" class="nad-vl0to30" title="L57-56-1">
             <g>
                 <polyline points="-6.73,-9.90 -7.93,-9.66"/>
             </g>
@@ -693,232 +695,578 @@
     </g>
     <g class="nad-vl-nodes">
         <g transform="translate(-7.03,10.20)">
-            <circle id="0" class="nad-vl0to30" title="VL1" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="1" class="nad-vl0to30" title="VL1" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.14,12.72)">
-            <circle id="2" class="nad-vl0to30" title="VL2" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="4" class="nad-vl0to30" title="VL2" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.40,11.54)">
-            <circle id="4" class="nad-vl0to30" title="VL3" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="7" class="nad-vl0to30" title="VL3" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.83,13.29)">
-            <circle id="6" class="nad-vl0to30" title="VL4" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="10" class="nad-vl0to30" title="VL4" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.21,14.80)">
-            <circle id="8" class="nad-vl0to30" title="VL5" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="13" class="nad-vl0to30" title="VL5" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(2.46,11.32)">
-            <circle id="10" class="nad-vl0to30" title="VL6" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="16" class="nad-vl0to30" title="VL6" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.08,8.85)">
-            <circle id="12" class="nad-vl0to30" title="VL7" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="19" class="nad-vl0to30" title="VL7" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.09,8.68)">
-            <circle id="14" class="nad-vl0to30" title="VL8" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="22" class="nad-vl0to30" title="VL8" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.18,5.19)">
-            <circle id="16" class="nad-vl0to30" title="VL9" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="25" class="nad-vl0to30" title="VL9" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.33,4.82)">
-            <circle id="18" class="nad-vl0to30" title="VL10" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="28" class="nad-vl0to30" title="VL10" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.56,-0.23)">
-            <circle id="20" class="nad-vl0to30" title="VL11" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="31" class="nad-vl0to30" title="VL11" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-8.83,6.82)">
-            <circle id="22" class="nad-vl0to30" title="VL12" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="34" class="nad-vl0to30" title="VL12" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.88,3.07)">
-            <circle id="24" class="nad-vl0to30" title="VL13" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="37" class="nad-vl0to30" title="VL13" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.46,3.45)">
-            <circle id="26" class="nad-vl0to30" title="VL14" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="40" class="nad-vl0to30" title="VL14" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-4.33,6.84)">
-            <circle id="28" class="nad-vl0to30" title="VL15" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="43" class="nad-vl0to30" title="VL15" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.33,10.78)">
-            <circle id="30" class="nad-vl0to30" title="VL16" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="46" class="nad-vl0to30" title="VL16" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.30,8.99)">
-            <circle id="32" class="nad-vl0to30" title="VL17" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="49" class="nad-vl0to30" title="VL17" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.49,12.74)">
-            <circle id="34" class="nad-vl0to30" title="VL18" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="52" class="nad-vl0to30" title="VL18" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(9.54,10.26)">
-            <circle id="36" class="nad-vl0to30" title="VL19" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="55" class="nad-vl0to30" title="VL19" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(10.49,6.18)">
-            <circle id="38" class="nad-vl0to30" title="VL20" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="58" class="nad-vl0to30" title="VL20" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.54,1.31)">
-            <circle id="40" class="nad-vl0to30" title="VL21" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="61" class="nad-vl0to30" title="VL21" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(5.62,-2.58)">
-            <circle id="42" class="nad-vl0to30" title="VL22" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="64" class="nad-vl0to30" title="VL22" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.93,-4.35)">
-            <circle id="44" class="nad-vl0to30" title="VL23" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="67" class="nad-vl0to30" title="VL23" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(12.23,-5.38)">
-            <circle id="46" class="nad-vl0to30" title="VL24" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="70" class="nad-vl0to30" title="VL24" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(12.54,-8.75)">
-            <circle id="48" class="nad-vl0to30" title="VL25" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="73" class="nad-vl0to30" title="VL25" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(14.12,-2.50)">
-            <circle id="50" class="nad-vl0to30" title="VL26" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="76" class="nad-vl0to30" title="VL26" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(14.13,0.81)">
-            <circle id="52" class="nad-vl0to30" title="VL27" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="79" class="nad-vl0to30" title="VL27" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(12.13,3.77)">
-            <circle id="54" class="nad-vl0to30" title="VL28" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="82" class="nad-vl0to30" title="VL28" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(8.10,6.52)">
-            <circle id="56" class="nad-vl0to30" title="VL29" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="85" class="nad-vl0to30" title="VL29" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(11.58,-11.77)">
-            <circle id="58" class="nad-vl0to30" title="VL30" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="88" class="nad-vl0to30" title="VL30" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(9.57,-14.22)">
-            <circle id="60" class="nad-vl0to30" title="VL31" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="91" class="nad-vl0to30" title="VL31" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.90,-16.19)">
-            <circle id="62" class="nad-vl0to30" title="VL32" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="94" class="nad-vl0to30" title="VL32" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(7.62,-18.78)">
-            <circle id="64" class="nad-vl0to30" title="VL33" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="97" class="nad-vl0to30" title="VL33" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(3.58,-15.95)">
-            <circle id="66" class="nad-vl0to30" title="VL34" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="100" class="nad-vl0to30" title="VL34" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.50,-14.87)">
-            <circle id="68" class="nad-vl0to30" title="VL35" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="103" class="nad-vl0to30" title="VL35" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.25,-12.64)">
-            <circle id="70" class="nad-vl0to30" title="VL36" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="106" class="nad-vl0to30" title="VL36" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.36,-8.72)">
-            <circle id="72" class="nad-vl0to30" title="VL37" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="109" class="nad-vl0to30" title="VL37" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-0.32,-3.93)">
-            <circle id="74" class="nad-vl0to30" title="VL38" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="112" class="nad-vl0to30" title="VL38" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.95,-9.60)">
-            <circle id="76" class="nad-vl0to30" title="VL39" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="115" class="nad-vl0to30" title="VL39" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.20,-12.61)">
-            <circle id="78" class="nad-vl0to30" title="VL40" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="118" class="nad-vl0to30" title="VL40" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.12,-5.40)">
-            <circle id="80" class="nad-vl0to30" title="VL41" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="121" class="nad-vl0to30" title="VL41" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-11.47,-8.07)">
-            <circle id="82" class="nad-vl0to30" title="VL42" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="124" class="nad-vl0to30" title="VL42" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.79,-2.94)">
-            <circle id="84" class="nad-vl0to30" title="VL43" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="127" class="nad-vl0to30" title="VL43" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(0.52,-0.69)">
-            <circle id="86" class="nad-vl0to30" title="VL44" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="130" class="nad-vl0to30" title="VL44" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.12,2.87)">
-            <circle id="88" class="nad-vl0to30" title="VL45" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="133" class="nad-vl0to30" title="VL45" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.48,0.72)">
-            <circle id="90" class="nad-vl0to30" title="VL46" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="136" class="nad-vl0to30" title="VL46" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-2.69,-1.76)">
-            <circle id="92" class="nad-vl0to30" title="VL47" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="139" class="nad-vl0to30" title="VL47" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-3.31,-3.83)">
-            <circle id="94" class="nad-vl0to30" title="VL48" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="142" class="nad-vl0to30" title="VL48" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-5.70,-1.46)">
-            <circle id="96" class="nad-vl0to30" title="VL49" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="145" class="nad-vl0to30" title="VL49" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-10.70,0.31)">
-            <circle id="98" class="nad-vl0to30" title="VL50" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="148" class="nad-vl0to30" title="VL50" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-12.64,2.69)">
-            <circle id="100" class="nad-vl0to30" title="VL51" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="151" class="nad-vl0to30" title="VL51" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(6.72,4.66)">
-            <circle id="102" class="nad-vl0to30" title="VL52" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="154" class="nad-vl0to30" title="VL52" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(4.24,4.30)">
-            <circle id="104" class="nad-vl0to30" title="VL53" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="157" class="nad-vl0to30" title="VL53" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(1.52,5.13)">
-            <circle id="106" class="nad-vl0to30" title="VL54" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="160" class="nad-vl0to30" title="VL54" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-1.90,5.73)">
-            <circle id="108" class="nad-vl0to30" title="VL55" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="163" class="nad-vl0to30" title="VL55" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-9.12,-9.43)">
-            <circle id="110" class="nad-vl0to30" title="VL56" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="166" class="nad-vl0to30" title="VL56" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
         <g transform="translate(-6.73,-9.90)">
-            <circle id="112" class="nad-vl0to30" title="VL57" r="0.60"/>
-            <text style="text-anchor:middle;dominant-baseline:middle">1</text>
+            <circle id="169" class="nad-vl0to30" title="VL57" r="0.60"/>
+            <text class="nad-text-buses" style="text-anchor:middle;dominant-baseline:middle">1</text>
         </g>
+    </g>
+    <g class="nad-text-edges">
+        <g id="0_edge">
+            <g>
+                <polyline points="-6.43,10.20 -6.03,10.20"/>
+            </g>
+        </g>
+        <g id="3_edge">
+            <g>
+                <polyline points="-4.54,12.72 -4.14,12.72"/>
+            </g>
+        </g>
+        <g id="6_edge">
+            <g>
+                <polyline points="-1.80,11.54 -1.40,11.54"/>
+            </g>
+        </g>
+        <g id="9_edge">
+            <g>
+                <polyline points="2.43,13.29 2.83,13.29"/>
+            </g>
+        </g>
+        <g id="12_edge">
+            <g>
+                <polyline points="3.81,14.80 4.21,14.80"/>
+            </g>
+        </g>
+        <g id="15_edge">
+            <g>
+                <polyline points="3.06,11.32 3.46,11.32"/>
+            </g>
+        </g>
+        <g id="18_edge">
+            <g>
+                <polyline points="4.68,8.85 5.08,8.85"/>
+            </g>
+        </g>
+        <g id="21_edge">
+            <g>
+                <polyline points="0.51,8.68 0.91,8.68"/>
+            </g>
+        </g>
+        <g id="24_edge">
+            <g>
+                <polyline points="-5.58,5.19 -5.18,5.19"/>
+            </g>
+        </g>
+        <g id="27_edge">
+            <g>
+                <polyline points="-9.73,4.82 -9.33,4.82"/>
+            </g>
+        </g>
+        <g id="30_edge">
+            <g>
+                <polyline points="-7.96,-0.23 -7.56,-0.23"/>
+            </g>
+        </g>
+        <g id="33_edge">
+            <g>
+                <polyline points="-8.23,6.82 -7.83,6.82"/>
+            </g>
+        </g>
+        <g id="36_edge">
+            <g>
+                <polyline points="-6.28,3.07 -5.88,3.07"/>
+            </g>
+        </g>
+        <g id="39_edge">
+            <g>
+                <polyline points="-3.86,3.45 -3.46,3.45"/>
+            </g>
+        </g>
+        <g id="42_edge">
+            <g>
+                <polyline points="-3.73,6.84 -3.33,6.84"/>
+            </g>
+        </g>
+        <g id="45_edge">
+            <g>
+                <polyline points="-8.73,10.78 -8.33,10.78"/>
+            </g>
+        </g>
+        <g id="48_edge">
+            <g>
+                <polyline points="-9.70,8.99 -9.30,8.99"/>
+            </g>
+        </g>
+        <g id="51_edge">
+            <g>
+                <polyline points="7.09,12.74 7.49,12.74"/>
+            </g>
+        </g>
+        <g id="54_edge">
+            <g>
+                <polyline points="10.14,10.26 10.54,10.26"/>
+            </g>
+        </g>
+        <g id="57_edge">
+            <g>
+                <polyline points="11.09,6.18 11.49,6.18"/>
+            </g>
+        </g>
+        <g id="60_edge">
+            <g>
+                <polyline points="9.14,1.31 9.54,1.31"/>
+            </g>
+        </g>
+        <g id="63_edge">
+            <g>
+                <polyline points="6.22,-2.58 6.62,-2.58"/>
+            </g>
+        </g>
+        <g id="66_edge">
+            <g>
+                <polyline points="9.53,-4.35 9.93,-4.35"/>
+            </g>
+        </g>
+        <g id="69_edge">
+            <g>
+                <polyline points="12.83,-5.38 13.23,-5.38"/>
+            </g>
+        </g>
+        <g id="72_edge">
+            <g>
+                <polyline points="13.14,-8.75 13.54,-8.75"/>
+            </g>
+        </g>
+        <g id="75_edge">
+            <g>
+                <polyline points="14.72,-2.50 15.12,-2.50"/>
+            </g>
+        </g>
+        <g id="78_edge">
+            <g>
+                <polyline points="14.73,0.81 15.13,0.81"/>
+            </g>
+        </g>
+        <g id="81_edge">
+            <g>
+                <polyline points="12.73,3.77 13.13,3.77"/>
+            </g>
+        </g>
+        <g id="84_edge">
+            <g>
+                <polyline points="8.70,6.52 9.10,6.52"/>
+            </g>
+        </g>
+        <g id="87_edge">
+            <g>
+                <polyline points="12.18,-11.77 12.58,-11.77"/>
+            </g>
+        </g>
+        <g id="90_edge">
+            <g>
+                <polyline points="10.17,-14.22 10.57,-14.22"/>
+            </g>
+        </g>
+        <g id="93_edge">
+            <g>
+                <polyline points="7.50,-16.19 7.90,-16.19"/>
+            </g>
+        </g>
+        <g id="96_edge">
+            <g>
+                <polyline points="8.22,-18.78 8.62,-18.78"/>
+            </g>
+        </g>
+        <g id="99_edge">
+            <g>
+                <polyline points="4.18,-15.95 4.58,-15.95"/>
+            </g>
+        </g>
+        <g id="102_edge">
+            <g>
+                <polyline points="1.10,-14.87 1.50,-14.87"/>
+            </g>
+        </g>
+        <g id="105_edge">
+            <g>
+                <polyline points="-1.65,-12.64 -1.25,-12.64"/>
+            </g>
+        </g>
+        <g id="108_edge">
+            <g>
+                <polyline points="-0.76,-8.72 -0.36,-8.72"/>
+            </g>
+        </g>
+        <g id="111_edge">
+            <g>
+                <polyline points="0.28,-3.93 0.68,-3.93"/>
+            </g>
+        </g>
+        <g id="114_edge">
+            <g>
+                <polyline points="-3.35,-9.60 -2.95,-9.60"/>
+            </g>
+        </g>
+        <g id="117_edge">
+            <g>
+                <polyline points="-5.60,-12.61 -5.20,-12.61"/>
+            </g>
+        </g>
+        <g id="120_edge">
+            <g>
+                <polyline points="-9.52,-5.40 -9.12,-5.40"/>
+            </g>
+        </g>
+        <g id="123_edge">
+            <g>
+                <polyline points="-10.87,-8.07 -10.47,-8.07"/>
+            </g>
+        </g>
+        <g id="126_edge">
+            <g>
+                <polyline points="-10.19,-2.94 -9.79,-2.94"/>
+            </g>
+        </g>
+        <g id="129_edge">
+            <g>
+                <polyline points="1.12,-0.69 1.52,-0.69"/>
+            </g>
+        </g>
+        <g id="132_edge">
+            <g>
+                <polyline points="-0.52,2.87 -0.12,2.87"/>
+            </g>
+        </g>
+        <g id="135_edge">
+            <g>
+                <polyline points="-2.88,0.72 -2.48,0.72"/>
+            </g>
+        </g>
+        <g id="138_edge">
+            <g>
+                <polyline points="-2.09,-1.76 -1.69,-1.76"/>
+            </g>
+        </g>
+        <g id="141_edge">
+            <g>
+                <polyline points="-2.71,-3.83 -2.31,-3.83"/>
+            </g>
+        </g>
+        <g id="144_edge">
+            <g>
+                <polyline points="-5.10,-1.46 -4.70,-1.46"/>
+            </g>
+        </g>
+        <g id="147_edge">
+            <g>
+                <polyline points="-10.10,0.31 -9.70,0.31"/>
+            </g>
+        </g>
+        <g id="150_edge">
+            <g>
+                <polyline points="-12.04,2.69 -11.64,2.69"/>
+            </g>
+        </g>
+        <g id="153_edge">
+            <g>
+                <polyline points="7.32,4.66 7.72,4.66"/>
+            </g>
+        </g>
+        <g id="156_edge">
+            <g>
+                <polyline points="4.84,4.30 5.24,4.30"/>
+            </g>
+        </g>
+        <g id="159_edge">
+            <g>
+                <polyline points="2.12,5.13 2.52,5.13"/>
+            </g>
+        </g>
+        <g id="162_edge">
+            <g>
+                <polyline points="-1.30,5.73 -0.90,5.73"/>
+            </g>
+        </g>
+        <g id="165_edge">
+            <g>
+                <polyline points="-8.52,-9.43 -8.12,-9.43"/>
+            </g>
+        </g>
+        <g id="168_edge">
+            <g>
+                <polyline points="-6.13,-9.90 -5.73,-9.90"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-nodes">
+        <text transform="translate(-6.03,10.20)" style="dominant-baseline:middle">VL1</text>
+        <text transform="translate(-4.14,12.72)" style="dominant-baseline:middle">VL2</text>
+        <text transform="translate(-1.40,11.54)" style="dominant-baseline:middle">VL3</text>
+        <text transform="translate(2.83,13.29)" style="dominant-baseline:middle">VL4</text>
+        <text transform="translate(4.21,14.80)" style="dominant-baseline:middle">VL5</text>
+        <text transform="translate(3.46,11.32)" style="dominant-baseline:middle">VL6</text>
+        <text transform="translate(5.08,8.85)" style="dominant-baseline:middle">VL7</text>
+        <text transform="translate(0.91,8.68)" style="dominant-baseline:middle">VL8</text>
+        <text transform="translate(-5.18,5.19)" style="dominant-baseline:middle">VL9</text>
+        <text transform="translate(-9.33,4.82)" style="dominant-baseline:middle">VL10</text>
+        <text transform="translate(-7.56,-0.23)" style="dominant-baseline:middle">VL11</text>
+        <text transform="translate(-7.83,6.82)" style="dominant-baseline:middle">VL12</text>
+        <text transform="translate(-5.88,3.07)" style="dominant-baseline:middle">VL13</text>
+        <text transform="translate(-3.46,3.45)" style="dominant-baseline:middle">VL14</text>
+        <text transform="translate(-3.33,6.84)" style="dominant-baseline:middle">VL15</text>
+        <text transform="translate(-8.33,10.78)" style="dominant-baseline:middle">VL16</text>
+        <text transform="translate(-9.30,8.99)" style="dominant-baseline:middle">VL17</text>
+        <text transform="translate(7.49,12.74)" style="dominant-baseline:middle">VL18</text>
+        <text transform="translate(10.54,10.26)" style="dominant-baseline:middle">VL19</text>
+        <text transform="translate(11.49,6.18)" style="dominant-baseline:middle">VL20</text>
+        <text transform="translate(9.54,1.31)" style="dominant-baseline:middle">VL21</text>
+        <text transform="translate(6.62,-2.58)" style="dominant-baseline:middle">VL22</text>
+        <text transform="translate(9.93,-4.35)" style="dominant-baseline:middle">VL23</text>
+        <text transform="translate(13.23,-5.38)" style="dominant-baseline:middle">VL24</text>
+        <text transform="translate(13.54,-8.75)" style="dominant-baseline:middle">VL25</text>
+        <text transform="translate(15.12,-2.50)" style="dominant-baseline:middle">VL26</text>
+        <text transform="translate(15.13,0.81)" style="dominant-baseline:middle">VL27</text>
+        <text transform="translate(13.13,3.77)" style="dominant-baseline:middle">VL28</text>
+        <text transform="translate(9.10,6.52)" style="dominant-baseline:middle">VL29</text>
+        <text transform="translate(12.58,-11.77)" style="dominant-baseline:middle">VL30</text>
+        <text transform="translate(10.57,-14.22)" style="dominant-baseline:middle">VL31</text>
+        <text transform="translate(7.90,-16.19)" style="dominant-baseline:middle">VL32</text>
+        <text transform="translate(8.62,-18.78)" style="dominant-baseline:middle">VL33</text>
+        <text transform="translate(4.58,-15.95)" style="dominant-baseline:middle">VL34</text>
+        <text transform="translate(1.50,-14.87)" style="dominant-baseline:middle">VL35</text>
+        <text transform="translate(-1.25,-12.64)" style="dominant-baseline:middle">VL36</text>
+        <text transform="translate(-0.36,-8.72)" style="dominant-baseline:middle">VL37</text>
+        <text transform="translate(0.68,-3.93)" style="dominant-baseline:middle">VL38</text>
+        <text transform="translate(-2.95,-9.60)" style="dominant-baseline:middle">VL39</text>
+        <text transform="translate(-5.20,-12.61)" style="dominant-baseline:middle">VL40</text>
+        <text transform="translate(-9.12,-5.40)" style="dominant-baseline:middle">VL41</text>
+        <text transform="translate(-10.47,-8.07)" style="dominant-baseline:middle">VL42</text>
+        <text transform="translate(-9.79,-2.94)" style="dominant-baseline:middle">VL43</text>
+        <text transform="translate(1.52,-0.69)" style="dominant-baseline:middle">VL44</text>
+        <text transform="translate(-0.12,2.87)" style="dominant-baseline:middle">VL45</text>
+        <text transform="translate(-2.48,0.72)" style="dominant-baseline:middle">VL46</text>
+        <text transform="translate(-1.69,-1.76)" style="dominant-baseline:middle">VL47</text>
+        <text transform="translate(-2.31,-3.83)" style="dominant-baseline:middle">VL48</text>
+        <text transform="translate(-4.70,-1.46)" style="dominant-baseline:middle">VL49</text>
+        <text transform="translate(-9.70,0.31)" style="dominant-baseline:middle">VL50</text>
+        <text transform="translate(-11.64,2.69)" style="dominant-baseline:middle">VL51</text>
+        <text transform="translate(7.72,4.66)" style="dominant-baseline:middle">VL52</text>
+        <text transform="translate(5.24,4.30)" style="dominant-baseline:middle">VL53</text>
+        <text transform="translate(2.52,5.13)" style="dominant-baseline:middle">VL54</text>
+        <text transform="translate(-0.90,5.73)" style="dominant-baseline:middle">VL55</text>
+        <text transform="translate(-8.12,-9.43)" style="dominant-baseline:middle">VL56</text>
+        <text transform="translate(-5.73,-9.90)" style="dominant-baseline:middle">VL57</text>
     </g>
 </svg>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -1211,62 +1211,62 @@
         </g>
     </g>
     <g class="nad-text-nodes">
-        <text transform="translate(-6.03,10.20)" style="dominant-baseline:middle">VL1</text>
-        <text transform="translate(-4.14,12.72)" style="dominant-baseline:middle">VL2</text>
-        <text transform="translate(-1.40,11.54)" style="dominant-baseline:middle">VL3</text>
-        <text transform="translate(2.83,13.29)" style="dominant-baseline:middle">VL4</text>
-        <text transform="translate(4.21,14.80)" style="dominant-baseline:middle">VL5</text>
-        <text transform="translate(3.46,11.32)" style="dominant-baseline:middle">VL6</text>
-        <text transform="translate(5.08,8.85)" style="dominant-baseline:middle">VL7</text>
-        <text transform="translate(0.91,8.68)" style="dominant-baseline:middle">VL8</text>
-        <text transform="translate(-5.18,5.19)" style="dominant-baseline:middle">VL9</text>
-        <text transform="translate(-9.33,4.82)" style="dominant-baseline:middle">VL10</text>
-        <text transform="translate(-7.56,-0.23)" style="dominant-baseline:middle">VL11</text>
-        <text transform="translate(-7.83,6.82)" style="dominant-baseline:middle">VL12</text>
-        <text transform="translate(-5.88,3.07)" style="dominant-baseline:middle">VL13</text>
-        <text transform="translate(-3.46,3.45)" style="dominant-baseline:middle">VL14</text>
-        <text transform="translate(-3.33,6.84)" style="dominant-baseline:middle">VL15</text>
-        <text transform="translate(-8.33,10.78)" style="dominant-baseline:middle">VL16</text>
-        <text transform="translate(-9.30,8.99)" style="dominant-baseline:middle">VL17</text>
-        <text transform="translate(7.49,12.74)" style="dominant-baseline:middle">VL18</text>
-        <text transform="translate(10.54,10.26)" style="dominant-baseline:middle">VL19</text>
-        <text transform="translate(11.49,6.18)" style="dominant-baseline:middle">VL20</text>
-        <text transform="translate(9.54,1.31)" style="dominant-baseline:middle">VL21</text>
-        <text transform="translate(6.62,-2.58)" style="dominant-baseline:middle">VL22</text>
-        <text transform="translate(9.93,-4.35)" style="dominant-baseline:middle">VL23</text>
-        <text transform="translate(13.23,-5.38)" style="dominant-baseline:middle">VL24</text>
-        <text transform="translate(13.54,-8.75)" style="dominant-baseline:middle">VL25</text>
-        <text transform="translate(15.12,-2.50)" style="dominant-baseline:middle">VL26</text>
-        <text transform="translate(15.13,0.81)" style="dominant-baseline:middle">VL27</text>
-        <text transform="translate(13.13,3.77)" style="dominant-baseline:middle">VL28</text>
-        <text transform="translate(9.10,6.52)" style="dominant-baseline:middle">VL29</text>
-        <text transform="translate(12.58,-11.77)" style="dominant-baseline:middle">VL30</text>
-        <text transform="translate(10.57,-14.22)" style="dominant-baseline:middle">VL31</text>
-        <text transform="translate(7.90,-16.19)" style="dominant-baseline:middle">VL32</text>
-        <text transform="translate(8.62,-18.78)" style="dominant-baseline:middle">VL33</text>
-        <text transform="translate(4.58,-15.95)" style="dominant-baseline:middle">VL34</text>
-        <text transform="translate(1.50,-14.87)" style="dominant-baseline:middle">VL35</text>
-        <text transform="translate(-1.25,-12.64)" style="dominant-baseline:middle">VL36</text>
-        <text transform="translate(-0.36,-8.72)" style="dominant-baseline:middle">VL37</text>
-        <text transform="translate(0.68,-3.93)" style="dominant-baseline:middle">VL38</text>
-        <text transform="translate(-2.95,-9.60)" style="dominant-baseline:middle">VL39</text>
-        <text transform="translate(-5.20,-12.61)" style="dominant-baseline:middle">VL40</text>
-        <text transform="translate(-9.12,-5.40)" style="dominant-baseline:middle">VL41</text>
-        <text transform="translate(-10.47,-8.07)" style="dominant-baseline:middle">VL42</text>
-        <text transform="translate(-9.79,-2.94)" style="dominant-baseline:middle">VL43</text>
-        <text transform="translate(1.52,-0.69)" style="dominant-baseline:middle">VL44</text>
-        <text transform="translate(-0.12,2.87)" style="dominant-baseline:middle">VL45</text>
-        <text transform="translate(-2.48,0.72)" style="dominant-baseline:middle">VL46</text>
-        <text transform="translate(-1.69,-1.76)" style="dominant-baseline:middle">VL47</text>
-        <text transform="translate(-2.31,-3.83)" style="dominant-baseline:middle">VL48</text>
-        <text transform="translate(-4.70,-1.46)" style="dominant-baseline:middle">VL49</text>
-        <text transform="translate(-9.70,0.31)" style="dominant-baseline:middle">VL50</text>
-        <text transform="translate(-11.64,2.69)" style="dominant-baseline:middle">VL51</text>
-        <text transform="translate(7.72,4.66)" style="dominant-baseline:middle">VL52</text>
-        <text transform="translate(5.24,4.30)" style="dominant-baseline:middle">VL53</text>
-        <text transform="translate(2.52,5.13)" style="dominant-baseline:middle">VL54</text>
-        <text transform="translate(-0.90,5.73)" style="dominant-baseline:middle">VL55</text>
-        <text transform="translate(-8.12,-9.43)" style="dominant-baseline:middle">VL56</text>
-        <text transform="translate(-5.73,-9.90)" style="dominant-baseline:middle">VL57</text>
+        <text x="-6.03" y="10.20" style="dominant-baseline:middle">VL1</text>
+        <text x="-4.14" y="12.72" style="dominant-baseline:middle">VL2</text>
+        <text x="-1.40" y="11.54" style="dominant-baseline:middle">VL3</text>
+        <text x="2.83" y="13.29" style="dominant-baseline:middle">VL4</text>
+        <text x="4.21" y="14.80" style="dominant-baseline:middle">VL5</text>
+        <text x="3.46" y="11.32" style="dominant-baseline:middle">VL6</text>
+        <text x="5.08" y="8.85" style="dominant-baseline:middle">VL7</text>
+        <text x="0.91" y="8.68" style="dominant-baseline:middle">VL8</text>
+        <text x="-5.18" y="5.19" style="dominant-baseline:middle">VL9</text>
+        <text x="-9.33" y="4.82" style="dominant-baseline:middle">VL10</text>
+        <text x="-7.56" y="-0.23" style="dominant-baseline:middle">VL11</text>
+        <text x="-7.83" y="6.82" style="dominant-baseline:middle">VL12</text>
+        <text x="-5.88" y="3.07" style="dominant-baseline:middle">VL13</text>
+        <text x="-3.46" y="3.45" style="dominant-baseline:middle">VL14</text>
+        <text x="-3.33" y="6.84" style="dominant-baseline:middle">VL15</text>
+        <text x="-8.33" y="10.78" style="dominant-baseline:middle">VL16</text>
+        <text x="-9.30" y="8.99" style="dominant-baseline:middle">VL17</text>
+        <text x="7.49" y="12.74" style="dominant-baseline:middle">VL18</text>
+        <text x="10.54" y="10.26" style="dominant-baseline:middle">VL19</text>
+        <text x="11.49" y="6.18" style="dominant-baseline:middle">VL20</text>
+        <text x="9.54" y="1.31" style="dominant-baseline:middle">VL21</text>
+        <text x="6.62" y="-2.58" style="dominant-baseline:middle">VL22</text>
+        <text x="9.93" y="-4.35" style="dominant-baseline:middle">VL23</text>
+        <text x="13.23" y="-5.38" style="dominant-baseline:middle">VL24</text>
+        <text x="13.54" y="-8.75" style="dominant-baseline:middle">VL25</text>
+        <text x="15.12" y="-2.50" style="dominant-baseline:middle">VL26</text>
+        <text x="15.13" y="0.81" style="dominant-baseline:middle">VL27</text>
+        <text x="13.13" y="3.77" style="dominant-baseline:middle">VL28</text>
+        <text x="9.10" y="6.52" style="dominant-baseline:middle">VL29</text>
+        <text x="12.58" y="-11.77" style="dominant-baseline:middle">VL30</text>
+        <text x="10.57" y="-14.22" style="dominant-baseline:middle">VL31</text>
+        <text x="7.90" y="-16.19" style="dominant-baseline:middle">VL32</text>
+        <text x="8.62" y="-18.78" style="dominant-baseline:middle">VL33</text>
+        <text x="4.58" y="-15.95" style="dominant-baseline:middle">VL34</text>
+        <text x="1.50" y="-14.87" style="dominant-baseline:middle">VL35</text>
+        <text x="-1.25" y="-12.64" style="dominant-baseline:middle">VL36</text>
+        <text x="-0.36" y="-8.72" style="dominant-baseline:middle">VL37</text>
+        <text x="0.68" y="-3.93" style="dominant-baseline:middle">VL38</text>
+        <text x="-2.95" y="-9.60" style="dominant-baseline:middle">VL39</text>
+        <text x="-5.20" y="-12.61" style="dominant-baseline:middle">VL40</text>
+        <text x="-9.12" y="-5.40" style="dominant-baseline:middle">VL41</text>
+        <text x="-10.47" y="-8.07" style="dominant-baseline:middle">VL42</text>
+        <text x="-9.79" y="-2.94" style="dominant-baseline:middle">VL43</text>
+        <text x="1.52" y="-0.69" style="dominant-baseline:middle">VL44</text>
+        <text x="-0.12" y="2.87" style="dominant-baseline:middle">VL45</text>
+        <text x="-2.48" y="0.72" style="dominant-baseline:middle">VL46</text>
+        <text x="-1.69" y="-1.76" style="dominant-baseline:middle">VL47</text>
+        <text x="-2.31" y="-3.83" style="dominant-baseline:middle">VL48</text>
+        <text x="-4.70" y="-1.46" style="dominant-baseline:middle">VL49</text>
+        <text x="-9.70" y="0.31" style="dominant-baseline:middle">VL50</text>
+        <text x="-11.64" y="2.69" style="dominant-baseline:middle">VL51</text>
+        <text x="7.72" y="4.66" style="dominant-baseline:middle">VL52</text>
+        <text x="5.24" y="4.30" style="dominant-baseline:middle">VL53</text>
+        <text x="2.52" y="5.13" style="dominant-baseline:middle">VL54</text>
+        <text x="-0.90" y="5.73" style="dominant-baseline:middle">VL55</text>
+        <text x="-8.12" y="-9.43" style="dominant-baseline:middle">VL56</text>
+        <text x="-5.73" y="-9.90" style="dominant-baseline:middle">VL57</text>
     </g>
 </svg>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No

**What kind of change does this PR introduce?**
Feature



**What is the current behavior?** 
No info is displayed about the voltage level (only number of buses)


**What is the new behavior (if this is a feature change)?**
Name of voltage level is displayed

![screenshot](https://user-images.githubusercontent.com/66690739/142893902-1c944c67-f290-4835-963e-2046c691ef03.png)


**Does this PR introduce a breaking change or deprecate an API?** 
No