### PR TITLE
Add active and reactive arrows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         </sonar.exclusions>
 
         <powsybl-core.version>4.5.0-RC1</powsybl-core.version>
+        <powsybl-olf.version>0.14.0</powsybl-olf.version>
         <junit-jupiter.version>5.8.1</junit-jupiter.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -140,6 +141,12 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-open-loadflow</artifactId>
+            <version>${powsybl-olf.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
+++ b/src/main/java/com/powsybl/nad/NetworkAreaDiagram.java
@@ -14,10 +14,7 @@ import com.powsybl.nad.layout.BasicForceLayoutFactory;
 import com.powsybl.nad.layout.LayoutFactory;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.model.Graph;
-import com.powsybl.nad.svg.DefaultStyleProvider;
-import com.powsybl.nad.svg.StyleProvider;
-import com.powsybl.nad.svg.SvgParameters;
-import com.powsybl.nad.svg.SvgWriter;
+import com.powsybl.nad.svg.*;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -51,16 +48,22 @@ public class NetworkAreaDiagram {
 
     public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters,
                                    StyleProvider styleProvider) {
-        draw(svgFile, svgParameters, layoutParameters, styleProvider, new BasicForceLayoutFactory());
+        draw(svgFile, svgParameters, layoutParameters, styleProvider, new DefaultLabelProvider(network));
     }
 
     public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters,
-                                   StyleProvider styleProvider, LayoutFactory layoutFactory) {
-        draw(svgFile, svgParameters, layoutParameters, styleProvider, layoutFactory, new IntIdProvider());
+                                   StyleProvider styleProvider, LabelProvider labelProvider) {
+        draw(svgFile, svgParameters, layoutParameters, styleProvider, labelProvider, new BasicForceLayoutFactory());
     }
 
     public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters,
-                                   StyleProvider styleProvider, LayoutFactory layoutFactory, IdProvider idProvider) {
+                                   StyleProvider styleProvider, LabelProvider labelProvider, LayoutFactory layoutFactory) {
+        draw(svgFile, svgParameters, layoutParameters, styleProvider, labelProvider, layoutFactory, new IntIdProvider());
+    }
+
+    public void draw(Path svgFile, SvgParameters svgParameters, LayoutParameters layoutParameters,
+                                   StyleProvider styleProvider, LabelProvider labelProvider, LayoutFactory layoutFactory,
+                                   IdProvider idProvider) {
         Objects.requireNonNull(svgFile);
         Objects.requireNonNull(layoutParameters);
         Objects.requireNonNull(svgParameters);
@@ -70,7 +73,7 @@ public class NetworkAreaDiagram {
 
         Graph graph = new NetworkGraphBuilder(network, idProvider).buildGraph();
         layoutFactory.create().run(graph, layoutParameters);
-        new SvgWriter(svgParameters, styleProvider).writeSvg(graph, svgFile);
+        new SvgWriter(svgParameters, styleProvider, labelProvider).writeSvg(graph, svgFile);
     }
 
     public void draw(Writer writer) {
@@ -87,19 +90,25 @@ public class NetworkAreaDiagram {
 
     public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters,
                      StyleProvider styleProvider) {
-        draw(writer, svgParameters, layoutParameters, styleProvider, new BasicForceLayoutFactory());
+        draw(writer, svgParameters, layoutParameters, styleProvider, new DefaultLabelProvider(network));
     }
 
     public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters,
-                     StyleProvider styleProvider, LayoutFactory layoutFactory) {
-        draw(writer, svgParameters, layoutParameters, styleProvider, layoutFactory, new IntIdProvider());
+                     StyleProvider styleProvider, LabelProvider labelProvider) {
+        draw(writer, svgParameters, layoutParameters, styleProvider, labelProvider, new BasicForceLayoutFactory());
     }
 
     public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters,
-                     StyleProvider styleProvider, LayoutFactory layoutFactory, IdProvider idProvider) {
+                     StyleProvider styleProvider, LabelProvider labelProvider, LayoutFactory layoutFactory) {
+        draw(writer, svgParameters, layoutParameters, styleProvider, labelProvider, layoutFactory, new IntIdProvider());
+    }
+
+    public void draw(Writer writer, SvgParameters svgParameters, LayoutParameters layoutParameters,
+                     StyleProvider styleProvider, LabelProvider labelProvider, LayoutFactory layoutFactory,
+                     IdProvider idProvider) {
         Graph graph = new NetworkGraphBuilder(network, idProvider).buildGraph();
         layoutFactory.create().run(graph, layoutParameters);
-        new SvgWriter(svgParameters, styleProvider).writeSvg(graph, writer);
+        new SvgWriter(svgParameters, styleProvider, labelProvider).writeSvg(graph, writer);
     }
 
     public String drawToString(SvgParameters svgParameters) {

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -22,14 +22,6 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractStyleProvider implements StyleProvider {
 
-    private static final String CLASSES_PREFIX = "nad-";
-    private static final String VOLTAGE_LEVEL_NODES_CLASS = CLASSES_PREFIX + "vl-nodes";
-    private static final String TEXT_NODES_CLASS = CLASSES_PREFIX + "text-nodes";
-    private static final String BUSES_TEXT_CLASS = CLASSES_PREFIX + "text-buses";
-    private static final String DISCONNECTED_SIDE_EDGE_CLASS = CLASSES_PREFIX + "disconnected";
-    private static final String BRANCH_EDGES_CLASS = CLASSES_PREFIX + "branch-edges";
-    private static final String TEXT_EDGES_CLASS = CLASSES_PREFIX + "text-edges";
-
     private final BaseVoltagesConfig baseVoltagesConfig;
 
     protected AbstractStyleProvider() {
@@ -69,31 +61,6 @@ public abstract class AbstractStyleProvider implements StyleProvider {
             getBaseVoltageStyle(nominalV).ifPresent(styles::add);
         }
         return styles;
-    }
-
-    @Override
-    public String getBranchEdgesStyle() {
-        return BRANCH_EDGES_CLASS;
-    }
-
-    @Override
-    public String getTextEdgesStyle() {
-        return TEXT_EDGES_CLASS;
-    }
-
-    @Override
-    public String getVoltageLevelNodesStyle() {
-        return VOLTAGE_LEVEL_NODES_CLASS;
-    }
-
-    @Override
-    public String getTextNodesStyle() {
-        return TEXT_NODES_CLASS;
-    }
-
-    @Override
-    public String getBusesTextStyle() {
-        return BUSES_TEXT_CLASS;
     }
 
     @Override

--- a/src/main/java/com/powsybl/nad/svg/DefaultLabelProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultLabelProvider.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import com.powsybl.nad.model.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class DefaultLabelProvider implements LabelProvider {
+    private final Network network;
+
+    public DefaultLabelProvider(Network network) {
+        this.network = network;
+    }
+
+    @Override
+    public List<EdgeInfo> getEdgeInfos(Graph graph, BranchEdge edge, BranchEdge.Side side) {
+        Branch<?> branch = network.getBranch(edge.getEquipmentId());
+        if (branch == null) {
+            throw new PowsyblException("Unknown branch '" + edge.getEquipmentId() + "'");
+        }
+        Terminal terminal = branch.getTerminal(getSideFromNadSide(side));
+        return Arrays.asList(new EdgeInfo(EdgeInfo.ACTIVE_POWER, terminal.getP()),
+                new EdgeInfo(EdgeInfo.REACTIVE_POWER, terminal.getQ()));
+    }
+
+    private static Branch.Side getSideFromNadSide(BranchEdge.Side side) {
+        return side == BranchEdge.Side.ONE ? Branch.Side.ONE : Branch.Side.TWO;
+    }
+
+    @Override
+    public String getArrowPathDIn() {
+        return "M-0.1 -0.1 H0.1 L0 0.1z";
+    }
+
+    @Override
+    public String getArrowPathDOut() {
+        return "M-0.1 0.1 H0.1 L0 -0.1z";
+    }
+}

--- a/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
@@ -34,12 +34,12 @@ public class DefaultStyleProvider extends AbstractStyleProvider {
     public List<String> getEdgeInfoStyles(EdgeInfo info) {
         List<String> styles = new LinkedList<>();
         if (info.getInfoType().equals(EdgeInfo.ACTIVE_POWER)) {
-            styles.add(AbstractStyleProvider.CLASSES_PREFIX + "active");
+            styles.add(CLASSES_PREFIX + "active");
         } else if (info.getInfoType().equals(EdgeInfo.REACTIVE_POWER)) {
-            styles.add(AbstractStyleProvider.CLASSES_PREFIX + "reactive");
+            styles.add(CLASSES_PREFIX + "reactive");
         }
         info.getDirection().ifPresent(direction -> styles.add(
-                AbstractStyleProvider.CLASSES_PREFIX + (direction == EdgeInfo.Direction.IN ? "state-in" : "state-out")));
+                CLASSES_PREFIX + (direction == EdgeInfo.Direction.IN ? "state-in" : "state-out")));
         return styles;
     }
 

--- a/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultStyleProvider.java
@@ -9,6 +9,7 @@ package com.powsybl.nad.svg;
 import com.powsybl.commons.config.BaseVoltagesConfig;
 
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -27,6 +28,19 @@ public class DefaultStyleProvider extends AbstractStyleProvider {
     @Override
     public List<String> getCssFilenames() {
         return Collections.singletonList("defaultStyle.css");
+    }
+
+    @Override
+    public List<String> getEdgeInfoStyles(EdgeInfo info) {
+        List<String> styles = new LinkedList<>();
+        if (info.getInfoType().equals(EdgeInfo.ACTIVE_POWER)) {
+            styles.add(AbstractStyleProvider.CLASSES_PREFIX + "active");
+        } else if (info.getInfoType().equals(EdgeInfo.REACTIVE_POWER)) {
+            styles.add(AbstractStyleProvider.CLASSES_PREFIX + "reactive");
+        }
+        info.getDirection().ifPresent(direction -> styles.add(
+                AbstractStyleProvider.CLASSES_PREFIX + (direction == EdgeInfo.Direction.IN ? "state-in" : "state-out")));
+        return styles;
     }
 
 }

--- a/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
+++ b/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import java.util.Optional;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class EdgeInfo {
+    static final String ACTIVE_POWER = "ActivePower";
+    static final String REACTIVE_POWER = "ReactivePower";
+
+    private final String infoType;
+    private final Direction arrowDirection;
+    private final String leftLabel;
+    private final String rightLabel;
+
+    public EdgeInfo(String infoType, Direction arrowDirection, String leftLabel, String rightLabel) {
+        this.infoType = infoType;
+        this.arrowDirection = arrowDirection;
+        this.leftLabel = leftLabel;
+        this.rightLabel = rightLabel;
+    }
+
+    public EdgeInfo(String infoType, double value) {
+        this(infoType, value < 0 ? Direction.IN : Direction.OUT, null, String.valueOf(Math.round(value)));
+    }
+
+    public String getInfoType() {
+        return infoType;
+    }
+
+    public Optional<Direction> getDirection() {
+        return Optional.ofNullable(arrowDirection);
+    }
+
+    public Optional<String> getLeftLabel() {
+        return Optional.ofNullable(leftLabel);
+    }
+
+    public Optional<String> getRightLabel() {
+        return Optional.ofNullable(rightLabel);
+    }
+
+    public enum Direction {
+        IN, OUT
+    }
+}

--- a/src/main/java/com/powsybl/nad/svg/LabelProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/LabelProvider.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.nad.model.BranchEdge;
+import com.powsybl.nad.model.Graph;
+
+import java.util.List;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public interface LabelProvider {
+    List<EdgeInfo> getEdgeInfos(Graph graph, BranchEdge edge, BranchEdge.Side side);
+
+    String getArrowPathDIn();
+
+    String getArrowPathDOut();
+}

--- a/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -16,24 +16,27 @@ import java.util.List;
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
 public interface StyleProvider {
+
+    String CLASSES_PREFIX = "nad-";
+    String VOLTAGE_LEVEL_NODES_CLASS = CLASSES_PREFIX + "vl-nodes";
+    String TEXT_NODES_CLASS = CLASSES_PREFIX + "text-nodes";
+    String BUSES_TEXT_CLASS = CLASSES_PREFIX + "text-buses";
+    String DISCONNECTED_SIDE_EDGE_CLASS = CLASSES_PREFIX + "disconnected";
+    String BRANCH_EDGES_CLASS = CLASSES_PREFIX + "branch-edges";
+    String TEXT_EDGES_CLASS = CLASSES_PREFIX + "text-edges";
+    String EDGE_INFOS_CLASS = CLASSES_PREFIX + "edge-infos";
+    String ARROW_IN_CLASS = CLASSES_PREFIX + "arrow-in";
+    String ARROW_OUT_CLASS = CLASSES_PREFIX + "arrow-out";
+
     List<String> getCssFilenames();
 
     String getStyleDefs();
 
     List<String> getNodeStyleClasses(Node node);
 
-    String getBranchEdgesStyle();
-
-    String getTextEdgesStyle();
-
-    String getVoltageLevelNodesStyle();
-
-    String getTextNodesStyle();
-
-    String getBusesTextStyle();
-
     List<String> getEdgeStyleClasses(Edge edge);
 
     List<String> getSideEdgeStyleClasses(BranchEdge edge, BranchEdge.Side side);
 
+    List<String> getEdgeInfoStyles(EdgeInfo info);
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -20,9 +20,11 @@ public class SvgParameters {
     private SizeConstraint sizeConstraint = SizeConstraint.NONE;
     private int fixedWidth = -1;
     private int fixedHeight = -1;
+    private double arrowShift = 0.3;
+    private double arrowLabelShift = 0.12;
 
     public enum CssLocation {
-        INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT;
+        INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT
     }
 
     public enum SizeConstraint {
@@ -94,4 +96,21 @@ public class SvgParameters {
         return this;
     }
 
+    public double getArrowShift() {
+        return arrowShift;
+    }
+
+    public SvgParameters setArrowShift(double arrowShift) {
+        this.arrowShift = arrowShift;
+        return this;
+    }
+
+    public double getArrowLabelShift() {
+        return arrowLabelShift;
+    }
+
+    public SvgParameters setArrowLabelShift(double arrowLabelShift) {
+        this.arrowLabelShift = arrowLabelShift;
+        return this;
+    }
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -147,7 +147,7 @@ public class SvgWriter {
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.EDGE_INFOS_CLASS);
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getTranslateString(getArrowCenter(edge, side)));
         double angle = getEdgeYAxisAngle(edge, side);
-        double textAngle = angle > Math.PI / 2 ? angle - Math.PI : (angle < -Math.PI / 2 ? angle + Math.PI : angle);
+        double textAngle = Math.abs(angle) > Math.PI / 2 ? angle - Math.signum(angle) * Math.PI : angle;
         for (EdgeInfo info : edgeInfos) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
             writer.writeAttribute(CLASS_ATTRIBUTE, String.join(" ", styleProvider.getEdgeInfoStyles(info)));

--- a/src/main/resources/defaultStyle.css
+++ b/src/main/resources/defaultStyle.css
@@ -3,8 +3,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/java/com/powsybl/nad/AbstractTest.java
+++ b/src/test/java/com/powsybl/nad/AbstractTest.java
@@ -13,6 +13,7 @@ import com.powsybl.nad.build.iidm.NetworkGraphBuilder;
 import com.powsybl.nad.layout.BasicForceLayout;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.model.Graph;
+import com.powsybl.nad.svg.LabelProvider;
 import com.powsybl.nad.svg.StyleProvider;
 import com.powsybl.nad.svg.SvgParameters;
 import com.powsybl.nad.svg.SvgWriter;
@@ -35,11 +36,13 @@ public abstract class AbstractTest {
 
     protected abstract StyleProvider getStyleProvider();
 
+    protected abstract LabelProvider getLabelProvider(Network network);
+
     protected String generateSvgString(Network network, String refFilename) {
         Graph graph = new NetworkGraphBuilder(network, new IntIdProvider()).buildGraph();
         new BasicForceLayout().run(graph, getLayoutParameters());
         StringWriter writer = new StringWriter();
-        new SvgWriter(getSvgParameters(), getStyleProvider()).writeSvg(graph, writer);
+        new SvgWriter(getSvgParameters(), getStyleProvider(), getLabelProvider(network)).writeSvg(graph, writer);
         String svgString = writer.toString();
         if (debugSvg) {
             writeToHomeDir(refFilename, svgString);

--- a/src/test/java/com/powsybl/nad/SvgWriterTest.java
+++ b/src/test/java/com/powsybl/nad/SvgWriterTest.java
@@ -10,9 +10,7 @@ import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.nad.layout.LayoutParameters;
-import com.powsybl.nad.svg.DefaultStyleProvider;
-import com.powsybl.nad.svg.StyleProvider;
-import com.powsybl.nad.svg.SvgParameters;
+import com.powsybl.nad.svg.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +44,11 @@ class SvgWriterTest extends AbstractTest {
     @Override
     protected StyleProvider getStyleProvider() {
         return new DefaultStyleProvider();
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new DefaultLabelProvider(network);
     }
 
     @Test

--- a/src/test/java/com/powsybl/nad/SvgWriterTest.java
+++ b/src/test/java/com/powsybl/nad/SvgWriterTest.java
@@ -9,6 +9,7 @@ package com.powsybl.nad;
 import com.powsybl.ieeecdf.converter.IeeeCdfNetworkFactory;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.xml.NetworkXml;
+import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.svg.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +61,7 @@ class SvgWriterTest extends AbstractTest {
     @Test
     void testIEEE14() {
         Network network = IeeeCdfNetworkFactory.create14();
+        LoadFlow.run(network);
         assertEquals(toString("/IEEE_14_bus.svg"), generateSvgString(network, "/IEEE_14_bus.svg"));
     }
 

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,1507 +30,7459 @@
         <g id="354" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="27.03,10.72 26.59,9.59"/>
+                <g class="nad-edge-infos" transform="translate(26.70,9.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-21.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-21.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="26.15,8.45 26.59,9.59"/>
+                <g class="nad-edge-infos" transform="translate(26.48,9.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(158.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(158.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="355" class="nad-vl120to180" title="L1-3-1">
             <g>
                 <polyline points="27.03,10.72 25.45,10.47"/>
+                <g class="nad-edge-infos" transform="translate(26.14,10.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="23.87,10.22 25.45,10.47"/>
+                <g class="nad-edge-infos" transform="translate(24.75,10.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="356" class="nad-vl120to180" title="L2-12-1">
             <g>
                 <polyline points="26.15,8.45 24.53,8.51"/>
+                <g class="nad-edge-infos" transform="translate(25.25,8.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-91.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-91.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="22.90,8.56 24.53,8.51"/>
+                <g class="nad-edge-infos" transform="translate(23.80,8.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(88.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(88.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="357" class="nad-vl120to180" title="L3-5-1">
             <g>
                 <polyline points="23.87,10.22 22.06,10.56"/>
+                <g class="nad-edge-infos" transform="translate(22.98,10.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-100.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-100.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="20.26,10.90 22.06,10.56"/>
+                <g class="nad-edge-infos" transform="translate(21.14,10.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(79.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(79.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="358" class="nad-vl120to180" title="L3-12-1">
             <g>
                 <polyline points="23.87,10.22 23.38,9.39"/>
+                <g class="nad-edge-infos" transform="translate(23.41,9.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-30.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-30.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="22.90,8.56 23.38,9.39"/>
+                <g class="nad-edge-infos" transform="translate(23.35,9.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(149.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(149.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="359" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="22.56,13.16 21.41,12.03"/>
+                <g class="nad-edge-infos" transform="translate(21.92,12.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-45.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-45.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="20.26,10.90 21.41,12.03"/>
+                <g class="nad-edge-infos" transform="translate(20.90,11.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(134.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(134.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="360" class="nad-vl120to180" title="L4-11-1">
             <g>
                 <polyline points="22.56,13.16 21.23,12.85"/>
+                <g class="nad-edge-infos" transform="translate(21.68,12.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-76.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-76.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="19.91,12.54 21.23,12.85"/>
+                <g class="nad-edge-infos" transform="translate(20.79,12.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(103.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(103.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="361" class="nad-vl120to180" title="L5-6-1">
             <g>
                 <polyline points="20.26,10.90 20.61,8.56"/>
+                <g class="nad-edge-infos" transform="translate(20.39,10.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(8.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(8.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="20.96,6.22 20.61,8.56"/>
+                <g class="nad-edge-infos" transform="translate(20.83,7.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-171.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-171.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="362" title="T8-5-1">
             <g class="nad-vl120to180">
                 <polyline points="15.05,11.34 17.65,11.12"/>
                 <circle cx="17.55" cy="11.13" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(15.94,11.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(85.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(85.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="20.26,10.90 17.65,11.12"/>
                 <circle cx="17.75" cy="11.11" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(19.36,10.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-94.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-94.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="363" class="nad-vl120to180" title="L5-11-1">
             <g>
                 <polyline points="20.26,10.90 20.08,11.72"/>
+                <g class="nad-edge-infos" transform="translate(20.07,11.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-167.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-167.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="19.91,12.54 20.08,11.72"/>
+                <g class="nad-edge-infos" transform="translate(20.10,11.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(12.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(12.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="364" class="nad-vl120to180" title="L6-7-1">
             <g>
                 <polyline points="20.96,6.22 21.87,5.57"/>
+                <g class="nad-edge-infos" transform="translate(21.69,5.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(54.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(54.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="22.79,4.92 21.87,5.57"/>
+                <g class="nad-edge-infos" transform="translate(22.05,5.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-125.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-125.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="365" class="nad-vl120to180" title="L7-12-1">
             <g>
                 <polyline points="22.79,4.92 22.84,6.74"/>
+                <g class="nad-edge-infos" transform="translate(22.82,5.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(178.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(178.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="22.90,8.56 22.84,6.74"/>
+                <g class="nad-edge-infos" transform="translate(22.87,7.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-1.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-1.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="366" class="nad-vl120to180" title="L8-9-1">
             <g>
                 <polyline points="15.05,11.34 15.08,13.64"/>
+                <g class="nad-edge-infos" transform="translate(15.06,12.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(179.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(179.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="15.12,15.94 15.08,13.64"/>
+                <g class="nad-edge-infos" transform="translate(15.11,15.04)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-0.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-0.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="367" class="nad-vl120to180" title="L8-30-1">
             <g>
                 <polyline points="15.05,11.34 12.97,9.22"/>
+                <g class="nad-edge-infos" transform="translate(14.42,10.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-44.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-44.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="10.89,7.10 12.97,9.22"/>
+                <g class="nad-edge-infos" transform="translate(11.52,7.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(135.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(135.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="368" class="nad-vl120to180" title="L9-10-1">
             <g>
                 <polyline points="15.12,15.94 15.29,17.46"/>
+                <g class="nad-edge-infos" transform="translate(15.22,16.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(173.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(173.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="15.46,18.97 15.29,17.46"/>
+                <g class="nad-edge-infos" transform="translate(15.36,18.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-6.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-6.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="369" class="nad-vl120to180" title="L11-12-1">
             <g>
                 <polyline points="19.91,12.54 21.41,10.55"/>
+                <g class="nad-edge-infos" transform="translate(20.45,11.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(36.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(36.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="22.90,8.56 21.41,10.55"/>
+                <g class="nad-edge-infos" transform="translate(22.36,9.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-143.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-143.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="370" class="nad-vl120to180" title="L11-13-1">
             <g>
                 <polyline points="19.91,12.54 18.68,12.43"/>
+                <g class="nad-edge-infos" transform="translate(19.01,12.46)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-85.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-85.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="17.46,12.32 18.68,12.43"/>
+                <g class="nad-edge-infos" transform="translate(18.36,12.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(94.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(94.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="371" class="nad-vl120to180" title="L12-14-1">
             <g>
                 <polyline points="22.90,8.56 20.32,8.68"/>
+                <g class="nad-edge-infos" transform="translate(22.00,8.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-92.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-92.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="17.73,8.79 20.32,8.68"/>
+                <g class="nad-edge-infos" transform="translate(18.63,8.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(87.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(87.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="372" class="nad-vl120to180" title="L12-16-1">
             <g>
                 <polyline points="22.90,8.56 20.76,6.97"/>
+                <g class="nad-edge-infos" transform="translate(22.18,8.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-53.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-53.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="18.62,5.39 20.76,6.97"/>
+                <g class="nad-edge-infos" transform="translate(19.35,5.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(126.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(126.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="373" class="nad-vl120to180" title="L12-117-1">
             <g>
                 <polyline points="22.90,8.56 24.32,6.98"/>
+                <g class="nad-edge-infos" transform="translate(23.50,7.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(41.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(41.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="25.75,5.39 24.32,6.98"/>
+                <g class="nad-edge-infos" transform="translate(25.15,6.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-138.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-138.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="374" class="nad-vl120to180" title="L13-15-1">
             <g>
                 <polyline points="17.46,12.32 15.55,10.97"/>
+                <g class="nad-edge-infos" transform="translate(16.72,11.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-54.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-54.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="13.64,9.63 15.55,10.97"/>
+                <g class="nad-edge-infos" transform="translate(14.38,10.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(125.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(125.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="375" class="nad-vl120to180" title="L14-15-1">
             <g>
                 <polyline points="17.73,8.79 15.69,9.21"/>
+                <g class="nad-edge-infos" transform="translate(16.85,8.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-101.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-101.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="13.64,9.63 15.69,9.21"/>
+                <g class="nad-edge-infos" transform="translate(14.52,9.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(78.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(78.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="376" class="nad-vl120to180" title="L15-17-1">
             <g>
                 <polyline points="13.64,9.63 14.14,7.15"/>
+                <g class="nad-edge-infos" transform="translate(13.82,8.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.65,4.68 14.14,7.15"/>
+                <g class="nad-edge-infos" transform="translate(14.47,5.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="377" class="nad-vl120to180" title="L15-19-1">
             <g>
                 <polyline points="13.64,9.63 11.63,9.46"/>
+                <g class="nad-edge-infos" transform="translate(12.74,9.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-85.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-85.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.62,9.30 11.63,9.46"/>
+                <g class="nad-edge-infos" transform="translate(10.52,9.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(94.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(94.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-85.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="378" class="nad-vl120to180" title="L15-33-1">
             <g>
                 <polyline points="13.64,9.63 11.54,11.17"/>
+                <g class="nad-edge-infos" transform="translate(12.92,10.16)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-126.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-126.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.43,12.71 11.54,11.17"/>
+                <g class="nad-edge-infos" transform="translate(10.16,12.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(53.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(53.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="379" class="nad-vl120to180" title="L16-17-1">
             <g>
                 <polyline points="18.62,5.39 16.63,5.03"/>
+                <g class="nad-edge-infos" transform="translate(17.74,5.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-79.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-79.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.65,4.68 16.63,5.03"/>
+                <g class="nad-edge-infos" transform="translate(15.53,4.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(100.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(100.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="380" class="nad-vl120to180" title="L17-18-1">
             <g>
                 <polyline points="14.65,4.68 13.57,5.79"/>
+                <g class="nad-edge-infos" transform="translate(14.02,5.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-135.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-135.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="12.49,6.90 13.57,5.79"/>
+                <g class="nad-edge-infos" transform="translate(13.11,6.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(44.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(44.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="381" title="T30-17-1">
             <g class="nad-vl120to180">
                 <polyline points="10.89,7.10 12.77,5.89"/>
                 <circle cx="12.68" cy="5.95" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(11.64,6.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(57.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(57.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(57.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(57.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="14.65,4.68 12.77,5.89"/>
                 <circle cx="12.85" cy="5.84" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(13.89,5.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-122.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(57.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-122.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(57.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="382" class="nad-vl120to180" title="L17-31-1">
             <g>
                 <polyline points="14.65,4.68 15.77,2.06"/>
+                <g class="nad-edge-infos" transform="translate(15.00,3.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(23.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(23.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="16.89,-0.57 15.77,2.06"/>
+                <g class="nad-edge-infos" transform="translate(16.53,0.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-156.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-156.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="383" class="nad-vl120to180" title="L17-113-1">
             <g>
                 <polyline points="14.65,4.68 14.67,2.74"/>
+                <g class="nad-edge-infos" transform="translate(14.66,3.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(0.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(0.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.70,0.80 14.67,2.74"/>
+                <g class="nad-edge-infos" transform="translate(14.69,1.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-179.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-179.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="384" class="nad-vl120to180" title="L18-19-1">
             <g>
                 <polyline points="12.49,6.90 11.05,8.10"/>
+                <g class="nad-edge-infos" transform="translate(11.80,7.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.62,9.30 11.05,8.10"/>
+                <g class="nad-edge-infos" transform="translate(10.31,8.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="385" class="nad-vl120to180" title="L19-20-1">
             <g>
                 <polyline points="9.62,9.30 8.51,7.71"/>
+                <g class="nad-edge-infos" transform="translate(9.10,8.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-35.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-35.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.39,6.12 8.51,7.71"/>
+                <g class="nad-edge-infos" transform="translate(7.91,6.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(144.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(144.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="386" class="nad-vl120to180" title="L19-34-1">
             <g>
                 <polyline points="9.62,9.30 7.99,10.97"/>
+                <g class="nad-edge-infos" transform="translate(8.99,9.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-135.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-135.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.37,12.65 7.99,10.97"/>
+                <g class="nad-edge-infos" transform="translate(7.00,12.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(44.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(44.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="387" class="nad-vl120to180" title="L20-21-1">
             <g>
                 <polyline points="7.39,6.12 7.21,4.46"/>
+                <g class="nad-edge-infos" transform="translate(7.29,5.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-6.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-6.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.02,2.80 7.21,4.46"/>
+                <g class="nad-edge-infos" transform="translate(7.12,3.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(173.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(173.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="388" class="nad-vl120to180" title="L21-22-1">
             <g>
                 <polyline points="7.02,2.80 7.56,1.24"/>
+                <g class="nad-edge-infos" transform="translate(7.31,1.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(19.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(19.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.09,-0.32 7.56,1.24"/>
+                <g class="nad-edge-infos" transform="translate(7.80,0.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-160.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-160.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="389" class="nad-vl120to180" title="L22-23-1">
             <g>
                 <polyline points="8.09,-0.32 8.92,-1.67"/>
+                <g class="nad-edge-infos" transform="translate(8.56,-1.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(31.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(31.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.74,-3.02 8.92,-1.67"/>
+                <g class="nad-edge-infos" transform="translate(9.27,-2.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-148.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-148.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="390" class="nad-vl120to180" title="L23-24-1">
             <g>
                 <polyline points="9.74,-3.02 7.58,-3.33"/>
+                <g class="nad-edge-infos" transform="translate(8.85,-3.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.43,-3.64 7.58,-3.33"/>
+                <g class="nad-edge-infos" transform="translate(6.32,-3.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="391" class="nad-vl120to180" title="L23-25-1">
             <g>
                 <polyline points="9.74,-3.02 10.98,-2.53"/>
+                <g class="nad-edge-infos" transform="translate(10.58,-2.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(111.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(111.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="12.21,-2.05 10.98,-2.53"/>
+                <g class="nad-edge-infos" transform="translate(11.38,-2.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-68.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-68.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="392" class="nad-vl120to180" title="L23-32-1">
             <g>
                 <polyline points="9.74,-3.02 12.00,-3.11"/>
+                <g class="nad-edge-infos" transform="translate(10.64,-3.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(87.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(87.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.25,-3.21 12.00,-3.11"/>
+                <g class="nad-edge-infos" transform="translate(13.35,-3.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-92.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-92.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="393" class="nad-vl120to180" title="L24-70-1">
             <g>
                 <polyline points="5.43,-3.64 2.78,-3.25"/>
+                <g class="nad-edge-infos" transform="translate(4.54,-3.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-98.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.13,-2.86 2.78,-3.25"/>
+                <g class="nad-edge-infos" transform="translate(1.02,-2.99)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="394" class="nad-vl120to180" title="L24-72-1">
             <g>
                 <polyline points="5.43,-3.64 5.39,-5.00"/>
+                <g class="nad-edge-infos" transform="translate(5.40,-4.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-1.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-1.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.34,-6.36 5.39,-5.00"/>
+                <g class="nad-edge-infos" transform="translate(5.37,-5.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(178.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(178.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="395" title="T26-25-1">
             <g class="nad-vl120to180">
                 <polyline points="11.13,2.34 11.67,0.15"/>
                 <circle cx="11.65" cy="0.24" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(11.35,1.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="12.21,-2.05 11.67,0.15"/>
                 <circle cx="11.70" cy="0.05" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(12.00,-1.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="396" class="nad-vl120to180" title="L25-27-1">
             <g>
                 <polyline points="12.21,-2.05 13.94,-3.69"/>
+                <g class="nad-edge-infos" transform="translate(12.87,-2.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(46.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(46.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="15.67,-5.34 13.94,-3.69"/>
+                <g class="nad-edge-infos" transform="translate(15.02,-4.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-133.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-133.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="397" class="nad-vl120to180" title="L26-30-1">
             <g>
                 <polyline points="11.13,2.34 11.01,4.72"/>
+                <g class="nad-edge-infos" transform="translate(11.09,3.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-177.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-177.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="10.89,7.10 11.01,4.72"/>
+                <g class="nad-edge-infos" transform="translate(10.93,6.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(2.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(2.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="398" class="nad-vl120to180" title="L27-28-1">
             <g>
                 <polyline points="15.67,-5.34 17.27,-5.62"/>
+                <g class="nad-edge-infos" transform="translate(16.55,-5.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(79.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(79.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="18.87,-5.91 17.27,-5.62"/>
+                <g class="nad-edge-infos" transform="translate(17.98,-5.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-100.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-100.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(79.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="399" class="nad-vl120to180" title="L27-32-1">
             <g>
                 <polyline points="15.67,-5.34 14.96,-4.27"/>
+                <g class="nad-edge-infos" transform="translate(15.17,-4.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-146.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-146.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.25,-3.21 14.96,-4.27"/>
+                <g class="nad-edge-infos" transform="translate(14.75,-3.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(33.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(33.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="400" class="nad-vl120to180" title="L27-115-1">
             <g>
                 <polyline points="15.67,-5.34 15.65,-6.96"/>
+                <g class="nad-edge-infos" transform="translate(15.66,-6.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-0.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-0.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="15.63,-8.59 15.65,-6.96"/>
+                <g class="nad-edge-infos" transform="translate(15.64,-7.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(179.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(179.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="401" class="nad-vl120to180" title="L28-29-1">
             <g>
                 <polyline points="18.87,-5.91 19.14,-4.57"/>
+                <g class="nad-edge-infos" transform="translate(19.05,-5.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="19.41,-3.24 19.14,-4.57"/>
+                <g class="nad-edge-infos" transform="translate(19.23,-4.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="402" class="nad-vl120to180" title="L29-31-1">
             <g>
                 <polyline points="19.41,-3.24 18.15,-1.90"/>
+                <g class="nad-edge-infos" transform="translate(18.79,-2.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-136.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-136.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="16.89,-0.57 18.15,-1.90"/>
+                <g class="nad-edge-infos" transform="translate(17.51,-1.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(43.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(43.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="403" class="nad-vl120to180" title="L30-38-1">
             <g>
                 <polyline points="10.89,7.10 8.05,8.78"/>
+                <g class="nad-edge-infos" transform="translate(10.11,7.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-120.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-120.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.22,10.46 8.05,8.78"/>
+                <g class="nad-edge-infos" transform="translate(5.99,10.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(59.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(59.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="404" class="nad-vl120to180" title="L31-32-1">
             <g>
                 <polyline points="16.89,-0.57 15.57,-1.89"/>
+                <g class="nad-edge-infos" transform="translate(16.25,-1.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-45.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-45.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.25,-3.21 15.57,-1.89"/>
+                <g class="nad-edge-infos" transform="translate(14.89,-2.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(135.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(135.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="405" class="nad-vl120to180" title="L32-113-1">
             <g>
                 <polyline points="14.25,-3.21 14.48,-1.20"/>
+                <g class="nad-edge-infos" transform="translate(14.35,-2.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(173.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(173.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.70,0.80 14.48,-1.20"/>
+                <g class="nad-edge-infos" transform="translate(14.60,-0.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-6.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-6.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="406" class="nad-vl120to180" title="L32-114-1">
             <g>
                 <polyline points="14.25,-3.21 14.01,-5.13"/>
+                <g class="nad-edge-infos" transform="translate(14.14,-4.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-7.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-7.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="13.77,-7.06 14.01,-5.13"/>
+                <g class="nad-edge-infos" transform="translate(13.88,-6.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(172.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(172.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="407" class="nad-vl120to180" title="L33-37-1">
             <g>
                 <polyline points="9.43,12.71 7.10,13.65"/>
+                <g class="nad-edge-infos" transform="translate(8.60,13.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-111.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-111.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.76,14.59 7.10,13.65"/>
+                <g class="nad-edge-infos" transform="translate(5.60,14.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(68.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(68.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="408" class="nad-vl120to180" title="L34-36-1">
             <g>
                 <polyline points="6.37,12.65 6.93,14.26"/>
+                <g class="nad-edge-infos" transform="translate(6.66,13.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(160.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(160.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.48,15.88 6.93,14.26"/>
+                <g class="nad-edge-infos" transform="translate(7.19,15.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-19.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-19.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="409" class="nad-vl120to180" title="L34-37-1">
             <g>
                 <polyline points="6.37,12.65 5.57,13.62"/>
+                <g class="nad-edge-infos" transform="translate(5.80,13.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-140.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-140.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.76,14.59 5.57,13.62"/>
+                <g class="nad-edge-infos" transform="translate(5.34,13.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(39.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(39.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="410" class="nad-vl120to180" title="L34-43-1">
             <g>
                 <polyline points="6.37,12.65 4.13,11.98"/>
+                <g class="nad-edge-infos" transform="translate(5.51,12.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-73.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-73.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.89,11.30 4.13,11.98"/>
+                <g class="nad-edge-infos" transform="translate(2.75,11.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(106.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(106.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="411" class="nad-vl120to180" title="L35-36-1">
             <g>
                 <polyline points="5.77,17.43 6.63,16.65"/>
+                <g class="nad-edge-infos" transform="translate(6.44,16.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(47.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(47.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.48,15.88 6.63,16.65"/>
+                <g class="nad-edge-infos" transform="translate(6.82,16.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-132.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-132.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="412" class="nad-vl120to180" title="L35-37-1">
             <g>
                 <polyline points="5.77,17.43 5.27,16.01"/>
+                <g class="nad-edge-infos" transform="translate(5.47,16.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-19.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-19.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.76,14.59 5.27,16.01"/>
+                <g class="nad-edge-infos" transform="translate(5.06,15.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(160.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(160.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="413" title="T38-37-1">
             <g class="nad-vl120to180">
                 <polyline points="5.22,10.46 4.99,12.52"/>
                 <circle cx="5.00" cy="12.42" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(5.12,11.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-173.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-173.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="4.76,14.59 4.99,12.52"/>
                 <circle cx="4.98" cy="12.62" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(4.86,13.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(6.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(6.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="414" class="nad-vl120to180" title="L37-39-1">
             <g>
                 <polyline points="4.76,14.59 3.57,15.75"/>
+                <g class="nad-edge-infos" transform="translate(4.12,15.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-134.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-134.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.38,16.92 3.57,15.75"/>
+                <g class="nad-edge-infos" transform="translate(3.02,16.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(45.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(45.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="415" class="nad-vl120to180" title="L37-40-1">
             <g>
                 <polyline points="4.76,14.59 2.44,14.93"/>
+                <g class="nad-edge-infos" transform="translate(3.87,14.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-98.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.12,15.27 2.44,14.93"/>
+                <g class="nad-edge-infos" transform="translate(1.01,15.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="416" class="nad-vl120to180" title="L38-65-1">
             <g>
                 <polyline points="5.22,10.46 0.24,9.77"/>
+                <g class="nad-edge-infos" transform="translate(4.32,10.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-82.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-82.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.73,9.08 0.24,9.77"/>
+                <g class="nad-edge-infos" transform="translate(-3.84,9.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(97.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(97.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="417" class="nad-vl120to180" title="L39-40-1">
             <g>
                 <polyline points="2.38,16.92 1.25,16.10"/>
+                <g class="nad-edge-infos" transform="translate(1.65,16.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-53.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-53.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.12,15.27 1.25,16.10"/>
+                <g class="nad-edge-infos" transform="translate(0.84,15.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(126.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(126.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="418" class="nad-vl120to180" title="L40-41-1">
             <g>
                 <polyline points="0.12,15.27 -1.22,15.55"/>
+                <g class="nad-edge-infos" transform="translate(-0.77,15.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-101.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-101.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.56,15.82 -1.22,15.55"/>
+                <g class="nad-edge-infos" transform="translate(-1.68,15.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(78.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(78.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="419" class="nad-vl120to180" title="L40-42-1">
             <g>
                 <polyline points="0.12,15.27 -1.97,14.40"/>
+                <g class="nad-edge-infos" transform="translate(-0.71,14.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-67.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-67.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.05,13.53 -1.97,14.40"/>
+                <g class="nad-edge-infos" transform="translate(-3.22,13.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(112.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(112.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="420" class="nad-vl120to180" title="L41-42-1">
             <g>
                 <polyline points="-2.56,15.82 -3.31,14.67"/>
+                <g class="nad-edge-infos" transform="translate(-3.05,15.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-32.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-32.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.05,13.53 -3.31,14.67"/>
+                <g class="nad-edge-infos" transform="translate(-3.56,14.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(147.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(147.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="421" class="nad-vl120to180" title="L42-49-1">
             <g>
                 <polyline points="-4.05,13.53 -4.02,12.73 -5.77,9.45"/>
+                <g class="nad-edge-infos" transform="translate(-4.16,12.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-28.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-28.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.20,5.75 -7.52,6.18 -5.77,9.45"/>
+                <g class="nad-edge-infos" transform="translate(-7.38,6.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(151.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(151.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="422" class="nad-vl120to180" title="L42-49-2">
             <g>
                 <polyline points="-4.05,13.53 -4.73,13.11 -6.48,9.83"/>
+                <g class="nad-edge-infos" transform="translate(-4.87,12.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-28.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-28.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.20,5.75 -8.23,6.55 -6.48,9.83"/>
+                <g class="nad-edge-infos" transform="translate(-8.09,6.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(151.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(151.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="423" class="nad-vl120to180" title="L43-44-1">
             <g>
                 <polyline points="1.89,11.30 -0.49,9.35"/>
+                <g class="nad-edge-infos" transform="translate(1.19,10.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-50.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-50.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.88,7.40 -0.49,9.35"/>
+                <g class="nad-edge-infos" transform="translate(-2.18,7.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(129.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(129.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="424" class="nad-vl120to180" title="L44-45-1">
             <g>
                 <polyline points="-2.88,7.40 -4.60,6.71"/>
+                <g class="nad-edge-infos" transform="translate(-3.71,7.07)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-68.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-68.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.32,6.02 -4.60,6.71"/>
+                <g class="nad-edge-infos" transform="translate(-5.49,6.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(111.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(111.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-68.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="425" class="nad-vl120to180" title="L45-46-1">
             <g>
                 <polyline points="-6.32,6.02 -6.34,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.35,6.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-178.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.37,7.34 -6.34,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.34,6.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(1.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(1.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="426" class="nad-vl120to180" title="L45-49-1">
             <g>
                 <polyline points="-6.32,6.02 -7.26,5.88"/>
+                <g class="nad-edge-infos" transform="translate(-7.21,5.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-82.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-82.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.20,5.75 -7.26,5.88"/>
+                <g class="nad-edge-infos" transform="translate(-7.31,5.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(97.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(97.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="427" class="nad-vl120to180" title="L46-47-1">
             <g>
                 <polyline points="-6.37,7.34 -5.51,6.12"/>
+                <g class="nad-edge-infos" transform="translate(-5.85,6.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(34.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(34.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.66,4.90 -5.51,6.12"/>
+                <g class="nad-edge-infos" transform="translate(-5.18,5.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-145.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-145.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="428" class="nad-vl120to180" title="L46-48-1">
             <g>
                 <polyline points="-6.37,7.34 -9.06,10.29"/>
+                <g class="nad-edge-infos" transform="translate(-6.97,8.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-137.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-137.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.75,13.24 -9.06,10.29"/>
+                <g class="nad-edge-infos" transform="translate(-11.14,12.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(42.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(42.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="429" class="nad-vl120to180" title="L47-49-1">
             <g>
                 <polyline points="-4.66,4.90 -6.43,5.33"/>
+                <g class="nad-edge-infos" transform="translate(-5.54,5.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-103.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-103.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.20,5.75 -6.43,5.33"/>
+                <g class="nad-edge-infos" transform="translate(-7.33,5.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(76.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(76.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="430" class="nad-vl120to180" title="L47-69-1">
             <g>
                 <polyline points="-4.66,4.90 -8.40,-1.00"/>
+                <g class="nad-edge-infos" transform="translate(-5.14,4.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-32.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-32.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-12.14,-6.89 -8.40,-1.00"/>
+                <g class="nad-edge-infos" transform="translate(-11.66,-6.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(147.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(147.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="431" class="nad-vl120to180" title="L48-49-1">
             <g>
                 <polyline points="-11.75,13.24 -9.98,9.50"/>
+                <g class="nad-edge-infos" transform="translate(-11.36,12.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(25.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(25.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.20,5.75 -9.98,9.50"/>
+                <g class="nad-edge-infos" transform="translate(-8.59,6.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-154.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-154.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="432" class="nad-vl120to180" title="L49-50-1">
             <g>
                 <polyline points="-8.20,5.75 -9.82,2.86"/>
+                <g class="nad-edge-infos" transform="translate(-8.64,4.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-29.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-29.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.45,-0.04 -9.82,2.86"/>
+                <g class="nad-edge-infos" transform="translate(-11.01,0.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(150.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(150.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="433" class="nad-vl120to180" title="L49-51-1">
             <g>
                 <polyline points="-8.20,5.75 -10.81,5.92"/>
+                <g class="nad-edge-infos" transform="translate(-9.10,5.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-93.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(86.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-93.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(86.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-13.42,6.08 -10.81,5.92"/>
+                <g class="nad-edge-infos" transform="translate(-12.52,6.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(86.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(86.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(86.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(86.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="434" class="nad-vl120to180" title="L49-54-1">
             <g>
                 <polyline points="-8.20,5.75 -8.38,6.53 -6.94,11.09"/>
+                <g class="nad-edge-infos" transform="translate(-8.29,6.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.92,16.19 -5.51,15.65 -6.94,11.09"/>
+                <g class="nad-edge-infos" transform="translate(-5.60,15.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="435" class="nad-vl120to180" title="L49-54-2">
             <g>
                 <polyline points="-8.20,5.75 -7.61,6.29 -6.18,10.85"/>
+                <g class="nad-edge-infos" transform="translate(-7.52,6.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.92,16.19 -4.74,15.41 -6.18,10.85"/>
+                <g class="nad-edge-infos" transform="translate(-4.83,15.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="436" class="nad-vl120to180" title="L49-66-1">
             <g>
                 <polyline points="-8.20,5.75 -8.95,5.47 -11.57,5.89"/>
+                <g class="nad-edge-infos" transform="translate(-9.25,5.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-99.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-99.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.81,6.82 -14.19,6.32 -11.57,5.89"/>
+                <g class="nad-edge-infos" transform="translate(-13.89,6.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(80.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(80.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="437" class="nad-vl120to180" title="L49-66-2">
             <g>
                 <polyline points="-8.20,5.75 -8.82,6.26 -11.44,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-9.12,6.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-99.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-99.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.81,6.82 -14.06,7.10 -11.44,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-13.76,7.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(80.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(80.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="438" class="nad-vl120to180" title="L49-69-1">
             <g>
                 <polyline points="-8.20,5.75 -10.17,-0.57"/>
+                <g class="nad-edge-infos" transform="translate(-8.47,4.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-12.14,-6.89 -10.17,-0.57"/>
+                <g class="nad-edge-infos" transform="translate(-11.87,-6.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="439" class="nad-vl120to180" title="L50-57-1">
             <g>
                 <polyline points="-11.45,-0.04 -12.79,2.74"/>
+                <g class="nad-edge-infos" transform="translate(-11.84,0.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-154.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-154.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.14,5.51 -12.79,2.74"/>
+                <g class="nad-edge-infos" transform="translate(-13.75,4.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(25.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(25.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="440" class="nad-vl120to180" title="L51-52-1">
             <g>
                 <polyline points="-13.42,6.08 -15.24,6.64"/>
+                <g class="nad-edge-infos" transform="translate(-14.28,6.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-107.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-107.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-17.07,7.21 -15.24,6.64"/>
+                <g class="nad-edge-infos" transform="translate(-16.21,6.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(72.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(72.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="441" class="nad-vl120to180" title="L51-58-1">
             <g>
                 <polyline points="-13.42,6.08 -13.50,7.10"/>
+                <g class="nad-edge-infos" transform="translate(-13.49,6.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-175.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(4.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-175.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(4.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-13.58,8.12 -13.50,7.10"/>
+                <g class="nad-edge-infos" transform="translate(-13.51,7.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(4.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(4.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(4.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(4.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="442" class="nad-vl120to180" title="L52-53-1">
             <g>
                 <polyline points="-17.07,7.21 -16.66,8.33"/>
+                <g class="nad-edge-infos" transform="translate(-16.76,8.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(160.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(160.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.25,9.46 -16.66,8.33"/>
+                <g class="nad-edge-infos" transform="translate(-16.56,8.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-19.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-19.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="443" class="nad-vl120to180" title="L53-54-1">
             <g>
                 <polyline points="-16.25,9.46 -10.58,12.83"/>
+                <g class="nad-edge-infos" transform="translate(-15.48,9.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(120.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(120.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.92,16.19 -10.58,12.83"/>
+                <g class="nad-edge-infos" transform="translate(-5.69,15.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-59.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-59.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="444" class="nad-vl120to180" title="L54-55-1">
             <g>
                 <polyline points="-4.92,16.19 -5.95,16.33"/>
+                <g class="nad-edge-infos" transform="translate(-5.81,16.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-97.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-97.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.98,16.47 -5.95,16.33"/>
+                <g class="nad-edge-infos" transform="translate(-6.09,16.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(82.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(82.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="445" class="nad-vl120to180" title="L54-56-1">
             <g>
                 <polyline points="-4.92,16.19 -7.21,15.92"/>
+                <g class="nad-edge-infos" transform="translate(-5.81,16.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.51,15.65 -7.21,15.92"/>
+                <g class="nad-edge-infos" transform="translate(-8.61,15.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="446" class="nad-vl120to180" title="L54-59-1">
             <g>
                 <polyline points="-4.92,16.19 -7.73,15.42"/>
+                <g class="nad-edge-infos" transform="translate(-5.79,15.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-74.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-74.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.53,14.64 -7.73,15.42"/>
+                <g class="nad-edge-infos" transform="translate(-9.67,14.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(105.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(105.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="447" class="nad-vl120to180" title="L55-56-1">
             <g>
                 <polyline points="-6.98,16.47 -8.25,16.06"/>
+                <g class="nad-edge-infos" transform="translate(-7.84,16.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.51,15.65 -8.25,16.06"/>
+                <g class="nad-edge-infos" transform="translate(-8.65,15.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="448" class="nad-vl120to180" title="L55-59-1">
             <g>
                 <polyline points="-6.98,16.47 -8.76,15.56"/>
+                <g class="nad-edge-infos" transform="translate(-7.78,16.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-62.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.53,14.64 -8.76,15.56"/>
+                <g class="nad-edge-infos" transform="translate(-9.73,15.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(117.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="449" class="nad-vl120to180" title="L56-57-1">
             <g>
                 <polyline points="-9.51,15.65 -11.82,10.58"/>
+                <g class="nad-edge-infos" transform="translate(-9.88,14.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-24.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-24.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-24.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-24.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.14,5.51 -11.82,10.58"/>
+                <g class="nad-edge-infos" transform="translate(-13.77,6.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(155.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-24.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(155.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-24.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="450" class="nad-vl120to180" title="L56-58-1">
             <g>
                 <polyline points="-9.51,15.65 -11.54,11.89"/>
+                <g class="nad-edge-infos" transform="translate(-9.94,14.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-28.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-28.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-13.58,8.12 -11.54,11.89"/>
+                <g class="nad-edge-infos" transform="translate(-13.15,8.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(151.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(151.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="451" class="nad-vl120to180" title="L56-59-1">
             <g>
                 <polyline points="-9.51,15.65 -9.72,14.88 -9.74,14.86"/>
+                <g class="nad-edge-infos" transform="translate(-9.94,14.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-45.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-45.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.53,14.64 -9.76,14.84 -9.74,14.86"/>
+                <g class="nad-edge-infos" transform="translate(-9.55,15.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(134.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(134.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="452" class="nad-vl120to180" title="L56-59-2">
             <g>
                 <polyline points="-9.51,15.65 -10.28,15.45 -10.30,15.43"/>
+                <g class="nad-edge-infos" transform="translate(-10.50,15.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-45.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-45.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.53,14.64 -10.32,15.41 -10.30,15.43"/>
+                <g class="nad-edge-infos" transform="translate(-10.11,15.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(134.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(134.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-45.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="453" class="nad-vl120to180" title="L59-60-1">
             <g>
                 <polyline points="-10.53,14.64 -8.77,16.63"/>
+                <g class="nad-edge-infos" transform="translate(-9.94,15.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(138.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(138.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.01,18.61 -8.77,16.63"/>
+                <g class="nad-edge-infos" transform="translate(-7.61,17.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-41.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-41.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="454" class="nad-vl120to180" title="L59-61-1">
             <g>
                 <polyline points="-10.53,14.64 -12.48,14.29"/>
+                <g class="nad-edge-infos" transform="translate(-11.42,14.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-79.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-79.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.43,13.95 -12.48,14.29"/>
+                <g class="nad-edge-infos" transform="translate(-13.54,14.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(100.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(100.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-79.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="455" title="T63-59-1">
             <g class="nad-vl120to180">
                 <polyline points="-3.93,22.99 -7.23,18.82"/>
                 <circle cx="-7.17" cy="18.90" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-4.49,22.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-38.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-38.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-10.53,14.64 -7.23,18.82"/>
                 <circle cx="-7.30" cy="18.74" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-9.98,15.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(141.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(141.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="456" class="nad-vl120to180" title="L60-61-1">
             <g>
                 <polyline points="-7.01,18.61 -10.72,16.28"/>
+                <g class="nad-edge-infos" transform="translate(-7.77,18.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-57.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-57.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-57.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-57.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.43,13.95 -10.72,16.28"/>
+                <g class="nad-edge-infos" transform="translate(-13.67,14.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(122.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-57.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(122.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-57.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="457" class="nad-vl120to180" title="L60-62-1">
             <g>
                 <polyline points="-7.01,18.61 -15.53,10.81"/>
+                <g class="nad-edge-infos" transform="translate(-7.68,18.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-24.05,3.01 -15.53,10.81"/>
+                <g class="nad-edge-infos" transform="translate(-23.39,3.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(132.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="458" class="nad-vl120to180" title="L61-62-1">
             <g>
                 <polyline points="-14.43,13.95 -19.24,8.48"/>
+                <g class="nad-edge-infos" transform="translate(-15.02,13.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-41.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-41.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-24.05,3.01 -19.24,8.48"/>
+                <g class="nad-edge-infos" transform="translate(-23.46,3.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(138.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(138.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="459" title="T64-61-1">
             <g class="nad-vl120to180">
                 <polyline points="-9.38,15.01 -11.90,14.48"/>
                 <circle cx="-11.80" cy="14.50" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-10.26,14.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-78.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-78.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-14.43,13.95 -11.90,14.48"/>
                 <circle cx="-12.00" cy="14.46" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-13.55,14.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(101.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(101.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="460" class="nad-vl120to180" title="L62-66-1">
             <g>
                 <polyline points="-24.05,3.01 -19.43,4.92"/>
+                <g class="nad-edge-infos" transform="translate(-23.22,3.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(112.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(112.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.81,6.82 -19.43,4.92"/>
+                <g class="nad-edge-infos" transform="translate(-15.64,6.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-67.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-67.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="461" class="nad-vl120to180" title="L62-67-1">
             <g>
                 <polyline points="-24.05,3.01 -21.48,5.85"/>
+                <g class="nad-edge-infos" transform="translate(-23.45,3.68)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(137.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(137.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-18.92,8.69 -21.48,5.85"/>
+                <g class="nad-edge-infos" transform="translate(-19.52,8.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-42.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-42.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="462" class="nad-vl120to180" title="L63-64-1">
             <g>
                 <polyline points="-3.93,22.99 -6.66,19.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.44,22.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-34.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-34.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.38,15.01 -6.66,19.00"/>
+                <g class="nad-edge-infos" transform="translate(-8.87,15.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(145.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(145.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="463" class="nad-vl120to180" title="L64-65-1">
             <g>
                 <polyline points="-9.38,15.01 -7.06,12.05"/>
+                <g class="nad-edge-infos" transform="translate(-8.82,14.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.73,9.08 -7.06,12.05"/>
+                <g class="nad-edge-infos" transform="translate(-5.29,9.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="464" title="T65-66-1">
             <g class="nad-vl120to180">
                 <polyline points="-4.73,9.08 -9.77,7.95"/>
                 <circle cx="-9.67" cy="7.97" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-5.61,8.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-77.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-14.81,6.82 -9.77,7.95"/>
                 <circle cx="-9.87" cy="7.93" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-13.93,7.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(102.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="465" class="nad-vl120to180" title="L65-68-1">
             <g>
                 <polyline points="-4.73,9.08 -1.61,9.61"/>
+                <g class="nad-edge-infos" transform="translate(-3.85,9.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(99.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-80.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(99.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-80.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.51,10.13 -1.61,9.61"/>
+                <g class="nad-edge-infos" transform="translate(0.62,9.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-80.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-80.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-80.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-80.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="466" class="nad-vl120to180" title="L66-67-1">
             <g>
                 <polyline points="-14.81,6.82 -16.86,7.76"/>
+                <g class="nad-edge-infos" transform="translate(-15.63,7.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-114.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-114.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-18.92,8.69 -16.86,7.76"/>
+                <g class="nad-edge-infos" transform="translate(-18.10,8.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(65.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(65.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="467" title="T68-69-1">
             <g class="nad-vl120to180">
                 <polyline points="1.51,10.13 -5.32,1.62"/>
                 <circle cx="-5.25" cy="1.70" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(0.94,9.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-38.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-38.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-12.14,-6.89 -5.32,1.62"/>
                 <circle cx="-5.38" cy="1.54" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-11.58,-6.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(141.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(141.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="468" class="nad-vl120to180" title="L68-81-1">
             <g>
                 <polyline points="1.51,10.13 -2.14,1.62"/>
+                <g class="nad-edge-infos" transform="translate(1.15,9.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-23.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-23.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.79,-6.89 -2.14,1.62"/>
+                <g class="nad-edge-infos" transform="translate(-5.43,-6.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(156.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(156.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="469" class="nad-vl120to180" title="L68-116-1">
             <g>
                 <polyline points="1.51,10.13 -4.07,4.98"/>
+                <g class="nad-edge-infos" transform="translate(0.84,9.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.66,-0.16 -4.07,4.98"/>
+                <g class="nad-edge-infos" transform="translate(-8.99,0.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(132.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="470" class="nad-vl120to180" title="L69-70-1">
             <g>
                 <polyline points="-12.14,-6.89 -6.00,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(-11.28,-6.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.13,-2.86 -6.00,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(-0.72,-3.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="471" class="nad-vl120to180" title="L69-75-1">
             <g>
                 <polyline points="-12.14,-6.89 -7.53,-4.48"/>
+                <g class="nad-edge-infos" transform="translate(-11.34,-6.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(117.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.92,-2.06 -7.53,-4.48"/>
+                <g class="nad-edge-infos" transform="translate(-3.72,-2.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-62.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="472" class="nad-vl120to180" title="L69-77-1">
             <g>
                 <polyline points="-12.14,-6.89 -9.74,-5.63"/>
+                <g class="nad-edge-infos" transform="translate(-11.34,-6.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(117.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.34,-4.37 -9.74,-5.63"/>
+                <g class="nad-edge-infos" transform="translate(-8.14,-4.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-62.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="473" class="nad-vl120to180" title="L70-71-1">
             <g>
                 <polyline points="0.13,-2.86 1.50,-4.59"/>
+                <g class="nad-edge-infos" transform="translate(0.69,-3.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.87,-6.32 1.50,-4.59"/>
+                <g class="nad-edge-infos" transform="translate(2.31,-5.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="474" class="nad-vl120to180" title="L70-74-1">
             <g>
                 <polyline points="0.13,-2.86 -0.36,-1.91"/>
+                <g class="nad-edge-infos" transform="translate(-0.28,-2.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-152.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-152.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.85,-0.96 -0.36,-1.91"/>
+                <g class="nad-edge-infos" transform="translate(-0.44,-1.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(27.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(27.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="475" class="nad-vl120to180" title="L70-75-1">
             <g>
                 <polyline points="0.13,-2.86 -1.40,-2.46"/>
+                <g class="nad-edge-infos" transform="translate(-0.74,-2.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-104.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-104.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.92,-2.06 -1.40,-2.46"/>
+                <g class="nad-edge-infos" transform="translate(-2.05,-2.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(75.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(75.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="476" class="nad-vl120to180" title="L71-72-1">
             <g>
                 <polyline points="2.87,-6.32 4.11,-6.34"/>
+                <g class="nad-edge-infos" transform="translate(3.77,-6.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(89.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(89.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.34,-6.36 4.11,-6.34"/>
+                <g class="nad-edge-infos" transform="translate(4.44,-6.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-90.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-90.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="477" class="nad-vl120to180" title="L71-73-1">
             <g>
                 <polyline points="2.87,-6.32 3.23,-7.85"/>
+                <g class="nad-edge-infos" transform="translate(3.07,-7.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.59,-9.39 3.23,-7.85"/>
+                <g class="nad-edge-infos" transform="translate(3.39,-8.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="478" class="nad-vl120to180" title="L74-75-1">
             <g>
                 <polyline points="-0.85,-0.96 -1.89,-1.51"/>
+                <g class="nad-edge-infos" transform="translate(-1.64,-1.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-62.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.92,-2.06 -1.89,-1.51"/>
+                <g class="nad-edge-infos" transform="translate(-2.13,-1.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(117.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="479" class="nad-vl120to180" title="L75-77-1">
             <g>
                 <polyline points="-2.92,-2.06 -5.13,-3.22"/>
+                <g class="nad-edge-infos" transform="translate(-3.72,-2.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-62.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-62.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.34,-4.37 -5.13,-3.22"/>
+                <g class="nad-edge-infos" transform="translate(-6.54,-3.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(117.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(117.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-62.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="480" class="nad-vl120to180" title="L75-118-1">
             <g>
                 <polyline points="-2.92,-2.06 -2.59,-3.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.73,-2.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(12.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(12.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.25,-5.16 -2.59,-3.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.44,-4.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-167.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-167.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="481" class="nad-vl120to180" title="L76-77-1">
             <g>
                 <polyline points="-4.13,-2.99 -5.73,-3.68"/>
+                <g class="nad-edge-infos" transform="translate(-4.96,-3.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-66.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-66.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-66.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-66.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.34,-4.37 -5.73,-3.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.51,-4.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(113.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-66.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(113.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-66.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="482" class="nad-vl120to180" title="L76-118-1">
             <g>
                 <polyline points="-4.13,-2.99 -3.19,-4.08"/>
+                <g class="nad-edge-infos" transform="translate(-3.54,-3.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(40.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(40.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(40.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(40.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.25,-5.16 -3.19,-4.08"/>
+                <g class="nad-edge-infos" transform="translate(-2.84,-4.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-139.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(40.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-139.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(40.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="483" class="nad-vl120to180" title="L77-78-1">
             <g>
                 <polyline points="-7.34,-4.37 -8.72,-4.84"/>
+                <g class="nad-edge-infos" transform="translate(-8.19,-4.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.09,-5.31 -8.72,-4.84"/>
+                <g class="nad-edge-infos" transform="translate(-9.24,-5.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="484" class="nad-vl120to180" title="L77-80-1">
             <g>
                 <polyline points="-7.34,-4.37 -7.02,-5.10 -7.25,-7.05"/>
+                <g class="nad-edge-infos" transform="translate(-7.06,-5.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-6.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-6.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.95,-9.65 -7.48,-9.00 -7.25,-7.05"/>
+                <g class="nad-edge-infos" transform="translate(-7.44,-8.71)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(173.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(173.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="485" class="nad-vl120to180" title="L77-80-2">
             <g>
                 <polyline points="-7.34,-4.37 -7.82,-5.01 -8.04,-6.96"/>
+                <g class="nad-edge-infos" transform="translate(-7.85,-5.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-6.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-6.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.95,-9.65 -8.27,-8.91 -8.04,-6.96"/>
+                <g class="nad-edge-infos" transform="translate(-8.24,-8.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(173.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(173.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="486" class="nad-vl120to180" title="L77-82-1">
             <g>
                 <polyline points="-7.34,-4.37 -9.94,-6.22"/>
+                <g class="nad-edge-infos" transform="translate(-8.07,-4.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-54.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-54.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-12.54,-8.08 -9.94,-6.22"/>
+                <g class="nad-edge-infos" transform="translate(-11.81,-7.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(125.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(125.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="487" class="nad-vl120to180" title="L78-79-1">
             <g>
                 <polyline points="-10.09,-5.31 -10.65,-5.40"/>
+                <g class="nad-edge-infos" transform="translate(-10.98,-5.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.22,-5.48 -10.65,-5.40"/>
+                <g class="nad-edge-infos" transform="translate(-10.33,-5.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="488" class="nad-vl120to180" title="L79-80-1">
             <g>
                 <polyline points="-11.22,-5.48 -9.58,-7.56"/>
+                <g class="nad-edge-infos" transform="translate(-10.66,-6.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.95,-9.65 -9.58,-7.56"/>
+                <g class="nad-edge-infos" transform="translate(-8.51,-8.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="489" title="T81-80-1">
             <g class="nad-vl120to180">
                 <polyline points="-5.79,-6.89 -6.87,-8.27"/>
                 <circle cx="-6.81" cy="-8.19" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-6.34,-7.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-38.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-38.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-7.95,-9.65 -6.87,-8.27"/>
                 <circle cx="-6.93" cy="-8.35" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-7.40,-8.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(141.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(141.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-38.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="490" class="nad-vl120to180" title="L80-96-1">
             <g>
                 <polyline points="-7.95,-9.65 -9.84,-11.21"/>
+                <g class="nad-edge-infos" transform="translate(-8.65,-10.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-50.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-50.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.72,-12.77 -9.84,-11.21"/>
+                <g class="nad-edge-infos" transform="translate(-11.03,-12.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(129.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(129.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="491" class="nad-vl120to180" title="L80-97-1">
             <g>
                 <polyline points="-7.95,-9.65 -8.63,-10.15"/>
+                <g class="nad-edge-infos" transform="translate(-8.67,-10.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-52.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-52.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.30,-10.66 -8.63,-10.15"/>
+                <g class="nad-edge-infos" transform="translate(-8.58,-10.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(127.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(127.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="492" class="nad-vl120to180" title="L80-98-1">
             <g>
                 <polyline points="-7.95,-9.65 -7.04,-11.26"/>
+                <g class="nad-edge-infos" transform="translate(-7.51,-10.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(29.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(29.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(29.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(29.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.13,-12.88 -7.04,-11.26"/>
+                <g class="nad-edge-infos" transform="translate(-6.57,-12.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-150.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(29.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-150.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(29.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="493" class="nad-vl120to180" title="L80-99-1">
             <g>
                 <polyline points="-7.95,-9.65 -7.22,-11.99"/>
+                <g class="nad-edge-infos" transform="translate(-7.68,-10.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(17.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(17.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.49,-14.34 -7.22,-11.99"/>
+                <g class="nad-edge-infos" transform="translate(-6.75,-13.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-162.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-162.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="494" class="nad-vl120to180" title="L82-83-1">
             <g>
                 <polyline points="-12.54,-8.08 -14.74,-8.70"/>
+                <g class="nad-edge-infos" transform="translate(-13.41,-8.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-74.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-74.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.93,-9.33 -14.74,-8.70"/>
+                <g class="nad-edge-infos" transform="translate(-16.07,-9.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(105.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(105.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="495" class="nad-vl120to180" title="L82-96-1">
             <g>
                 <polyline points="-12.54,-8.08 -12.13,-10.42"/>
+                <g class="nad-edge-infos" transform="translate(-12.39,-8.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(9.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(9.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.72,-12.77 -12.13,-10.42"/>
+                <g class="nad-edge-infos" transform="translate(-11.88,-11.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-170.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-170.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="496" class="nad-vl120to180" title="L83-84-1">
             <g>
                 <polyline points="-16.93,-9.33 -18.38,-9.13"/>
+                <g class="nad-edge-infos" transform="translate(-17.83,-9.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-97.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-97.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-19.82,-8.93 -18.38,-9.13"/>
+                <g class="nad-edge-infos" transform="translate(-18.93,-9.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(82.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(82.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="497" class="nad-vl120to180" title="L83-85-1">
             <g>
                 <polyline points="-16.93,-9.33 -18.09,-10.36"/>
+                <g class="nad-edge-infos" transform="translate(-17.60,-9.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-48.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-48.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-19.24,-11.39 -18.09,-10.36"/>
+                <g class="nad-edge-infos" transform="translate(-18.57,-10.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(131.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(131.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="498" class="nad-vl120to180" title="L84-85-1">
             <g>
                 <polyline points="-19.82,-8.93 -19.53,-10.16"/>
+                <g class="nad-edge-infos" transform="translate(-19.62,-9.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-19.24,-11.39 -19.53,-10.16"/>
+                <g class="nad-edge-infos" transform="translate(-19.45,-10.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="499" class="nad-vl120to180" title="L85-86-1">
             <g>
                 <polyline points="-19.24,-11.39 -21.06,-11.02"/>
+                <g class="nad-edge-infos" transform="translate(-20.12,-11.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-101.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-101.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-22.87,-10.65 -21.06,-11.02"/>
+                <g class="nad-edge-infos" transform="translate(-21.99,-10.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(78.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(78.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="500" class="nad-vl120to180" title="L85-88-1">
             <g>
                 <polyline points="-19.24,-11.39 -19.21,-12.77"/>
+                <g class="nad-edge-infos" transform="translate(-19.22,-12.29)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(1.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(1.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-19.17,-14.14 -19.21,-12.77"/>
+                <g class="nad-edge-infos" transform="translate(-19.19,-13.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-178.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="501" class="nad-vl120to180" title="L85-89-1">
             <g>
                 <polyline points="-19.24,-11.39 -17.85,-12.81"/>
+                <g class="nad-edge-infos" transform="translate(-18.61,-12.04)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(44.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(44.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.45,-14.23 -17.85,-12.81"/>
+                <g class="nad-edge-infos" transform="translate(-17.08,-13.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-135.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-135.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="502" class="nad-vl120to180" title="L86-87-1">
             <g>
                 <polyline points="-22.87,-10.65 -24.14,-10.13"/>
+                <g class="nad-edge-infos" transform="translate(-23.71,-10.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-112.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-112.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-25.41,-9.61 -24.14,-10.13"/>
+                <g class="nad-edge-infos" transform="translate(-24.58,-9.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(67.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(67.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="503" class="nad-vl120to180" title="L88-89-1">
             <g>
                 <polyline points="-19.17,-14.14 -17.81,-14.19"/>
+                <g class="nad-edge-infos" transform="translate(-18.27,-14.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(87.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(87.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.45,-14.23 -17.81,-14.19"/>
+                <g class="nad-edge-infos" transform="translate(-17.35,-14.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-92.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-92.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(87.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="504" class="nad-vl120to180" title="L89-90-1">
             <g>
                 <polyline points="-16.45,-14.23 -16.12,-14.96 -16.22,-15.92"/>
+                <g class="nad-edge-infos" transform="translate(-16.15,-15.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-5.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-5.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.78,-17.52 -16.31,-16.87 -16.22,-15.92"/>
+                <g class="nad-edge-infos" transform="translate(-16.28,-16.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(174.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(174.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="505" class="nad-vl120to180" title="L89-90-2">
             <g>
                 <polyline points="-16.45,-14.23 -16.92,-14.88 -17.01,-15.83"/>
+                <g class="nad-edge-infos" transform="translate(-16.95,-15.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-5.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-5.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-16.78,-17.52 -17.11,-16.79 -17.01,-15.83"/>
+                <g class="nad-edge-infos" transform="translate(-17.08,-16.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(174.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(174.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-5.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="506" class="nad-vl120to180" title="L89-92-1">
             <g>
                 <polyline points="-16.45,-14.23 -15.85,-14.77 -14.98,-17.41"/>
+                <g class="nad-edge-infos" transform="translate(-15.76,-15.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(18.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(18.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.28,-20.83 -14.11,-20.05 -14.98,-17.41"/>
+                <g class="nad-edge-infos" transform="translate(-14.21,-19.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-161.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-161.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="507" class="nad-vl120to180" title="L89-92-2">
             <g>
                 <polyline points="-16.45,-14.23 -16.61,-15.02 -15.74,-17.66"/>
+                <g class="nad-edge-infos" transform="translate(-16.52,-15.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(18.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(18.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.28,-20.83 -14.87,-20.30 -15.74,-17.66"/>
+                <g class="nad-edge-infos" transform="translate(-14.97,-20.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-161.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-161.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(18.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="508" class="nad-vl120to180" title="L90-91-1">
             <g>
                 <polyline points="-16.78,-17.52 -15.15,-17.36"/>
+                <g class="nad-edge-infos" transform="translate(-15.89,-17.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(95.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(95.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-13.52,-17.20 -15.15,-17.36"/>
+                <g class="nad-edge-infos" transform="translate(-14.42,-17.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-84.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-84.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="509" class="nad-vl120to180" title="L91-92-1">
             <g>
                 <polyline points="-13.52,-17.20 -13.90,-19.01"/>
+                <g class="nad-edge-infos" transform="translate(-13.70,-18.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-11.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-11.79)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.28,-20.83 -13.90,-19.01"/>
+                <g class="nad-edge-infos" transform="translate(-14.09,-19.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(168.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(168.21)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="510" class="nad-vl120to180" title="L92-93-1">
             <g>
                 <polyline points="-14.28,-20.83 -11.53,-19.14"/>
+                <g class="nad-edge-infos" transform="translate(-13.51,-20.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(121.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(121.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.78,-17.46 -11.53,-19.14"/>
+                <g class="nad-edge-infos" transform="translate(-9.55,-17.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-58.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-58.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="511" class="nad-vl120to180" title="L92-94-1">
             <g>
                 <polyline points="-14.28,-20.83 -11.47,-16.43"/>
+                <g class="nad-edge-infos" transform="translate(-13.79,-20.07)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(147.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(147.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.67,-12.03 -11.47,-16.43"/>
+                <g class="nad-edge-infos" transform="translate(-9.15,-12.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-32.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-32.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="512" class="nad-vl120to180" title="L92-100-1">
             <g>
                 <polyline points="-14.28,-20.83 -10.04,-19.66"/>
+                <g class="nad-edge-infos" transform="translate(-13.41,-20.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(105.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(105.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.81,-18.48 -10.04,-19.66"/>
+                <g class="nad-edge-infos" transform="translate(-6.68,-18.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-74.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-74.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="513" class="nad-vl120to180" title="L92-102-1">
             <g>
                 <polyline points="-14.28,-20.83 -12.41,-19.94"/>
+                <g class="nad-edge-infos" transform="translate(-13.47,-20.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(115.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(115.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.54,-19.05 -12.41,-19.94"/>
+                <g class="nad-edge-infos" transform="translate(-11.36,-19.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-64.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-64.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="514" class="nad-vl120to180" title="L93-94-1">
             <g>
                 <polyline points="-8.78,-17.46 -8.73,-14.74"/>
+                <g class="nad-edge-infos" transform="translate(-8.76,-16.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(178.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(178.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.67,-12.03 -8.73,-14.74"/>
+                <g class="nad-edge-infos" transform="translate(-8.69,-12.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-1.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-1.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-1.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="515" class="nad-vl120to180" title="L94-95-1">
             <g>
                 <polyline points="-8.67,-12.03 -11.44,-13.73"/>
+                <g class="nad-edge-infos" transform="translate(-9.44,-12.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-58.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-58.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-14.22,-15.43 -11.44,-13.73"/>
+                <g class="nad-edge-infos" transform="translate(-13.45,-14.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(121.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(121.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-58.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="516" class="nad-vl120to180" title="L94-96-1">
             <g>
                 <polyline points="-8.67,-12.03 -10.20,-12.40"/>
+                <g class="nad-edge-infos" transform="translate(-9.54,-12.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-76.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-76.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.72,-12.77 -10.20,-12.40"/>
+                <g class="nad-edge-infos" transform="translate(-10.85,-12.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(103.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(103.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="517" class="nad-vl120to180" title="L94-100-1">
             <g>
                 <polyline points="-8.67,-12.03 -7.24,-15.25"/>
+                <g class="nad-edge-infos" transform="translate(-8.30,-12.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(23.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(23.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.81,-18.48 -7.24,-15.25"/>
+                <g class="nad-edge-infos" transform="translate(-6.18,-17.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-156.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-156.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(23.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="518" class="nad-vl120to180" title="L95-96-1">
             <g>
                 <polyline points="-14.22,-15.43 -12.97,-14.10"/>
+                <g class="nad-edge-infos" transform="translate(-13.60,-14.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(136.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(136.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.72,-12.77 -12.97,-14.10"/>
+                <g class="nad-edge-infos" transform="translate(-12.34,-13.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-43.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-43.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="519" class="nad-vl120to180" title="L96-97-1">
             <g>
                 <polyline points="-11.72,-12.77 -10.51,-11.71"/>
+                <g class="nad-edge-infos" transform="translate(-11.04,-12.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(130.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(130.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.30,-10.66 -10.51,-11.71"/>
+                <g class="nad-edge-infos" transform="translate(-9.98,-11.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-49.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-49.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="520" class="nad-vl120to180" title="L98-100-1">
             <g>
                 <polyline points="-6.13,-12.88 -5.97,-15.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.08,-13.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(3.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(3.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.81,-18.48 -5.97,-15.68"/>
+                <g class="nad-edge-infos" transform="translate(-5.86,-17.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-176.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-176.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="521" class="nad-vl120to180" title="L99-100-1">
             <g>
                 <polyline points="-6.49,-14.34 -6.15,-16.41"/>
+                <g class="nad-edge-infos" transform="translate(-6.34,-15.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(9.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(9.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.81,-18.48 -6.15,-16.41"/>
+                <g class="nad-edge-infos" transform="translate(-5.96,-17.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-170.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-170.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="522" class="nad-vl120to180" title="L100-101-1">
             <g>
                 <polyline points="-5.81,-18.48 -7.20,-19.41"/>
+                <g class="nad-edge-infos" transform="translate(-6.56,-18.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-56.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-56.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.59,-20.33 -7.20,-19.41"/>
+                <g class="nad-edge-infos" transform="translate(-7.85,-19.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(123.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(123.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="523" class="nad-vl120to180" title="L100-103-1">
             <g>
                 <polyline points="-5.81,-18.48 -3.51,-19.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.93,-18.68)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(77.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(77.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.20,-19.52 -3.51,-19.00"/>
+                <g class="nad-edge-infos" transform="translate(-2.08,-19.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-102.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-102.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="524" class="nad-vl120to180" title="L100-104-1">
             <g>
                 <polyline points="-5.81,-18.48 -4.63,-18.74"/>
+                <g class="nad-edge-infos" transform="translate(-4.93,-18.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(77.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(77.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.45,-19.00 -4.63,-18.74"/>
+                <g class="nad-edge-infos" transform="translate(-4.33,-18.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-102.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-102.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="525" class="nad-vl120to180" title="L100-106-1">
             <g>
                 <polyline points="-5.81,-18.48 -5.50,-19.93"/>
+                <g class="nad-edge-infos" transform="translate(-5.62,-19.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(12.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(12.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.18,-21.38 -5.50,-19.93"/>
+                <g class="nad-edge-infos" transform="translate(-5.37,-20.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-167.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-167.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="526" class="nad-vl120to180" title="L101-102-1">
             <g>
                 <polyline points="-8.59,-20.33 -9.57,-19.69"/>
+                <g class="nad-edge-infos" transform="translate(-9.35,-19.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-123.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(56.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-123.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(56.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.54,-19.05 -9.57,-19.69"/>
+                <g class="nad-edge-infos" transform="translate(-9.79,-19.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(56.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(56.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(56.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(56.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="527" class="nad-vl120to180" title="L103-104-1">
             <g>
                 <polyline points="-1.20,-19.52 -2.32,-19.26"/>
+                <g class="nad-edge-infos" transform="translate(-2.08,-19.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-103.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-103.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.45,-19.00 -2.32,-19.26"/>
+                <g class="nad-edge-infos" transform="translate(-2.57,-19.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(76.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(76.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(76.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="528" class="nad-vl120to180" title="L103-105-1">
             <g>
                 <polyline points="-1.20,-19.52 -1.70,-20.88"/>
+                <g class="nad-edge-infos" transform="translate(-1.51,-20.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-20.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-20.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.20,-22.23 -1.70,-20.88"/>
+                <g class="nad-edge-infos" transform="translate(-1.89,-21.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(159.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(159.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="529" class="nad-vl120to180" title="L103-110-1">
             <g>
                 <polyline points="-1.20,-19.52 1.09,-20.27"/>
+                <g class="nad-edge-infos" transform="translate(-0.34,-19.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(71.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(71.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(71.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(71.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.38,-21.02 1.09,-20.27"/>
+                <g class="nad-edge-infos" transform="translate(2.53,-20.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-108.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(71.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-108.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(71.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="530" class="nad-vl120to180" title="L104-105-1">
             <g>
                 <polyline points="-3.45,-19.00 -2.83,-20.62"/>
+                <g class="nad-edge-infos" transform="translate(-3.13,-19.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(21.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(21.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.20,-22.23 -2.83,-20.62"/>
+                <g class="nad-edge-infos" transform="translate(-2.53,-21.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-158.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-158.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="531" class="nad-vl120to180" title="L105-106-1">
             <g>
                 <polyline points="-2.20,-22.23 -3.69,-21.81"/>
+                <g class="nad-edge-infos" transform="translate(-3.07,-21.99)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-105.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(74.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-105.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(74.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.18,-21.38 -3.69,-21.81"/>
+                <g class="nad-edge-infos" transform="translate(-4.32,-21.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(74.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(74.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(74.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(74.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="532" class="nad-vl120to180" title="L105-107-1">
             <g>
                 <polyline points="-2.20,-22.23 -3.13,-23.17"/>
+                <g class="nad-edge-infos" transform="translate(-2.84,-22.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-44.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-44.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.06,-24.10 -3.13,-23.17"/>
+                <g class="nad-edge-infos" transform="translate(-3.43,-23.46)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(135.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(135.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="533" class="nad-vl120to180" title="L105-108-1">
             <g>
                 <polyline points="-2.20,-22.23 -1.02,-23.22"/>
+                <g class="nad-edge-infos" transform="translate(-1.51,-22.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.17,-24.21 -1.02,-23.22"/>
+                <g class="nad-edge-infos" transform="translate(-0.52,-23.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="534" class="nad-vl120to180" title="L106-107-1">
             <g>
                 <polyline points="-5.18,-21.38 -4.62,-22.74"/>
+                <g class="nad-edge-infos" transform="translate(-4.84,-22.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(22.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(22.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.06,-24.10 -4.62,-22.74"/>
+                <g class="nad-edge-infos" transform="translate(-4.40,-23.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-157.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-157.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="535" class="nad-vl120to180" title="L108-109-1">
             <g>
                 <polyline points="0.17,-24.21 1.45,-24.01"/>
+                <g class="nad-edge-infos" transform="translate(1.06,-24.07)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.74,-23.81 1.45,-24.01"/>
+                <g class="nad-edge-infos" transform="translate(1.85,-23.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="536" class="nad-vl120to180" title="L109-110-1">
             <g>
                 <polyline points="2.74,-23.81 3.06,-22.42"/>
+                <g class="nad-edge-infos" transform="translate(2.94,-22.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(167.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(167.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.38,-21.02 3.06,-22.42"/>
+                <g class="nad-edge-infos" transform="translate(3.18,-21.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-12.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-12.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="537" class="nad-vl120to180" title="L110-111-1">
             <g>
                 <polyline points="3.38,-21.02 4.79,-21.67"/>
+                <g class="nad-edge-infos" transform="translate(4.20,-21.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(65.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(65.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.20,-22.32 4.79,-21.67"/>
+                <g class="nad-edge-infos" transform="translate(5.38,-21.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-114.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-114.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="538" class="nad-vl120to180" title="L110-112-1">
             <g>
                 <polyline points="3.38,-21.02 4.51,-20.09"/>
+                <g class="nad-edge-infos" transform="translate(4.07,-20.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(129.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(129.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.64,-19.15 4.51,-20.09"/>
+                <g class="nad-edge-infos" transform="translate(4.94,-19.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-50.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-50.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="539" class="nad-vl120to180" title="L114-115-1">
             <g>
                 <polyline points="13.77,-7.06 14.70,-7.82"/>
+                <g class="nad-edge-infos" transform="translate(14.46,-7.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="15.63,-8.59 14.70,-7.82"/>
+                <g class="nad-edge-infos" transform="translate(14.94,-8.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,167 +30,807 @@
         <g id="42" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.84,-3.02 2.61,-3.29"/>
+                <g class="nad-edge-infos" transform="translate(2.96,-3.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">157</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-77.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">-20</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.37,-3.57 2.61,-3.29"/>
+                <g class="nad-edge-infos" transform="translate(2.25,-3.37)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(102.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">-153</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(102.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">28</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="43" class="nad-vl120to180" title="L1-5-1">
             <g>
                 <polyline points="3.84,-3.02 2.86,-1.96"/>
+                <g class="nad-edge-infos" transform="translate(3.23,-2.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-137.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">76</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-137.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 2.86,-1.96"/>
+                <g class="nad-edge-infos" transform="translate(2.50,-1.57)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(42.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">-73</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(42.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="44" class="nad-vl120to180" title="L2-3-1">
             <g>
                 <polyline points="1.37,-3.57 0.42,-4.38"/>
+                <g class="nad-edge-infos" transform="translate(0.68,-4.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-49.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">73</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-49.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.54,-5.19 0.42,-4.38"/>
+                <g class="nad-edge-infos" transform="translate(0.15,-4.61)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(130.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">-71</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(130.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="45" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="1.37,-3.57 0.13,-2.96"/>
+                <g class="nad-edge-infos" transform="translate(0.56,-3.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-116.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">56</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-116.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.12,-2.35 0.13,-2.96"/>
+                <g class="nad-edge-infos" transform="translate(-0.31,-2.74)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(63.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">-54</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(63.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">3</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="46" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="1.37,-3.57 1.63,-2.24"/>
+                <g class="nad-edge-infos" transform="translate(1.54,-2.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(169.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">42</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(169.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">1</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 1.63,-2.24"/>
+                <g class="nad-edge-infos" transform="translate(1.71,-1.79)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-10.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">-41</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-10.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="47" class="nad-vl120to180" title="L3-4-1">
             <g>
                 <polyline points="-0.54,-5.19 -0.83,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-0.72,-4.31)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">-23</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.12,-2.35 -0.83,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-3.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">24</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">-5</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="48" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="-1.12,-2.35 0.38,-1.63"/>
+                <g class="nad-edge-infos" transform="translate(-0.31,-1.96)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(115.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">-61</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(115.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">16</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 0.38,-1.63"/>
+                <g class="nad-edge-infos" transform="translate(1.07,-1.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-64.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">62</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-64.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">-14</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="49" title="T4-7-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -2.69,-2.12"/>
                 <circle cx="-2.59" cy="-2.14" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.01,-2.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">28</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-98.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">-10</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-4.25,-1.90 -2.69,-2.12"/>
                 <circle cx="-2.78" cy="-2.11" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.36,-2.03)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(81.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">-28</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">11</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="50" title="T4-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -1.85,-0.92"/>
                 <circle cx="-1.81" cy="-1.01" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.53,-1.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-152.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">16</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-152.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-2.59,0.50 -1.85,-0.92"/>
                 <circle cx="-1.90" cy="-0.83" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.18,-0.30)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(27.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">-16</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(27.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="51" title="T5-6-1">
             <g class="nad-vl120to180">
                 <polyline points="1.88,-0.91 1.82,1.42"/>
                 <circle cx="1.82" cy="1.32" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.86,-0.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">44</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-178.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">12</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="1.76,3.74 1.82,1.42"/>
                 <circle cx="1.82" cy="1.52" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.78,2.84)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(1.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">-44</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(1.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">-8</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="52" class="nad-vl0to30" title="L6-11-1">
             <g>
                 <polyline points="1.76,3.74 0.34,4.57"/>
+                <g class="nad-edge-infos" transform="translate(0.98,4.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-120.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">7</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-120.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.08,5.40 0.34,4.57"/>
+                <g class="nad-edge-infos" transform="translate(-0.30,4.95)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(59.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">-7</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(59.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">-3</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="53" class="nad-vl0to30" title="L6-12-1">
             <g>
                 <polyline points="1.76,3.74 2.94,4.52"/>
+                <g class="nad-edge-infos" transform="translate(2.51,4.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(123.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">8</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(123.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">3</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.12,5.30 2.94,4.52"/>
+                <g class="nad-edge-infos" transform="translate(3.37,4.80)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-56.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">-8</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-56.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="54" class="nad-vl0to30" title="L6-13-1">
             <g>
                 <polyline points="1.76,3.74 2.66,3.35"/>
+                <g class="nad-edge-infos" transform="translate(2.58,3.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(66.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">18</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(66.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">7</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.56,2.95 2.66,3.35"/>
+                <g class="nad-edge-infos" transform="translate(2.73,3.31)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-113.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">-18</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-113.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">-7</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="55" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="-4.25,-1.90 -5.60,-2.40"/>
+                <g class="nad-edge-infos" transform="translate(-5.10,-2.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-69.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-69.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">-17</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.95,-2.90 -5.60,-2.40"/>
+                <g class="nad-edge-infos" transform="translate(-6.11,-2.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(110.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(110.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">18</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="56" class="nad-vl0to30" title="L7-9-1">
             <g>
                 <polyline points="-4.25,-1.90 -3.42,-0.70"/>
+                <g class="nad-edge-infos" transform="translate(-3.74,-1.16)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(145.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">28</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(145.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">6</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.59,0.50 -3.42,-0.70"/>
+                <g class="nad-edge-infos" transform="translate(-3.10,-0.24)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-34.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">-28</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-34.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">-5</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="57" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-2.59,0.50 -2.97,2.08"/>
+                <g class="nad-edge-infos" transform="translate(-2.80,1.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">5</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.34,3.67 -2.97,2.08"/>
+                <g class="nad-edge-infos" transform="translate(-3.13,2.79)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(13.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">-5</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(13.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">-4</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="58" class="nad-vl0to30" title="L9-14-1">
             <g>
                 <polyline points="-2.59,0.50 -1.17,1.14"/>
+                <g class="nad-edge-infos" transform="translate(-1.77,0.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(114.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">9</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(114.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.26,1.77 -1.17,1.14"/>
+                <g class="nad-edge-infos" transform="translate(-0.56,1.41)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-65.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">-9</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(-65.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">-3</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="59" class="nad-vl0to30" title="L10-11-1">
             <g>
                 <polyline points="-3.34,3.67 -2.21,4.53"/>
+                <g class="nad-edge-infos" transform="translate(-2.63,4.21)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(127.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">-4</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(127.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.08,5.40 -2.21,4.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.80,4.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-52.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">4</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-52.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="60" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="4.12,5.30 3.84,4.13"/>
+                <g class="nad-edge-infos" transform="translate(3.91,4.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-13.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-13.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">1</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.56,2.95 3.84,4.13"/>
+                <g class="nad-edge-infos" transform="translate(3.77,3.83)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(166.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(166.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">-1</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="61" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="3.56,2.95 1.91,2.36"/>
+                <g class="nad-edge-infos" transform="translate(2.71,2.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">6</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-70.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">2</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.26,1.77 1.91,2.36"/>
+                <g class="nad-edge-infos" transform="translate(1.11,2.08)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(109.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">-6</text>
+                    </g>
+                    <g class="nad-reactive nad-state-in">
+                        <g transform="rotate(109.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">-2</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,167 +30,807 @@
         <g id="42" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.84,-3.02 2.61,-3.29"/>
+                <g class="nad-edge-infos" transform="translate(2.96,-3.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-77.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.37,-3.57 2.61,-3.29"/>
+                <g class="nad-edge-infos" transform="translate(2.25,-3.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(102.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="43" class="nad-vl120to180" title="L1-5-1">
             <g>
                 <polyline points="3.84,-3.02 2.86,-1.96"/>
+                <g class="nad-edge-infos" transform="translate(3.23,-2.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-137.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-137.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 2.86,-1.96"/>
+                <g class="nad-edge-infos" transform="translate(2.50,-1.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(42.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(42.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="44" class="nad-vl120to180" title="L2-3-1">
             <g>
                 <polyline points="1.37,-3.57 0.42,-4.38"/>
+                <g class="nad-edge-infos" transform="translate(0.68,-4.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-49.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-49.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.54,-5.19 0.42,-4.38"/>
+                <g class="nad-edge-infos" transform="translate(0.15,-4.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(130.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(130.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-49.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="45" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="1.37,-3.57 0.13,-2.96"/>
+                <g class="nad-edge-infos" transform="translate(0.56,-3.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-116.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-116.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.12,-2.35 0.13,-2.96"/>
+                <g class="nad-edge-infos" transform="translate(-0.31,-2.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(63.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(63.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(63.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="46" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="1.37,-3.57 1.63,-2.24"/>
+                <g class="nad-edge-infos" transform="translate(1.54,-2.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(169.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(169.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 1.63,-2.24"/>
+                <g class="nad-edge-infos" transform="translate(1.71,-1.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-10.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-10.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="47" class="nad-vl120to180" title="L3-4-1">
             <g class="nad-disconnected">
                 <polyline points="-0.54,-5.19 -0.83,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-0.72,-4.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.12,-2.35 -0.83,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-3.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(11.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="48" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="-1.12,-2.35 0.38,-1.63"/>
+                <g class="nad-edge-infos" transform="translate(-0.31,-1.96)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(115.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(115.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.88,-0.91 0.38,-1.63"/>
+                <g class="nad-edge-infos" transform="translate(1.07,-1.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-64.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-64.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="49" title="T4-7-1">
             <g class="nad-disconnected nad-vl120to180">
                 <polyline points="-1.12,-2.35 -2.69,-2.12"/>
                 <circle cx="-2.59" cy="-2.14" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.01,-2.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-98.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-4.25,-1.90 -2.69,-2.12"/>
                 <circle cx="-2.78" cy="-2.11" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.36,-2.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="50" title="T4-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.12,-2.35 -1.85,-0.92"/>
                 <circle cx="-1.81" cy="-1.01" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.53,-1.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-152.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-152.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-2.59,0.50 -1.85,-0.92"/>
                 <circle cx="-1.90" cy="-0.83" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.18,-0.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(27.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(27.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="51" title="T5-6-1">
             <g class="nad-vl120to180">
                 <polyline points="1.88,-0.91 1.82,1.42"/>
                 <circle cx="1.82" cy="1.32" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.86,-0.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-178.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-178.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="1.76,3.74 1.82,1.42"/>
                 <circle cx="1.82" cy="1.52" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.78,2.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(1.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(1.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="52" class="nad-vl0to30" title="L6-11-1">
             <g>
                 <polyline points="1.76,3.74 0.34,4.57"/>
+                <g class="nad-edge-infos" transform="translate(0.98,4.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-120.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-120.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.08,5.40 0.34,4.57"/>
+                <g class="nad-edge-infos" transform="translate(-0.30,4.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(59.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(59.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="53" class="nad-vl0to30" title="L6-12-1">
             <g>
                 <polyline points="1.76,3.74 2.94,4.52"/>
+                <g class="nad-edge-infos" transform="translate(2.51,4.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(123.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(123.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.12,5.30 2.94,4.52"/>
+                <g class="nad-edge-infos" transform="translate(3.37,4.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-56.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-56.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="54" class="nad-vl0to30" title="L6-13-1">
             <g>
                 <polyline points="1.76,3.74 2.66,3.35"/>
+                <g class="nad-edge-infos" transform="translate(2.58,3.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(66.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(66.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.56,2.95 2.66,3.35"/>
+                <g class="nad-edge-infos" transform="translate(2.73,3.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-113.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-113.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="55" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="-4.25,-1.90 -5.60,-2.40"/>
+                <g class="nad-edge-infos" transform="translate(-5.10,-2.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-69.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-69.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.95,-2.90 -5.60,-2.40"/>
+                <g class="nad-edge-infos" transform="translate(-6.11,-2.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(110.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(110.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="56" class="nad-vl0to30" title="L7-9-1">
             <g>
                 <polyline points="-4.25,-1.90 -3.42,-0.70"/>
+                <g class="nad-edge-infos" transform="translate(-3.74,-1.16)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(145.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(145.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.59,0.50 -3.42,-0.70"/>
+                <g class="nad-edge-infos" transform="translate(-3.10,-0.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-34.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-34.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="57" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-2.59,0.50 -2.97,2.08"/>
+                <g class="nad-edge-infos" transform="translate(-2.80,1.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.34,3.67 -2.97,2.08"/>
+                <g class="nad-edge-infos" transform="translate(-3.13,2.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="58" class="nad-vl0to30" title="L9-14-1">
             <g>
                 <polyline points="-2.59,0.50 -1.17,1.14"/>
+                <g class="nad-edge-infos" transform="translate(-1.77,0.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(114.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(114.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.26,1.77 -1.17,1.14"/>
+                <g class="nad-edge-infos" transform="translate(-0.56,1.41)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-65.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-65.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-65.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="59" class="nad-vl0to30" title="L10-11-1">
             <g>
                 <polyline points="-3.34,3.67 -2.21,4.53"/>
+                <g class="nad-edge-infos" transform="translate(-2.63,4.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(127.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(127.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.08,5.40 -2.21,4.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.80,4.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-52.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-52.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="60" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="4.12,5.30 3.84,4.13"/>
+                <g class="nad-edge-infos" transform="translate(3.91,4.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-13.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-13.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.56,2.95 3.84,4.13"/>
+                <g class="nad-edge-infos" transform="translate(3.77,3.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(166.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(166.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-13.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="61" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="3.56,2.95 1.91,2.36"/>
+                <g class="nad-edge-infos" transform="translate(2.71,2.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-70.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.26,1.77 1.91,2.36"/>
+                <g class="nad-edge-infos" transform="translate(1.11,2.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(109.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(109.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,167 +30,807 @@
         <g id="42" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="-4.23,-6.18 -2.91,-5.73"/>
+                <g class="nad-edge-infos" transform="translate(-3.38,-5.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.59,-5.28 -2.91,-5.73"/>
+                <g class="nad-edge-infos" transform="translate(-2.44,-5.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="43" class="nad-vl120to180" title="L1-5-1">
             <g>
                 <polyline points="-4.23,-6.18 -3.56,-3.98"/>
+                <g class="nad-edge-infos" transform="translate(-3.97,-5.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(163.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(163.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.89,-1.79 -3.56,-3.98"/>
+                <g class="nad-edge-infos" transform="translate(-3.16,-2.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-16.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-16.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="44" class="nad-vl120to180" title="L2-3-1">
             <g>
                 <polyline points="-1.59,-5.28 -2.42,-4.66"/>
+                <g class="nad-edge-infos" transform="translate(-2.31,-4.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-126.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-126.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.24,-4.04 -2.42,-4.66"/>
+                <g class="nad-edge-infos" transform="translate(-2.52,-4.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(53.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(53.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(53.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="45" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="-1.59,-5.28 -0.39,-4.18"/>
+                <g class="nad-edge-infos" transform="translate(-0.93,-4.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(132.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.80,-3.09 -0.39,-4.18"/>
+                <g class="nad-edge-infos" transform="translate(0.14,-3.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="46" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="-1.59,-5.28 -2.24,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.91,-4.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-159.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(20.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-159.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(20.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.89,-1.79 -2.24,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-2.58,-2.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(20.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(20.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(20.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(20.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="47" class="nad-vl120to180" title="L3-4-1">
             <g>
                 <polyline points="-3.24,-4.04 -1.22,-3.56"/>
+                <g class="nad-edge-infos" transform="translate(-2.37,-3.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(103.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(103.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.80,-3.09 -1.22,-3.56"/>
+                <g class="nad-edge-infos" transform="translate(-0.07,-3.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-76.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-76.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-76.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="48" class="nad-vl120to180" title="L4-5-1">
             <g>
                 <polyline points="0.80,-3.09 -1.05,-2.44"/>
+                <g class="nad-edge-infos" transform="translate(-0.05,-2.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.89,-1.79 -1.05,-2.44"/>
+                <g class="nad-edge-infos" transform="translate(-2.04,-2.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="49" title="T4-7-1">
             <g class="nad-vl120to180">
                 <polyline points="0.80,-3.09 3.00,-3.00"/>
                 <circle cx="2.90" cy="-3.00" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.70,-3.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(92.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(92.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="5.21,-2.91 3.00,-3.00"/>
                 <circle cx="3.10" cy="-2.99" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(4.31,-2.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-87.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-87.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="50" title="T4-9-1">
             <g class="nad-vl120to180">
                 <polyline points="0.80,-3.09 2.32,-1.29"/>
                 <circle cx="2.26" cy="-1.37" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.38,-2.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(139.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-40.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(139.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-40.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="3.84,0.51 2.32,-1.29"/>
                 <circle cx="2.38" cy="-1.22" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(3.26,-0.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-40.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-40.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-40.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-40.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="51" title="T5-6-1">
             <g class="nad-vl120to180">
                 <polyline points="-2.89,-1.79 -3.08,1.13"/>
                 <circle cx="-3.07" cy="1.03" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.95,-0.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-176.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-176.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-3.27,4.05 -3.08,1.13"/>
                 <circle cx="-3.09" cy="1.23" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.21,3.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(3.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(3.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="52" class="nad-vl0to30" title="L6-11-1">
             <g>
                 <polyline points="-3.27,4.05 -1.59,4.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.41,4.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.09,5.16 -1.59,4.61"/>
+                <g class="nad-edge-infos" transform="translate(-0.77,4.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="53" class="nad-vl0to30" title="L6-12-1">
             <g>
                 <polyline points="-3.27,4.05 -3.91,5.63"/>
+                <g class="nad-edge-infos" transform="translate(-3.61,4.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-157.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-157.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.56,7.21 -3.91,5.63"/>
+                <g class="nad-edge-infos" transform="translate(-4.22,6.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(22.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(22.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="54" class="nad-vl0to30" title="L6-13-1">
             <g>
                 <polyline points="-3.27,4.05 -2.40,5.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.83,4.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(150.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(150.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.53,7.18 -2.40,5.61"/>
+                <g class="nad-edge-infos" transform="translate(-1.97,6.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-29.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-29.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-29.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="55" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="5.21,-2.91 7.09,-3.09"/>
+                <g class="nad-edge-infos" transform="translate(6.10,-2.99)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(84.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(84.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.98,-3.27 7.09,-3.09"/>
+                <g class="nad-edge-infos" transform="translate(8.08,-3.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-95.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-95.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="56" class="nad-vl0to30" title="L7-9-1">
             <g>
                 <polyline points="5.21,-2.91 4.52,-1.20"/>
+                <g class="nad-edge-infos" transform="translate(4.87,-2.07)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-158.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-158.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.84,0.51 4.52,-1.20"/>
+                <g class="nad-edge-infos" transform="translate(4.17,-0.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(21.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(21.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="57" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="3.84,0.51 2.87,1.56"/>
+                <g class="nad-edge-infos" transform="translate(3.23,1.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-137.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-137.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.89,2.61 2.87,1.56"/>
+                <g class="nad-edge-infos" transform="translate(2.50,1.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(42.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(42.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="58" class="nad-vl0to30" title="L9-14-1">
             <g>
                 <polyline points="3.84,0.51 3.56,2.87"/>
+                <g class="nad-edge-infos" transform="translate(3.73,1.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-173.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-173.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.29,5.23 3.56,2.87"/>
+                <g class="nad-edge-infos" transform="translate(3.39,4.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(6.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(6.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="59" class="nad-vl0to30" title="L10-11-1">
             <g>
                 <polyline points="1.89,2.61 0.99,3.89"/>
+                <g class="nad-edge-infos" transform="translate(1.37,3.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-144.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-144.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.09,5.16 0.99,3.89"/>
+                <g class="nad-edge-infos" transform="translate(0.61,4.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(35.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(35.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="60" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="-4.56,7.21 -3.05,7.19"/>
+                <g class="nad-edge-infos" transform="translate(-3.66,7.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(89.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(89.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.53,7.18 -3.05,7.19"/>
+                <g class="nad-edge-infos" transform="translate(-2.43,7.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-90.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-90.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="61" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="-1.53,7.18 0.88,6.20"/>
+                <g class="nad-edge-infos" transform="translate(-0.70,6.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(68.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(68.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.29,5.23 0.88,6.20"/>
+                <g class="nad-edge-infos" transform="translate(2.45,5.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-111.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-111.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(68.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,317 +30,1533 @@
         <g id="72" class="nad-vl120to180" title="L-1-2-1 ">
             <g>
                 <polyline points="-2.56,6.78 -1.68,7.75"/>
+                <g class="nad-edge-infos" transform="translate(-1.95,7.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(138.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(138.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.81,8.72 -1.68,7.75"/>
+                <g class="nad-edge-infos" transform="translate(-1.41,8.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-41.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-41.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="73" class="nad-vl120to180" title="L-3-1-1 ">
             <g>
                 <polyline points="-2.74,3.22 -2.65,5.00"/>
+                <g class="nad-edge-infos" transform="translate(-2.69,4.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(177.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(177.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.56,6.78 -2.65,5.00"/>
+                <g class="nad-edge-infos" transform="translate(-2.60,5.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-2.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-2.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="74" class="nad-vl120to180" title="L-1-5-1 ">
             <g>
                 <polyline points="-2.56,6.78 -0.83,6.84"/>
+                <g class="nad-edge-infos" transform="translate(-1.66,6.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(91.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-88.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(91.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-88.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.89,6.90 -0.83,6.84"/>
+                <g class="nad-edge-infos" transform="translate(-0.01,6.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-88.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-88.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-88.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-88.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="75" class="nad-vl120to180" title="L-2-4-1 ">
             <g>
                 <polyline points="-0.81,8.72 -0.72,7.10"/>
+                <g class="nad-edge-infos" transform="translate(-0.76,7.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(3.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(3.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.63,5.48 -0.72,7.10"/>
+                <g class="nad-edge-infos" transform="translate(-0.68,6.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-176.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-176.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(3.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="76" class="nad-vl120to180" title="L-2-6-1 ">
             <g>
                 <polyline points="-0.81,8.72 0.81,8.74"/>
+                <g class="nad-edge-infos" transform="translate(0.09,8.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(90.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(90.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.43,8.76 0.81,8.74"/>
+                <g class="nad-edge-infos" transform="translate(1.53,8.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-89.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-89.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="77" title="T-24-3-1 ">
             <g class="nad-vl180to300">
                 <polyline points="-4.85,0.21 -3.80,1.72"/>
                 <circle cx="-3.85" cy="1.64" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-4.33,0.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(144.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(144.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="-2.74,3.22 -3.80,1.72"/>
                 <circle cx="-3.74" cy="1.80" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.26,2.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-35.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-35.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-35.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="78" class="nad-vl120to180" title="L-3-9-1 ">
             <g>
                 <polyline points="-2.74,3.22 -0.61,3.25"/>
+                <g class="nad-edge-infos" transform="translate(-1.84,3.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(90.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(90.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.52,3.27 -0.61,3.25"/>
+                <g class="nad-edge-infos" transform="translate(0.62,3.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-89.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-89.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="79" class="nad-vl180to300" title="L-15-24-1 ">
             <g>
                 <polyline points="-4.99,-3.40 -4.92,-1.59"/>
+                <g class="nad-edge-infos" transform="translate(-4.96,-2.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(177.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(177.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.85,0.21 -4.92,-1.59"/>
+                <g class="nad-edge-infos" transform="translate(-4.89,-0.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-2.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-2.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="80" class="nad-vl120to180" title="L-4-9-1 ">
             <g>
                 <polyline points="-0.63,5.48 0.45,4.38"/>
+                <g class="nad-edge-infos" transform="translate(-0.00,4.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(44.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(44.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.52,3.27 0.45,4.38"/>
+                <g class="nad-edge-infos" transform="translate(0.90,3.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-135.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-135.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="81" title="T-5-10-1 ">
             <g class="nad-vl120to180">
                 <polyline points="0.89,6.90 2.08,5.90"/>
                 <circle cx="2.00" cy="5.97" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.58,6.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="3.27,4.91 2.08,5.90"/>
                 <circle cx="2.16" cy="5.84" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.58,5.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="82" title="T-11-9-1 ">
             <g class="nad-vl180to300">
                 <polyline points="1.98,0.84 1.75,2.06"/>
                 <circle cx="1.77" cy="1.96" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.81,1.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-169.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-169.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="1.52,3.27 1.75,2.06"/>
                 <circle cx="1.73" cy="2.16" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.69,2.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(10.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(10.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="83" title="T-9-12-1 ">
             <g class="nad-vl120to180">
                 <polyline points="1.52,3.27 3.07,2.47"/>
                 <circle cx="2.98" cy="2.51" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.32,2.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(62.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(62.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(62.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(62.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl180to300">
                 <polyline points="4.61,1.66 3.07,2.47"/>
                 <circle cx="3.16" cy="2.42" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(3.81,2.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-117.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(62.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-117.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(62.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="84" class="nad-vl180to300" title="L-8-9-1 ">
             <g>
                 <polyline points="5.53,5.20 3.53,4.24"/>
+                <g class="nad-edge-infos" transform="translate(4.72,4.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-64.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-64.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.52,3.27 3.53,4.24"/>
+                <g class="nad-edge-infos" transform="translate(2.34,3.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(115.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(115.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-64.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="85" title="T-11-10-1 ">
             <g class="nad-vl180to300">
                 <polyline points="1.98,0.84 2.62,2.87"/>
                 <circle cx="2.59" cy="2.78" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.25,1.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="3.27,4.91 2.62,2.87"/>
                 <circle cx="2.65" cy="2.97" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.99,4.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="86" title="T-12-10-1 ">
             <g class="nad-vl180to300">
                 <polyline points="4.61,1.66 3.94,3.28"/>
                 <circle cx="3.98" cy="3.19" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(4.27,2.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-157.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-157.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl120to180">
                 <polyline points="3.27,4.91 3.94,3.28"/>
                 <circle cx="3.90" cy="3.38" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(3.61,4.07)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(22.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(22.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(22.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="87" class="nad-vl120to180" title="L-10-6-1 ">
             <g>
                 <polyline points="3.27,4.91 2.85,6.83"/>
+                <g class="nad-edge-infos" transform="translate(3.08,5.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-167.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-167.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.43,8.76 2.85,6.83"/>
+                <g class="nad-edge-infos" transform="translate(2.62,7.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(12.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(12.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="88" class="nad-vl180to300" title="L-8-10-1 ">
             <g>
                 <polyline points="5.53,5.20 4.40,5.05"/>
+                <g class="nad-edge-infos" transform="translate(4.64,5.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-82.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-82.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.27,4.91 4.40,5.05"/>
+                <g class="nad-edge-infos" transform="translate(4.16,5.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(97.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(97.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="89" class="nad-vl180to300" title="L-11-13-1 ">
             <g>
                 <polyline points="1.98,0.84 3.25,0.16"/>
+                <g class="nad-edge-infos" transform="translate(2.77,0.41)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(61.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(61.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.52,-0.53 3.25,0.16"/>
+                <g class="nad-edge-infos" transform="translate(3.72,-0.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-118.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-118.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="90" class="nad-vl180to300" title="L-11-14-1 ">
             <g>
                 <polyline points="1.98,0.84 0.99,-0.76"/>
+                <g class="nad-edge-infos" transform="translate(1.51,0.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-31.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-31.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.00,-2.36 0.99,-0.76"/>
+                <g class="nad-edge-infos" transform="translate(0.48,-1.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(148.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(148.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="91" class="nad-vl180to300" title="L-12-13-1 ">
             <g>
                 <polyline points="4.61,1.66 4.56,0.57"/>
+                <g class="nad-edge-infos" transform="translate(4.57,0.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-2.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-2.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.52,-0.53 4.56,0.57"/>
+                <g class="nad-edge-infos" transform="translate(4.56,0.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(177.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(177.50)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="92" class="nad-vl180to300" title="L-12-23-1 ">
             <g>
                 <polyline points="4.61,1.66 5.23,-0.29"/>
+                <g class="nad-edge-infos" transform="translate(4.88,0.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(17.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(17.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.84,-2.24 5.23,-0.29"/>
+                <g class="nad-edge-infos" transform="translate(5.57,-1.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-162.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-162.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="93" class="nad-vl120to180" title="L-7-8-1 ">
             <g>
                 <polyline points="8.37,6.37 6.95,5.78"/>
+                <g class="nad-edge-infos" transform="translate(7.54,6.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-67.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-67.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.53,5.20 6.95,5.78"/>
+                <g class="nad-edge-infos" transform="translate(6.36,5.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(112.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(112.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="94" class="nad-vl180to300" title="L-23-13-1 ">
             <g>
                 <polyline points="5.84,-2.24 5.18,-1.38"/>
+                <g class="nad-edge-infos" transform="translate(5.29,-1.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-142.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(37.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-142.37)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(37.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.52,-0.53 5.18,-1.38"/>
+                <g class="nad-edge-infos" transform="translate(5.07,-1.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(37.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(37.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(37.63)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(37.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="95" class="nad-vl180to300" title="L-14-16-1 ">
             <g>
                 <polyline points="0.00,-2.36 -0.92,-3.79"/>
+                <g class="nad-edge-infos" transform="translate(-0.49,-3.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-33.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-33.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.85,-5.21 -0.92,-3.79"/>
+                <g class="nad-edge-infos" transform="translate(-1.36,-4.46)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(146.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(146.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="96" class="nad-vl180to300" title="L-16-15-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -3.42,-4.31"/>
+                <g class="nad-edge-infos" transform="translate(-2.63,-4.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-119.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(60.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-119.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(60.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.99,-3.40 -3.42,-4.31"/>
+                <g class="nad-edge-infos" transform="translate(-4.21,-3.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(60.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(60.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(60.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(60.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="97" class="nad-vl180to300" title="L-15-21-1 ">
             <g>
                 <polyline points="-4.99,-3.40 -5.10,-4.19 -5.45,-4.64"/>
+                <g class="nad-edge-infos" transform="translate(-5.29,-4.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-37.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-37.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.54,-5.38 -5.80,-5.08 -5.45,-4.64"/>
+                <g class="nad-edge-infos" transform="translate(-5.61,-4.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(142.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(142.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="98" class="nad-vl180to300" title="L-21-15-2 ">
             <g>
                 <polyline points="-4.99,-3.40 -5.74,-3.70 -6.08,-4.15"/>
+                <g class="nad-edge-infos" transform="translate(-5.92,-3.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-37.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-37.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.54,-5.38 -6.43,-4.59 -6.08,-4.15"/>
+                <g class="nad-edge-infos" transform="translate(-6.24,-4.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(142.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(142.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-37.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="99" class="nad-vl180to300" title="L-16-17-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -3.14,-6.34"/>
+                <g class="nad-edge-infos" transform="translate(-2.52,-5.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-48.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-48.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.44,-7.47 -3.14,-6.34"/>
+                <g class="nad-edge-infos" transform="translate(-3.76,-6.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(131.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(131.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-48.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="100" class="nad-vl180to300" title="L-16-19-1 ">
             <g>
                 <polyline points="-1.85,-5.21 -0.13,-5.83"/>
+                <g class="nad-edge-infos" transform="translate(-1.00,-5.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.59,-6.46 -0.13,-5.83"/>
+                <g class="nad-edge-infos" transform="translate(0.74,-6.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="101" class="nad-vl180to300" title="L-17-18-1 ">
             <g>
                 <polyline points="-4.44,-7.47 -6.15,-7.32"/>
+                <g class="nad-edge-infos" transform="translate(-5.34,-7.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-95.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-95.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.85,-7.16 -6.15,-7.32"/>
+                <g class="nad-edge-infos" transform="translate(-6.96,-7.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(84.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(84.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(84.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="102" class="nad-vl180to300" title="L-17-22-1 ">
             <g>
                 <polyline points="-4.44,-7.47 -5.31,-8.13"/>
+                <g class="nad-edge-infos" transform="translate(-5.16,-8.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-52.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-52.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.18,-8.79 -5.31,-8.13"/>
+                <g class="nad-edge-infos" transform="translate(-5.46,-8.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(127.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(127.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-52.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="103" class="nad-vl180to300" title="L-18-21-1 ">
             <g>
                 <polyline points="-7.85,-7.16 -7.76,-6.37 -7.52,-6.04"/>
+                <g class="nad-edge-infos" transform="translate(-7.58,-6.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.54,-5.38 -7.27,-5.70 -7.52,-6.04"/>
+                <g class="nad-edge-infos" transform="translate(-7.45,-5.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="104" class="nad-vl180to300" title="L-18-21-2 ">
             <g>
                 <polyline points="-7.85,-7.16 -7.12,-6.85 -6.87,-6.51"/>
+                <g class="nad-edge-infos" transform="translate(-6.94,-6.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.54,-5.38 -6.63,-6.18 -6.87,-6.51"/>
+                <g class="nad-edge-infos" transform="translate(-6.81,-6.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="105" class="nad-vl180to300" title="L-19-20-1 ">
             <g>
                 <polyline points="1.59,-6.46 2.11,-5.85 2.98,-5.54"/>
+                <g class="nad-edge-infos" transform="translate(2.39,-5.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(109.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(109.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.64,-5.38 3.85,-5.23 2.98,-5.54"/>
+                <g class="nad-edge-infos" transform="translate(3.57,-5.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-70.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="106" class="nad-vl180to300" title="L-19-20-2 ">
             <g>
                 <polyline points="1.59,-6.46 2.38,-6.60 3.25,-6.29"/>
+                <g class="nad-edge-infos" transform="translate(2.66,-6.50)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(109.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(109.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.64,-5.38 4.12,-5.99 3.25,-6.29"/>
+                <g class="nad-edge-infos" transform="translate(3.83,-6.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-70.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-70.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="107" class="nad-vl180to300" title="L-20-23-1 ">
             <g>
                 <polyline points="4.64,-5.38 4.51,-4.59 4.86,-3.67"/>
+                <g class="nad-edge-infos" transform="translate(4.62,-4.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(159.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(159.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.84,-2.24 5.22,-2.75 4.86,-3.67"/>
+                <g class="nad-edge-infos" transform="translate(5.11,-3.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-20.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-20.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="108" class="nad-vl180to300" title="L-20-23-2 ">
             <g>
                 <polyline points="4.64,-5.38 5.26,-4.88 5.61,-3.95"/>
+                <g class="nad-edge-infos" transform="translate(5.36,-4.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(159.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(159.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.84,-2.24 5.96,-3.03 5.61,-3.95"/>
+                <g class="nad-edge-infos" transform="translate(5.86,-3.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-20.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-20.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-20.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="109" class="nad-vl180to300" title="L-21-22-1 ">
             <g>
                 <polyline points="-6.54,-5.38 -6.36,-7.09"/>
+                <g class="nad-edge-infos" transform="translate(-6.44,-6.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(6.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(6.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.18,-8.79 -6.36,-7.09"/>
+                <g class="nad-edge-infos" transform="translate(-6.27,-7.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-173.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-173.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(6.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,337 +30,1649 @@
         <g id="90" class="nad-vl120to180" title="L1-2-1">
             <g>
                 <polyline points="3.43,-8.61 2.21,-7.58"/>
+                <g class="nad-edge-infos" transform="translate(2.74,-8.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.90)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.99,-6.56 2.21,-7.58"/>
+                <g class="nad-edge-infos" transform="translate(1.68,-7.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.10)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="91" class="nad-vl120to180" title="L1-3-1">
             <g>
                 <polyline points="3.43,-8.61 4.11,-7.56"/>
+                <g class="nad-edge-infos" transform="translate(3.92,-7.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(147.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(147.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.78,-6.52 4.11,-7.56"/>
+                <g class="nad-edge-infos" transform="translate(4.29,-7.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-32.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-32.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="92" class="nad-vl120to180" title="L2-4-1">
             <g>
                 <polyline points="0.99,-6.56 1.87,-5.15"/>
+                <g class="nad-edge-infos" transform="translate(1.47,-5.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(147.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(147.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.76,-3.75 1.87,-5.15"/>
+                <g class="nad-edge-infos" transform="translate(2.28,-4.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-32.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-32.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-32.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="93" class="nad-vl120to180" title="L2-5-1">
             <g>
                 <polyline points="0.99,-6.56 0.18,-7.89"/>
+                <g class="nad-edge-infos" transform="translate(0.52,-7.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-31.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-31.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.63,-9.21 0.18,-7.89"/>
+                <g class="nad-edge-infos" transform="translate(-0.16,-8.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(148.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(148.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="94" class="nad-vl120to180" title="L2-6-1">
             <g>
                 <polyline points="0.99,-6.56 -0.39,-5.11"/>
+                <g class="nad-edge-infos" transform="translate(0.37,-5.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-136.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-136.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.77,-3.65 -0.39,-5.11"/>
+                <g class="nad-edge-infos" transform="translate(-1.15,-4.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(43.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(43.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="95" class="nad-vl120to180" title="L3-4-1">
             <g>
                 <polyline points="4.78,-6.52 3.77,-5.13"/>
+                <g class="nad-edge-infos" transform="translate(4.25,-5.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-143.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-143.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.76,-3.75 3.77,-5.13"/>
+                <g class="nad-edge-infos" transform="translate(3.29,-4.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(36.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(36.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(36.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="96" class="nad-vl120to180" title="L4-6-1">
             <g>
                 <polyline points="2.76,-3.75 0.50,-3.70"/>
+                <g class="nad-edge-infos" transform="translate(1.86,-3.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-91.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-91.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.77,-3.65 0.50,-3.70"/>
+                <g class="nad-edge-infos" transform="translate(-0.87,-3.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(88.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(88.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="97" title="T4-12-1">
             <g class="nad-vl120to180">
                 <polyline points="2.76,-3.75 4.46,-0.93"/>
                 <circle cx="4.40" cy="-1.01" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(3.23,-2.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(148.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(148.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl30to50">
                 <polyline points="6.15,1.89 4.46,-0.93"/>
                 <circle cx="4.51" cy="-0.84" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(5.69,1.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-31.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-31.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-31.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="98" class="nad-vl120to180" title="L5-7-1">
             <g>
                 <polyline points="-0.63,-9.21 -1.48,-8.27"/>
+                <g class="nad-edge-infos" transform="translate(-1.23,-8.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-138.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-138.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.32,-7.33 -1.48,-8.27"/>
+                <g class="nad-edge-infos" transform="translate(-1.72,-8.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(41.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(41.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="99" class="nad-vl120to180" title="L6-7-1">
             <g>
                 <polyline points="-1.77,-3.65 -2.04,-5.49"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,-4.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-8.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-8.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.32,-7.33 -2.04,-5.49"/>
+                <g class="nad-edge-infos" transform="translate(-2.19,-6.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(171.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(171.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="100" class="nad-vl120to180" title="L6-8-1">
             <g>
                 <polyline points="-1.77,-3.65 -3.47,-3.00"/>
+                <g class="nad-edge-infos" transform="translate(-2.61,-3.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-110.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(69.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-110.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(69.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.17,-2.35 -3.47,-3.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.33,-2.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(69.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(69.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(69.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(69.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="101" title="T6-9-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.77,-3.65 -2.80,-3.96"/>
                 <circle cx="-2.70" cy="-3.94" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.63,-3.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-73.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-73.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-3.83,-4.28 -2.80,-3.96"/>
                 <circle cx="-2.90" cy="-3.99" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.97,-4.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(106.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(106.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-73.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="102" title="T6-10-1">
             <g class="nad-vl120to180">
                 <polyline points="-1.77,-3.65 -1.18,-2.23"/>
                 <circle cx="-1.22" cy="-2.32" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.42,-2.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(157.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(157.54)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl30to50">
                 <polyline points="-0.59,-0.81 -1.18,-2.23"/>
                 <circle cx="-1.14" cy="-2.14" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-1.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-22.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-22.46)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="103" class="nad-vl120to180" title="L6-28-1">
             <g>
                 <polyline points="-1.77,-3.65 -3.72,-1.87"/>
+                <g class="nad-edge-infos" transform="translate(-2.43,-3.04)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-132.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-132.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.67,-0.09 -3.72,-1.87"/>
+                <g class="nad-edge-infos" transform="translate(-5.00,-0.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(47.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(47.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(47.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="104" class="nad-vl120to180" title="L8-28-1">
             <g>
                 <polyline points="-5.17,-2.35 -5.42,-1.22"/>
+                <g class="nad-edge-infos" transform="translate(-5.37,-1.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-167.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-167.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.67,-0.09 -5.42,-1.22"/>
+                <g class="nad-edge-infos" transform="translate(-5.48,-0.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(12.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(12.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="105" class="nad-vl0to30" title="L9-11-1">
             <g>
                 <polyline points="-3.83,-4.28 -5.24,-5.26"/>
+                <g class="nad-edge-infos" transform="translate(-4.57,-4.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-54.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-54.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.64,-6.25 -5.24,-5.26"/>
+                <g class="nad-edge-infos" transform="translate(-5.90,-5.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(125.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(125.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="106" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-3.83,-4.28 -2.21,-2.54"/>
+                <g class="nad-edge-infos" transform="translate(-3.22,-3.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(136.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(136.97)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.59,-0.81 -2.21,-2.54"/>
+                <g class="nad-edge-infos" transform="translate(-1.21,-1.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-43.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-43.03)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-43.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="107" class="nad-vl30to50" title="L10-20-1">
             <g>
                 <polyline points="-0.59,-0.81 1.70,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(0.30,-0.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.99,-1.46 1.70,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(3.10,-1.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-98.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(81.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="108" class="nad-vl30to50" title="L10-17-1">
             <g>
                 <polyline points="-0.59,-0.81 0.45,0.16"/>
+                <g class="nad-edge-infos" transform="translate(0.07,-0.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(132.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.50,1.13 0.45,0.16"/>
+                <g class="nad-edge-infos" transform="translate(0.84,0.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="109" class="nad-vl30to50" title="L10-21-1">
             <g>
                 <polyline points="-0.59,-0.81 -1.43,0.26"/>
+                <g class="nad-edge-infos" transform="translate(-1.15,-0.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.26,1.32 -1.43,0.26"/>
+                <g class="nad-edge-infos" transform="translate(-1.71,0.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="110" class="nad-vl30to50" title="L10-22-1">
             <g>
                 <polyline points="-0.59,-0.81 -0.94,1.26"/>
+                <g class="nad-edge-infos" transform="translate(-0.74,0.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-170.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-170.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.28,3.32 -0.94,1.26"/>
+                <g class="nad-edge-infos" transform="translate(-1.13,2.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(9.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(9.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(9.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="111" class="nad-vl30to50" title="L12-13-1">
             <g>
                 <polyline points="6.15,1.89 7.22,3.88"/>
+                <g class="nad-edge-infos" transform="translate(6.58,2.68)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(151.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(151.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.28,5.88 7.22,3.88"/>
+                <g class="nad-edge-infos" transform="translate(7.86,5.08)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-28.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-28.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-28.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="112" class="nad-vl30to50" title="L12-14-1">
             <g>
                 <polyline points="6.15,1.89 7.52,2.62"/>
+                <g class="nad-edge-infos" transform="translate(6.94,2.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(118.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-61.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(118.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-61.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.90,3.36 7.52,2.62"/>
+                <g class="nad-edge-infos" transform="translate(8.10,2.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-61.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-61.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-61.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-61.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="113" class="nad-vl30to50" title="L12-15-1">
             <g>
                 <polyline points="6.15,1.89 6.37,2.99"/>
+                <g class="nad-edge-infos" transform="translate(6.33,2.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(168.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(168.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.58,4.09 6.37,2.99"/>
+                <g class="nad-edge-infos" transform="translate(6.41,3.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-11.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-11.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-11.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="114" class="nad-vl30to50" title="L12-16-1">
             <g>
                 <polyline points="6.15,1.89 4.91,2.22"/>
+                <g class="nad-edge-infos" transform="translate(5.28,2.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-104.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-104.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.66,2.54 4.91,2.22"/>
+                <g class="nad-edge-infos" transform="translate(4.53,2.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(75.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(75.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="115" class="nad-vl30to50" title="L14-15-1">
             <g>
                 <polyline points="8.90,3.36 7.74,3.72"/>
+                <g class="nad-edge-infos" transform="translate(8.04,3.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-107.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-107.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.58,4.09 7.74,3.72"/>
+                <g class="nad-edge-infos" transform="translate(7.44,3.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(72.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(72.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="116" class="nad-vl30to50" title="L15-18-1">
             <g>
                 <polyline points="6.58,4.09 7.79,2.40"/>
+                <g class="nad-edge-infos" transform="translate(7.11,3.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(35.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(35.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.99,0.72 7.79,2.40"/>
+                <g class="nad-edge-infos" transform="translate(8.47,1.45)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-144.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-144.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(35.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="117" class="nad-vl30to50" title="L15-23-1">
             <g>
                 <polyline points="6.58,4.09 4.79,5.37"/>
+                <g class="nad-edge-infos" transform="translate(5.85,4.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-125.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-125.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.00,6.66 4.79,5.37"/>
+                <g class="nad-edge-infos" transform="translate(3.73,6.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(54.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(54.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(54.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="118" class="nad-vl30to50" title="L16-17-1">
             <g>
                 <polyline points="3.66,2.54 2.58,1.83"/>
+                <g class="nad-edge-infos" transform="translate(2.91,2.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-56.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-56.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.50,1.13 2.58,1.83"/>
+                <g class="nad-edge-infos" transform="translate(2.25,1.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(123.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(123.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-56.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="119" class="nad-vl30to50" title="L18-19-1">
             <g>
                 <polyline points="8.99,0.72 8.27,-0.49"/>
+                <g class="nad-edge-infos" transform="translate(8.54,-0.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-30.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-30.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.55,-1.71 8.27,-0.49"/>
+                <g class="nad-edge-infos" transform="translate(8.01,-0.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(149.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(149.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-30.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="120" class="nad-vl30to50" title="L19-20-1">
             <g>
                 <polyline points="7.55,-1.71 5.77,-1.58"/>
+                <g class="nad-edge-infos" transform="translate(6.66,-1.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-94.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-94.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.99,-1.46 5.77,-1.58"/>
+                <g class="nad-edge-infos" transform="translate(4.89,-1.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(85.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(85.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="121" class="nad-vl30to50" title="L21-22-1">
             <g>
                 <polyline points="-2.26,1.32 -1.77,2.32"/>
+                <g class="nad-edge-infos" transform="translate(-1.87,2.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(153.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(153.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.28,3.32 -1.77,2.32"/>
+                <g class="nad-edge-infos" transform="translate(-1.67,2.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-26.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-26.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="122" class="nad-vl30to50" title="L22-24-1">
             <g>
                 <polyline points="-1.28,3.32 -1.14,4.96"/>
+                <g class="nad-edge-infos" transform="translate(-1.20,4.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(175.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-4.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(175.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-4.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.01,6.59 -1.14,4.96"/>
+                <g class="nad-edge-infos" transform="translate(-1.08,5.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-4.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-4.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-4.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-4.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="123" class="nad-vl30to50" title="L23-24-1">
             <g>
                 <polyline points="3.00,6.66 1.00,6.62"/>
+                <g class="nad-edge-infos" transform="translate(2.10,6.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-89.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-89.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.01,6.59 1.00,6.62"/>
+                <g class="nad-edge-infos" transform="translate(-0.11,6.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(90.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(90.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-89.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="124" class="nad-vl30to50" title="L24-25-1">
             <g>
                 <polyline points="-1.01,6.59 -2.93,6.80"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,6.69)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-96.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-96.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.86,7.02 -2.93,6.80"/>
+                <g class="nad-edge-infos" transform="translate(-3.97,6.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(83.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(83.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="125" class="nad-vl30to50" title="L25-26-1">
             <g>
                 <polyline points="-4.86,7.02 -5.22,8.44"/>
+                <g class="nad-edge-infos" transform="translate(-5.08,7.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.05)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.57,9.86 -5.22,8.44"/>
+                <g class="nad-edge-infos" transform="translate(-5.35,8.99)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.95)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="126" class="nad-vl30to50" title="L25-27-1">
             <g>
                 <polyline points="-4.86,7.02 -6.22,5.49"/>
+                <g class="nad-edge-infos" transform="translate(-5.46,6.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-41.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-41.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-7.57,3.96 -6.22,5.49"/>
+                <g class="nad-edge-infos" transform="translate(-6.97,4.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(138.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(138.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-41.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="127" title="T28-27-1">
             <g class="nad-vl120to180">
                 <polyline points="-5.67,-0.09 -6.62,1.94"/>
                 <circle cx="-6.58" cy="1.85" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-6.05,0.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-154.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-154.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl30to50">
                 <polyline points="-7.57,3.96 -6.62,1.94"/>
                 <circle cx="-6.66" cy="2.03" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-7.19,3.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(25.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(25.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="128" class="nad-vl30to50" title="L27-29-1">
             <g>
                 <polyline points="-7.57,3.96 -9.02,3.74"/>
+                <g class="nad-edge-infos" transform="translate(-8.46,3.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.47,3.51 -9.02,3.74"/>
+                <g class="nad-edge-infos" transform="translate(-9.58,3.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="129" class="nad-vl30to50" title="L27-30-1">
             <g>
                 <polyline points="-7.57,3.96 -8.78,4.79"/>
+                <g class="nad-edge-infos" transform="translate(-8.32,4.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-124.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-124.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.99,5.61 -8.78,4.79"/>
+                <g class="nad-edge-infos" transform="translate(-9.25,5.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(55.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(55.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="130" class="nad-vl30to50" title="L29-30-1">
             <g>
                 <polyline points="-10.47,3.51 -10.23,4.56"/>
+                <g class="nad-edge-infos" transform="translate(-10.27,4.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(167.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(167.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.99,5.61 -10.23,4.56"/>
+                <g class="nad-edge-infos" transform="translate(-10.19,4.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-12.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-12.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -6,8 +6,17 @@
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
 .nad-disconnected {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue)}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
 .nad-vl-nodes .nad-text-buses {font: 0.6px "Verdana"; fill: white}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: grey}
+.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -21,675 +30,3235 @@
         <g id="171" class="nad-vl0to30" title="L1-2-1">
             <g>
                 <polyline points="-7.03,10.20 -6.09,11.46"/>
+                <g class="nad-edge-infos" transform="translate(-6.49,10.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.14,12.72 -6.09,11.46"/>
+                <g class="nad-edge-infos" transform="translate(-5.68,12.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="172" class="nad-vl0to30" title="L1-15-1">
             <g>
                 <polyline points="-7.03,10.20 -5.68,8.52"/>
+                <g class="nad-edge-infos" transform="translate(-6.46,9.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.33,6.84 -5.68,8.52"/>
+                <g class="nad-edge-infos" transform="translate(-4.89,7.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="173" class="nad-vl0to30" title="L1-16-1">
             <g>
                 <polyline points="-7.03,10.20 -8.18,10.49"/>
+                <g class="nad-edge-infos" transform="translate(-7.90,10.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-104.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-104.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.33,10.78 -8.18,10.49"/>
+                <g class="nad-edge-infos" transform="translate(-8.46,10.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(75.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(75.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="174" class="nad-vl0to30" title="L1-17-1">
             <g>
                 <polyline points="-7.03,10.20 -8.66,9.60"/>
+                <g class="nad-edge-infos" transform="translate(-7.87,9.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-69.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-69.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.30,8.99 -8.66,9.60"/>
+                <g class="nad-edge-infos" transform="translate(-9.46,9.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(110.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(110.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-69.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="175" class="nad-vl0to30" title="L2-3-1">
             <g>
                 <polyline points="-5.14,12.72 -3.77,12.13"/>
+                <g class="nad-edge-infos" transform="translate(-4.32,12.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(66.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(66.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.40,11.54 -3.77,12.13"/>
+                <g class="nad-edge-infos" transform="translate(-3.23,11.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-113.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-113.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(66.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="176" class="nad-vl0to30" title="L3-4-1">
             <g>
                 <polyline points="-2.40,11.54 -0.28,12.41"/>
+                <g class="nad-edge-infos" transform="translate(-1.57,11.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(112.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(112.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.83,13.29 -0.28,12.41"/>
+                <g class="nad-edge-infos" transform="translate(1.00,12.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-67.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-67.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="177" class="nad-vl0to30" title="L3-15-1">
             <g>
                 <polyline points="-2.40,11.54 -3.37,9.19"/>
+                <g class="nad-edge-infos" transform="translate(-2.74,10.71)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-22.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-22.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.33,6.84 -3.37,9.19"/>
+                <g class="nad-edge-infos" transform="translate(-3.99,7.68)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(157.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(157.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-22.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="178" class="nad-vl0to30" title="L4-5-1">
             <g>
                 <polyline points="1.83,13.29 2.52,14.04"/>
+                <g class="nad-edge-infos" transform="translate(2.44,13.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(137.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(137.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="3.21,14.80 2.52,14.04"/>
+                <g class="nad-edge-infos" transform="translate(2.60,14.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-42.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-42.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-42.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="179" class="nad-vl0to30" title="L4-6-1">
             <g>
                 <polyline points="1.83,13.29 2.15,12.30"/>
+                <g class="nad-edge-infos" transform="translate(2.11,12.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(17.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(17.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.46,11.32 2.15,12.30"/>
+                <g class="nad-edge-infos" transform="translate(2.19,12.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-162.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-162.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="180" title="T4-18-1">
             <g class="nad-vl0to30">
                 <polyline points="1.83,13.29 2.57,13.60 4.21,13.41"/>
                 <circle cx="4.11" cy="13.42" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.87,13.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="6.49,12.74 5.85,13.22 4.21,13.41"/>
                 <circle cx="4.31" cy="13.40" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(5.55,13.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="181" title="T4-18-2">
             <g class="nad-vl0to30">
                 <polyline points="1.83,13.29 2.48,12.81 4.11,12.62"/>
                 <circle cx="4.02" cy="12.63" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(2.77,12.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(83.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="6.49,12.74 5.75,12.42 4.11,12.62"/>
                 <circle cx="4.21" cy="12.60" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(5.46,12.46)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-96.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(83.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="182" class="nad-vl0to30" title="L5-6-1">
             <g>
                 <polyline points="3.21,14.80 2.83,13.06"/>
+                <g class="nad-edge-infos" transform="translate(3.02,13.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-12.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-12.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="2.46,11.32 2.83,13.06"/>
+                <g class="nad-edge-infos" transform="translate(2.65,12.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(167.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(167.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="183" class="nad-vl0to30" title="L6-7-1">
             <g>
                 <polyline points="2.46,11.32 3.27,10.08"/>
+                <g class="nad-edge-infos" transform="translate(2.95,10.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(33.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(33.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.08,8.85 3.27,10.08"/>
+                <g class="nad-edge-infos" transform="translate(3.59,9.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-146.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-146.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(33.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="184" class="nad-vl0to30" title="L6-8-1">
             <g>
                 <polyline points="2.46,11.32 1.18,10.00"/>
+                <g class="nad-edge-infos" transform="translate(1.83,10.67)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-44.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-44.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.09,8.68 1.18,10.00"/>
+                <g class="nad-edge-infos" transform="translate(0.53,9.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(135.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(135.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-44.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="185" class="nad-vl0to30" title="L7-8-1">
             <g>
                 <polyline points="4.08,8.85 1.99,8.76"/>
+                <g class="nad-edge-infos" transform="translate(3.18,8.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-87.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-87.76)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.09,8.68 1.99,8.76"/>
+                <g class="nad-edge-infos" transform="translate(0.81,8.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(92.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(92.24)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-87.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="186" title="T7-29-1">
             <g class="nad-vl0to30">
                 <polyline points="4.08,8.85 6.09,7.68"/>
                 <circle cx="6.00" cy="7.73" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(4.86,8.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(59.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(59.92)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="8.10,6.52 6.09,7.68"/>
                 <circle cx="6.18" cy="7.63" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(7.32,6.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-120.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-120.08)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="187" class="nad-vl0to30" title="L8-9-1">
             <g>
                 <polyline points="-0.09,8.68 -3.14,6.94"/>
+                <g class="nad-edge-infos" transform="translate(-0.87,8.23)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-60.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-60.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-60.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-60.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.18,5.19 -3.14,6.94"/>
+                <g class="nad-edge-infos" transform="translate(-5.40,5.64)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(119.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-60.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(119.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-60.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="188" class="nad-vl0to30" title="L9-10-1">
             <g>
                 <polyline points="-6.18,5.19 -8.25,5.01"/>
+                <g class="nad-edge-infos" transform="translate(-7.08,5.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-84.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-84.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.33,4.82 -8.25,5.01"/>
+                <g class="nad-edge-infos" transform="translate(-9.43,4.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(95.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(95.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-84.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="189" class="nad-vl0to30" title="L9-11-1">
             <g>
                 <polyline points="-6.18,5.19 -7.37,2.48"/>
+                <g class="nad-edge-infos" transform="translate(-6.54,4.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-23.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-23.69)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.56,-0.23 -7.37,2.48"/>
+                <g class="nad-edge-infos" transform="translate(-8.20,0.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(156.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(156.31)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-23.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="190" class="nad-vl0to30" title="L9-12-1">
             <g>
                 <polyline points="-6.18,5.19 -7.51,6.00"/>
+                <g class="nad-edge-infos" transform="translate(-6.95,5.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-121.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(58.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-121.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(58.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.83,6.82 -7.51,6.00"/>
+                <g class="nad-edge-infos" transform="translate(-8.06,6.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(58.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(58.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(58.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(58.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="191" class="nad-vl0to30" title="L9-13-1">
             <g>
                 <polyline points="-6.18,5.19 -6.53,4.13"/>
+                <g class="nad-edge-infos" transform="translate(-6.46,4.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-18.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-18.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-18.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-18.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.88,3.07 -6.53,4.13"/>
+                <g class="nad-edge-infos" transform="translate(-6.60,3.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(161.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-18.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(161.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-18.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="192" title="T9-55-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.18,5.19 -4.04,5.46"/>
                 <circle cx="-4.14" cy="5.45" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-5.29,5.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(97.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(97.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-1.90,5.73 -4.04,5.46"/>
                 <circle cx="-3.94" cy="5.47" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-2.79,5.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-82.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-82.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-82.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="193" class="nad-vl0to30" title="L10-12-1">
             <g>
                 <polyline points="-10.33,4.82 -9.58,5.82"/>
+                <g class="nad-edge-infos" transform="translate(-9.79,5.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-8.83,6.82 -9.58,5.82"/>
+                <g class="nad-edge-infos" transform="translate(-9.37,6.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="194" title="T10-51-1">
             <g class="nad-vl0to30">
                 <polyline points="-10.33,4.82 -11.48,3.76"/>
                 <circle cx="-11.41" cy="3.83" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-10.99,4.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-12.64,2.69 -11.48,3.76"/>
                 <circle cx="-11.56" cy="3.69" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-11.98,3.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(132.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(132.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="195" class="nad-vl0to30" title="L11-13-1">
             <g>
                 <polyline points="-8.56,-0.23 -7.72,1.42"/>
+                <g class="nad-edge-infos" transform="translate(-8.15,0.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(152.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-27.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(152.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-27.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.88,3.07 -7.72,1.42"/>
+                <g class="nad-edge-infos" transform="translate(-7.29,2.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-27.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-27.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-27.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-27.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="196" title="T11-41-1">
             <g class="nad-vl0to30">
                 <polyline points="-8.56,-0.23 -9.34,-2.82"/>
                 <circle cx="-9.31" cy="-2.72" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-8.82,-1.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-16.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-16.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-10.12,-5.40 -9.34,-2.82"/>
                 <circle cx="-9.37" cy="-2.91" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-9.86,-4.54)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(163.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(163.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="197" title="T11-43-1">
             <g class="nad-vl0to30">
                 <polyline points="-8.56,-0.23 -9.68,-1.59"/>
                 <circle cx="-9.61" cy="-1.51" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-9.13,-0.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-39.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-39.52)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-10.79,-2.94 -9.68,-1.59"/>
                 <circle cx="-9.74" cy="-1.66" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-10.22,-2.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(140.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(140.48)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="198" class="nad-vl0to30" title="L12-13-1">
             <g>
                 <polyline points="-8.83,6.82 -7.85,4.94"/>
+                <g class="nad-edge-infos" transform="translate(-8.41,6.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(27.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(27.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.88,3.07 -7.85,4.94"/>
+                <g class="nad-edge-infos" transform="translate(-7.29,3.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-152.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-152.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(27.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="199" class="nad-vl0to30" title="L12-16-1">
             <g>
                 <polyline points="-8.83,6.82 -9.08,8.80"/>
+                <g class="nad-edge-infos" transform="translate(-8.94,7.71)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-172.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-172.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.33,10.78 -9.08,8.80"/>
+                <g class="nad-edge-infos" transform="translate(-9.22,9.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(7.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(7.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="200" class="nad-vl0to30" title="L12-17-1">
             <g>
                 <polyline points="-8.83,6.82 -9.57,7.91"/>
+                <g class="nad-edge-infos" transform="translate(-9.33,7.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-145.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-145.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.30,8.99 -9.57,7.91"/>
+                <g class="nad-edge-infos" transform="translate(-9.80,8.25)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(34.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(34.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="201" class="nad-vl0to30" title="L13-14-1">
             <g>
                 <polyline points="-6.88,3.07 -5.67,3.26"/>
+                <g class="nad-edge-infos" transform="translate(-5.99,3.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.46,3.45 -5.67,3.26"/>
+                <g class="nad-edge-infos" transform="translate(-5.35,3.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="202" class="nad-vl0to30" title="L13-15-1">
             <g>
                 <polyline points="-6.88,3.07 -5.60,4.95"/>
+                <g class="nad-edge-infos" transform="translate(-6.37,3.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(145.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(145.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.33,6.84 -5.60,4.95"/>
+                <g class="nad-edge-infos" transform="translate(-4.83,6.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-34.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-34.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-34.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="203" title="T13-49-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.88,3.07 -6.29,0.80"/>
                 <circle cx="-6.31" cy="0.90" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-6.65,2.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(14.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(14.58)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-5.70,-1.46 -6.29,0.80"/>
                 <circle cx="-6.26" cy="0.70" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-5.93,-0.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-165.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-165.42)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="204" class="nad-vl0to30" title="L14-15-1">
             <g>
                 <polyline points="-4.46,3.45 -4.39,5.15"/>
+                <g class="nad-edge-infos" transform="translate(-4.42,4.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(177.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(177.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-4.33,6.84 -4.39,5.15"/>
+                <g class="nad-edge-infos" transform="translate(-4.36,5.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-2.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-2.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-2.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="205" title="T14-46-1">
             <g class="nad-vl0to30">
                 <polyline points="-4.46,3.45 -3.97,2.08"/>
                 <circle cx="-4.00" cy="2.18" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-4.15,2.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(19.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(19.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-3.48,0.72 -3.97,2.08"/>
                 <circle cx="-3.93" cy="1.99" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.78,1.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-160.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-160.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="206" title="T15-45-1">
             <g class="nad-vl0to30">
                 <polyline points="-4.33,6.84 -2.73,4.86"/>
                 <circle cx="-2.79" cy="4.94" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.76,6.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-1.12,2.87 -2.73,4.86"/>
                 <circle cx="-2.66" cy="4.78" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.69,3.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(38.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="207" class="nad-vl0to30" title="L18-19-1">
             <g>
                 <polyline points="6.49,12.74 8.01,11.50"/>
+                <g class="nad-edge-infos" transform="translate(7.19,12.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.54,10.26 8.01,11.50"/>
+                <g class="nad-edge-infos" transform="translate(8.84,10.83)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="208" class="nad-vl0to30" title="L19-20-1">
             <g>
                 <polyline points="9.54,10.26 10.01,8.22"/>
+                <g class="nad-edge-infos" transform="translate(9.74,9.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(13.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(13.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="10.49,6.18 10.01,8.22"/>
+                <g class="nad-edge-infos" transform="translate(10.29,7.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(13.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="209" title="T21-20-1">
             <g class="nad-vl0to30">
                 <polyline points="8.54,1.31 9.52,3.74"/>
                 <circle cx="9.48" cy="3.65" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(8.87,2.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(158.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(158.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="10.49,6.18 9.52,3.74"/>
                 <circle cx="9.55" cy="3.84" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(10.16,5.34)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-21.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-21.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-21.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="210" class="nad-vl0to30" title="L21-22-1">
             <g>
                 <polyline points="8.54,1.31 7.08,-0.63"/>
+                <g class="nad-edge-infos" transform="translate(8.00,0.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="5.62,-2.58 7.08,-0.63"/>
+                <g class="nad-edge-infos" transform="translate(6.16,-1.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="211" class="nad-vl0to30" title="L22-23-1">
             <g>
                 <polyline points="5.62,-2.58 7.28,-3.46"/>
+                <g class="nad-edge-infos" transform="translate(6.42,-3.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(61.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(61.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.93,-4.35 7.28,-3.46"/>
+                <g class="nad-edge-infos" transform="translate(8.14,-3.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-118.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-118.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(61.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="212" class="nad-vl0to30" title="L22-38-1">
             <g>
                 <polyline points="5.62,-2.58 2.65,-3.25"/>
+                <g class="nad-edge-infos" transform="translate(4.75,-2.78)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-77.14)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.32,-3.93 2.65,-3.25"/>
+                <g class="nad-edge-infos" transform="translate(0.56,-3.73)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(102.86)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-77.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="213" class="nad-vl0to30" title="L23-24-1">
             <g>
                 <polyline points="8.93,-4.35 10.58,-4.86"/>
+                <g class="nad-edge-infos" transform="translate(9.79,-4.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(72.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(72.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="12.23,-5.38 10.58,-4.86"/>
+                <g class="nad-edge-infos" transform="translate(11.38,-5.11)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-107.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-107.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="214" title="T24-25-1">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 12.69,-6.03 12.78,-7.03"/>
                 <circle cx="12.77" cy="-6.93" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(12.72,-6.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(5.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(5.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="12.54,-8.75 12.87,-8.02 12.78,-7.03"/>
                 <circle cx="12.79" cy="-7.13" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(12.85,-7.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-174.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-174.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="215" title="T24-25-2">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 11.90,-6.10 11.99,-7.10"/>
                 <circle cx="11.98" cy="-7.00" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(11.92,-6.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(5.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(5.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="12.54,-8.75 12.08,-8.09 11.99,-7.10"/>
                 <circle cx="12.00" cy="-7.20" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(12.05,-7.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-174.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-174.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="216" title="T24-26-1">
             <g class="nad-vl0to30">
                 <polyline points="12.23,-5.38 13.18,-3.94"/>
                 <circle cx="13.12" cy="-4.02" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(12.73,-4.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(146.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(146.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="14.12,-2.50 13.18,-3.94"/>
                 <circle cx="13.23" cy="-3.86" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(13.63,-3.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-33.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-33.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-33.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="217" class="nad-vl0to30" title="L25-30-1">
             <g>
                 <polyline points="12.54,-8.75 12.06,-10.26"/>
+                <g class="nad-edge-infos" transform="translate(12.26,-9.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="11.58,-11.77 12.06,-10.26"/>
+                <g class="nad-edge-infos" transform="translate(11.85,-10.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-17.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="218" class="nad-vl0to30" title="L26-27-1">
             <g>
                 <polyline points="14.12,-2.50 14.13,-0.85"/>
+                <g class="nad-edge-infos" transform="translate(14.13,-1.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(179.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(179.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="14.13,0.81 14.13,-0.85"/>
+                <g class="nad-edge-infos" transform="translate(14.13,-0.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-0.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-0.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-0.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="219" class="nad-vl0to30" title="L27-28-1">
             <g>
                 <polyline points="14.13,0.81 13.13,2.29"/>
+                <g class="nad-edge-infos" transform="translate(13.63,1.55)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-145.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-145.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="12.13,3.77 13.13,2.29"/>
+                <g class="nad-edge-infos" transform="translate(12.63,3.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(34.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(34.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="220" class="nad-vl0to30" title="L28-29-1">
             <g>
                 <polyline points="12.13,3.77 10.11,5.14"/>
+                <g class="nad-edge-infos" transform="translate(11.38,4.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-124.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-124.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="8.10,6.52 10.11,5.14"/>
+                <g class="nad-edge-infos" transform="translate(8.84,6.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(55.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(55.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(55.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="221" class="nad-vl0to30" title="L29-52-1">
             <g>
                 <polyline points="8.10,6.52 7.41,5.59"/>
+                <g class="nad-edge-infos" transform="translate(7.56,5.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-36.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-36.66)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.72,4.66 7.41,5.59"/>
+                <g class="nad-edge-infos" transform="translate(7.26,5.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(143.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(143.34)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-36.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="222" class="nad-vl0to30" title="L30-31-1">
             <g>
                 <polyline points="11.58,-11.77 10.57,-13.00"/>
+                <g class="nad-edge-infos" transform="translate(11.01,-12.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-39.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-39.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="9.57,-14.22 10.57,-13.00"/>
+                <g class="nad-edge-infos" transform="translate(10.14,-13.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(140.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(140.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="223" class="nad-vl0to30" title="L31-32-1">
             <g>
                 <polyline points="9.57,-14.22 8.24,-15.21"/>
+                <g class="nad-edge-infos" transform="translate(8.85,-14.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-53.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-53.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="6.90,-16.19 8.24,-15.21"/>
+                <g class="nad-edge-infos" transform="translate(7.62,-15.66)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(126.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(126.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-53.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="224" class="nad-vl0to30" title="L32-33-1">
             <g>
                 <polyline points="6.90,-16.19 7.26,-17.49"/>
+                <g class="nad-edge-infos" transform="translate(7.14,-17.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(15.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(15.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="7.62,-18.78 7.26,-17.49"/>
+                <g class="nad-edge-infos" transform="translate(7.38,-17.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-164.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-164.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="225" title="T34-32-1">
             <g class="nad-vl0to30">
                 <polyline points="3.58,-15.95 5.24,-16.07"/>
                 <circle cx="5.14" cy="-16.06" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(4.48,-16.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(85.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(85.84)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="6.90,-16.19 5.24,-16.07"/>
                 <circle cx="5.34" cy="-16.08" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(6.00,-16.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-94.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-94.16)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(85.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="226" class="nad-vl0to30" title="L34-35-1">
             <g>
                 <polyline points="3.58,-15.95 2.04,-15.41"/>
+                <g class="nad-edge-infos" transform="translate(2.73,-15.65)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.35)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.50,-14.87 2.04,-15.41"/>
+                <g class="nad-edge-infos" transform="translate(1.35,-15.17)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.65)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="227" class="nad-vl0to30" title="L35-36-1">
             <g>
                 <polyline points="0.50,-14.87 -0.87,-13.75"/>
+                <g class="nad-edge-infos" transform="translate(-0.20,-14.30)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.25,-12.64 -0.87,-13.75"/>
+                <g class="nad-edge-infos" transform="translate(-1.55,-13.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="228" class="nad-vl0to30" title="L36-37-1">
             <g>
                 <polyline points="-2.25,-12.64 -1.80,-10.68"/>
+                <g class="nad-edge-infos" transform="translate(-2.05,-11.76)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(167.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(167.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.36,-8.72 -1.80,-10.68"/>
+                <g class="nad-edge-infos" transform="translate(-1.56,-9.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-12.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-12.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="229" class="nad-vl0to30" title="L36-40-1">
             <g>
                 <polyline points="-2.25,-12.64 -4.22,-12.63"/>
+                <g class="nad-edge-infos" transform="translate(-3.15,-12.63)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-90.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-90.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-6.20,-12.61 -4.22,-12.63"/>
+                <g class="nad-edge-infos" transform="translate(-5.30,-12.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(89.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(89.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="230" class="nad-vl0to30" title="L37-38-1">
             <g>
                 <polyline points="-1.36,-8.72 -0.84,-6.32"/>
+                <g class="nad-edge-infos" transform="translate(-1.17,-7.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(167.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(167.71)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-0.32,-3.93 -0.84,-6.32"/>
+                <g class="nad-edge-infos" transform="translate(-0.51,-4.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-12.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-12.29)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="231" class="nad-vl0to30" title="L37-39-1">
             <g>
                 <polyline points="-1.36,-8.72 -2.66,-9.16"/>
+                <g class="nad-edge-infos" transform="translate(-2.21,-9.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-71.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-71.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.95,-9.60 -2.66,-9.16"/>
+                <g class="nad-edge-infos" transform="translate(-3.10,-9.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(108.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(108.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-71.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="232" class="nad-vl0to30" title="L38-44-1">
             <g>
                 <polyline points="-0.32,-3.93 0.10,-2.31"/>
+                <g class="nad-edge-infos" transform="translate(-0.09,-3.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(165.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-14.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(165.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-14.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="0.52,-0.69 0.10,-2.31"/>
+                <g class="nad-edge-infos" transform="translate(0.30,-1.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-14.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-14.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-14.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-14.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="233" class="nad-vl0to30" title="L38-49-1">
             <g>
                 <polyline points="-0.32,-3.93 -3.01,-2.70"/>
+                <g class="nad-edge-infos" transform="translate(-1.13,-3.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-114.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-114.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.70,-1.46 -3.01,-2.70"/>
+                <g class="nad-edge-infos" transform="translate(-4.88,-1.84)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(65.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(65.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(65.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="234" class="nad-vl0to30" title="L38-48-1">
             <g>
                 <polyline points="-0.32,-3.93 -1.81,-3.88"/>
+                <g class="nad-edge-infos" transform="translate(-1.21,-3.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-91.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-91.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.31,-3.83 -1.81,-3.88"/>
+                <g class="nad-edge-infos" transform="translate(-2.41,-3.86)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(88.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(88.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(88.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="235" title="T39-57-1">
             <g class="nad-vl0to30">
                 <polyline points="-3.95,-9.60 -5.34,-9.75"/>
                 <circle cx="-5.24" cy="-9.74" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-4.85,-9.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-83.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-83.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-6.73,-9.90 -5.34,-9.75"/>
                 <circle cx="-5.44" cy="-9.76" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-5.84,-9.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(96.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(96.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-83.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="236" title="T40-56-1">
             <g class="nad-vl0to30">
                 <polyline points="-6.20,-12.61 -7.66,-11.02"/>
                 <circle cx="-7.59" cy="-11.10" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-6.80,-11.95)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-137.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-137.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g class="nad-vl0to30">
                 <polyline points="-9.12,-9.43 -7.66,-11.02"/>
                 <circle cx="-7.73" cy="-10.95" r="0.20"/>
+                <g class="nad-edge-infos" transform="translate(-8.51,-10.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(42.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(42.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(42.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="237" class="nad-vl0to30" title="L41-42-1">
             <g>
                 <polyline points="-10.12,-5.40 -10.79,-6.74"/>
+                <g class="nad-edge-infos" transform="translate(-10.53,-6.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-26.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-26.62)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.47,-8.07 -10.79,-6.74"/>
+                <g class="nad-edge-infos" transform="translate(-11.06,-7.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(153.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(153.38)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="238" class="nad-vl0to30" title="L41-43-1">
             <g>
                 <polyline points="-10.12,-5.40 -10.46,-4.17"/>
+                <g class="nad-edge-infos" transform="translate(-10.36,-4.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-164.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-164.81)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.79,-2.94 -10.46,-4.17"/>
+                <g class="nad-edge-infos" transform="translate(-10.56,-3.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(15.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(15.19)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="239" class="nad-vl0to30" title="L56-41-1">
             <g>
                 <polyline points="-9.12,-9.43 -9.62,-7.41"/>
+                <g class="nad-edge-infos" transform="translate(-9.34,-8.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-166.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-166.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.12,-5.40 -9.62,-7.41"/>
+                <g class="nad-edge-infos" transform="translate(-9.91,-6.27)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(14.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(14.00)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="240" class="nad-vl0to30" title="L56-42-1">
             <g>
                 <polyline points="-9.12,-9.43 -10.29,-8.75"/>
+                <g class="nad-edge-infos" transform="translate(-9.90,-8.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-120.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-120.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-11.47,-8.07 -10.29,-8.75"/>
+                <g class="nad-edge-infos" transform="translate(-10.69,-8.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(59.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(59.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(59.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="241" class="nad-vl0to30" title="L44-45-1">
             <g>
                 <polyline points="0.52,-0.69 -0.30,1.09"/>
+                <g class="nad-edge-infos" transform="translate(0.15,0.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-155.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-155.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.12,2.87 -0.30,1.09"/>
+                <g class="nad-edge-infos" transform="translate(-0.75,2.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(24.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(24.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="242" class="nad-vl0to30" title="L46-47-1">
             <g>
                 <polyline points="-3.48,0.72 -3.08,-0.52"/>
+                <g class="nad-edge-infos" transform="translate(-3.20,-0.14)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(17.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(17.59)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-2.69,-1.76 -3.08,-0.52"/>
+                <g class="nad-edge-infos" transform="translate(-2.96,-0.90)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-162.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-162.41)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="243" class="nad-vl0to30" title="L47-48-1">
             <g>
                 <polyline points="-2.69,-1.76 -3.00,-2.80"/>
+                <g class="nad-edge-infos" transform="translate(-2.95,-2.62)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-16.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-16.53)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-3.31,-3.83 -3.00,-2.80"/>
+                <g class="nad-edge-infos" transform="translate(-3.05,-2.97)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(163.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(163.47)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-16.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="244" class="nad-vl0to30" title="L48-49-1">
             <g>
                 <polyline points="-3.31,-3.83 -4.50,-2.65"/>
+                <g class="nad-edge-infos" transform="translate(-3.95,-3.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-134.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-134.73)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-5.70,-1.46 -4.50,-2.65"/>
+                <g class="nad-edge-infos" transform="translate(-5.06,-2.10)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(45.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(45.27)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(45.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="245" class="nad-vl0to30" title="L49-50-1">
             <g>
                 <polyline points="-5.70,-1.46 -8.20,-0.58"/>
+                <g class="nad-edge-infos" transform="translate(-6.55,-1.16)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.51)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-10.70,0.31 -8.20,-0.58"/>
+                <g class="nad-edge-infos" transform="translate(-9.85,0.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.49)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(70.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="246" class="nad-vl0to30" title="L50-51-1">
             <g>
                 <polyline points="-10.70,0.31 -11.67,1.50"/>
+                <g class="nad-edge-infos" transform="translate(-11.27,1.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-140.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-140.91)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-12.64,2.69 -11.67,1.50"/>
+                <g class="nad-edge-infos" transform="translate(-12.07,2.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(39.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(39.09)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="247" class="nad-vl0to30" title="L52-53-1">
             <g>
                 <polyline points="6.72,4.66 5.48,4.48"/>
+                <g class="nad-edge-infos" transform="translate(5.83,4.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-81.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-81.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="4.24,4.30 5.48,4.48"/>
+                <g class="nad-edge-infos" transform="translate(5.13,4.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(98.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(98.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="248" class="nad-vl0to30" title="L53-54-1">
             <g>
                 <polyline points="4.24,4.30 2.88,4.72"/>
+                <g class="nad-edge-infos" transform="translate(3.38,4.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-106.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-106.85)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="1.52,5.13 2.88,4.72"/>
+                <g class="nad-edge-infos" transform="translate(2.38,4.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(73.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(73.15)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="249" class="nad-vl0to30" title="L54-55-1">
             <g>
                 <polyline points="1.52,5.13 -0.19,5.43"/>
+                <g class="nad-edge-infos" transform="translate(0.63,5.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-99.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-99.93)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-1.90,5.73 -0.19,5.43"/>
+                <g class="nad-edge-infos" transform="translate(-1.01,5.57)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(80.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(80.07)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
         <g id="250" class="nad-vl0to30" title="L57-56-1">
             <g>
                 <polyline points="-6.73,-9.90 -7.93,-9.66"/>
+                <g class="nad-edge-infos" transform="translate(-7.61,-9.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-101.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-101.13)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
             <g>
                 <polyline points="-9.12,-9.43 -7.93,-9.66"/>
+                <g class="nad-edge-infos" transform="translate(-8.24,-9.60)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(78.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(78.87)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(78.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
             </g>
         </g>
     </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Feature


**What is the current behavior?** 
No information displayed about active/reactive power transiting on edges


**What is the new behavior (if this is a feature change)?**
Active or reactive power displayed, depending on CSS styles applied

Active powers displayed:
![screenshot](https://user-images.githubusercontent.com/66690739/143020991-7882e912-ac5b-4562-8679-ea6ff40a9c87.png)


Reactive powers displayed (same file with CSS style visibility changes):
![screenshot](https://user-images.githubusercontent.com/66690739/143025002-af40770f-7abb-45c8-bd6b-5bbf1462ded8.png)



**Does this PR introduce a breaking change or deprecate an API?**
Yes