### PR TITLE
Fix separation graph network

### DIFF
--- a/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
+++ b/src/main/java/com/powsybl/nad/build/iidm/NetworkGraphBuilder.java
@@ -48,8 +48,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
 
     private void addGraphNodes(Graph graph) {
         network.getVoltageLevelStream().filter(voltageLevelFilter).forEach(vl -> {
-            VoltageLevelNode vlNode = new VoltageLevelNode(idProvider.createId(vl),
-                    vl.getId(), vl.getNameOrId(), vl.getNominalV());
+            VoltageLevelNode vlNode = new VoltageLevelNode(idProvider.createId(vl), vl.getId(), vl.getNameOrId());
             TextNode textNode = new TextNode(vlNode.getDiagramId() + "_text", vl.getNameOrId());
             graph.addNode(vlNode);
             graph.addNode(textNode);
@@ -187,7 +186,7 @@ public class NetworkGraphBuilder implements GraphBuilder {
         }
 
         private VoltageLevelNode createInvisibleVoltageLevelNode(VoltageLevel vl) {
-            VoltageLevelNode invisibleVlNode = new VoltageLevelNode(idProvider.createId(vl), vl.getId(), vl.getNameOrId(), vl.getNominalV(), false);
+            VoltageLevelNode invisibleVlNode = new VoltageLevelNode(idProvider.createId(vl), vl.getId(), vl.getNameOrId(), false);
             graph.addNode(invisibleVlNode);
             return invisibleVlNode;
         }

--- a/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
+++ b/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
@@ -10,7 +10,7 @@ public abstract class AbstractLayout implements Layout {
     protected void edgeLayout(Graph graph, LayoutParameters layoutParameters) {
         Objects.requireNonNull(graph);
         Objects.requireNonNull(layoutParameters);
-        graph.getNonMultiBranchEdgesStream().forEach(edge -> singleBranchEdgeLayout(graph.getNode1(edge), graph.getNode2(edge), edge));
+        graph.getNonMultiBranchEdgesStream().forEach(edge -> singleBranchEdgeLayout(graph, edge));
         graph.getMultiBranchEdgesStream().forEach(edges -> multiBranchEdgesLayout(graph, edges, layoutParameters));
         graph.getThreeWtEdgesStream().forEach(edge -> threeWtEdgeLayout(graph.getNode1(edge), graph.getNode2(edge), edge));
         graph.getTextEdgesMap().forEach((edge, nodes) -> textEdgeLayout(nodes.getFirst(), nodes.getSecond(), edge));
@@ -22,12 +22,14 @@ public abstract class AbstractLayout implements Layout {
         edge.setPoints(point1, point2);
     }
 
-    private void singleBranchEdgeLayout(Node node1, Node node2, BranchEdge edge) {
+    private void singleBranchEdgeLayout(Graph graph, BranchEdge edge) {
+        Node node1 = graph.getNode1(edge);
+        Node node2 = graph.getNode2(edge);
         Point point1 = new Point(node1.getX(), node1.getY());
         Point point2 = new Point(node2.getX(), node2.getY());
         Point middle = Point.createMiddlePoint(point1, point2);
-        edge.setSide1(point1, middle);
-        edge.setSide2(point2, middle);
+        edge.setPoints1(point1, middle);
+        edge.setPoints2(point2, middle);
         if (node1 instanceof VoltageLevelNode && !((VoltageLevelNode) node1).isVisible()) {
             edge.setVisible(BranchEdge.Side.ONE, false);
         }
@@ -59,7 +61,7 @@ public abstract class AbstractLayout implements Layout {
             }
             BranchEdge branchEdge = (BranchEdge) edge;
             if (2 * i + 1 == nbForks) { // in the middle, hence alpha = 0
-                singleBranchEdgeLayout(node1, node2, branchEdge);
+                singleBranchEdgeLayout(graph, branchEdge);
             } else {
                 double alpha = -forkAperture / 2 + i * angleStep;
                 double angleFork1 = angle - alpha;
@@ -68,8 +70,13 @@ public abstract class AbstractLayout implements Layout {
                 Point fork2 = pointB.shift(forkLength * Math.cos(angleFork2), forkLength * Math.sin(angleFork2));
 
                 Point middle = Point.createMiddlePoint(fork1, fork2);
-                branchEdge.setSide1(pointA, fork1, middle);
-                branchEdge.setSide2(pointB, fork2, middle);
+                BranchEdge.Side side = graph.getNode1(edge) == node1 ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
+                BranchEdge.Side otherSide = side == BranchEdge.Side.ONE ? BranchEdge.Side.TWO : BranchEdge.Side.ONE;
+                branchEdge.setPoints(side, pointA, fork1, middle);
+                branchEdge.setPoints(otherSide, pointB, fork2, middle);
+                if (node1 instanceof VoltageLevelNode && !((VoltageLevelNode) node1).isVisible()) {
+                    branchEdge.setVisible(BranchEdge.Side.ONE, false);
+                }
                 if (node2 instanceof VoltageLevelNode && !((VoltageLevelNode) node2).isVisible()) {
                     branchEdge.setVisible(BranchEdge.Side.TWO, false);
                 }

--- a/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
+++ b/src/main/java/com/powsybl/nad/layout/AbstractLayout.java
@@ -30,12 +30,8 @@ public abstract class AbstractLayout implements Layout {
         Point middle = Point.createMiddlePoint(point1, point2);
         edge.setPoints1(point1, middle);
         edge.setPoints2(point2, middle);
-        if (node1 instanceof VoltageLevelNode && !((VoltageLevelNode) node1).isVisible()) {
-            edge.setVisible(BranchEdge.Side.ONE, false);
-        }
-        if (node2 instanceof VoltageLevelNode && !((VoltageLevelNode) node2).isVisible()) {
-            edge.setVisible(BranchEdge.Side.TWO, false);
-        }
+        setEdgeVisibility(node1, edge, BranchEdge.Side.ONE);
+        setEdgeVisibility(node2, edge, BranchEdge.Side.TWO);
     }
 
     private void multiBranchEdgesLayout(Graph graph, Set<Edge> edges, LayoutParameters layoutParameters) {
@@ -71,17 +67,18 @@ public abstract class AbstractLayout implements Layout {
 
                 Point middle = Point.createMiddlePoint(fork1, fork2);
                 BranchEdge.Side side = graph.getNode1(edge) == node1 ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
-                BranchEdge.Side otherSide = side == BranchEdge.Side.ONE ? BranchEdge.Side.TWO : BranchEdge.Side.ONE;
                 branchEdge.setPoints(side, pointA, fork1, middle);
-                branchEdge.setPoints(otherSide, pointB, fork2, middle);
-                if (node1 instanceof VoltageLevelNode && !((VoltageLevelNode) node1).isVisible()) {
-                    branchEdge.setVisible(BranchEdge.Side.ONE, false);
-                }
-                if (node2 instanceof VoltageLevelNode && !((VoltageLevelNode) node2).isVisible()) {
-                    branchEdge.setVisible(BranchEdge.Side.TWO, false);
-                }
+                branchEdge.setPoints(side.getOpposite(), pointB, fork2, middle);
+                setEdgeVisibility(node1, branchEdge, BranchEdge.Side.ONE);
+                setEdgeVisibility(node2, branchEdge, BranchEdge.Side.TWO);
             }
             i++;
+        }
+    }
+
+    private void setEdgeVisibility(Node node, BranchEdge branchEdge, BranchEdge.Side side) {
+        if (node instanceof VoltageLevelNode && !((VoltageLevelNode) node).isVisible()) {
+            branchEdge.setVisible(side, false);
         }
     }
 

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -24,8 +24,8 @@ public class BranchEdge extends AbstractEdge {
     public static final String LINE_EDGE = "LineEdge";
     public static final String HVDC_LINE_EDGE = "HvdcLineEdge";
 
-    private List<Point> line1 = Collections.emptyList();
-    private List<Point> line2 = Collections.emptyList();
+    private List<Point> points1 = Collections.emptyList();
+    private List<Point> points2 = Collections.emptyList();
     private final boolean[] visible = new boolean[] {true, true};
     private final String type;
 
@@ -38,27 +38,36 @@ public class BranchEdge extends AbstractEdge {
         return type;
     }
 
-    public List<Point> getLine(Side side) {
+    public List<Point> getPoints(Side side) {
         Objects.requireNonNull(side);
-        return side == Side.ONE ? getSide1() : getSide2();
+        return side == Side.ONE ? getPoints1() : getPoints2();
     }
 
-    public List<Point> getSide1() {
-        return Collections.unmodifiableList(line1);
+    public List<Point> getPoints1() {
+        return Collections.unmodifiableList(points1);
     }
 
-    public List<Point> getSide2() {
-        return Collections.unmodifiableList(line2);
+    public List<Point> getPoints2() {
+        return Collections.unmodifiableList(points2);
     }
 
-    public void setSide1(Point... points) {
+    public void setPoints(Side side, Point... points) {
+        Objects.requireNonNull(side);
+        if (side == Side.ONE) {
+            setPoints1(points);
+        } else {
+            setPoints2(points);
+        }
+    }
+
+    public void setPoints1(Point... points) {
         Arrays.stream(points).forEach(Objects::requireNonNull);
-        this.line1 = Arrays.asList(points);
+        this.points1 = Arrays.asList(points);
     }
 
-    public void setSide2(Point... points) {
+    public void setPoints2(Point... points) {
         Arrays.stream(points).forEach(Objects::requireNonNull);
-        this.line2 = Arrays.asList(points);
+        this.points2 = Arrays.asList(points);
     }
 
     public boolean isVisible(Side side) {

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -17,7 +17,11 @@ import java.util.Objects;
 public class BranchEdge extends AbstractEdge {
 
     public enum Side {
-        ONE, TWO
+        ONE, TWO;
+
+        public Side getOpposite() {
+            return this == ONE ? TWO : ONE;
+        }
     }
 
     public static final String TWO_WT_EDGE = "TwoWtEdge";

--- a/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
+++ b/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
@@ -17,11 +17,11 @@ public class VoltageLevelNode extends AbstractNode {
     private final List<BusInnerNode> busInnerNodes = new ArrayList<>();
     private final boolean visible;
 
-    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, double nominalV) {
-        this(diagramId, equipmentId, nameOrId, nominalV, true);
+    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId) {
+        this(diagramId, equipmentId, nameOrId, true);
     }
 
-    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, double nominalV, boolean visible) {
+    public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, boolean visible) {
         super(diagramId, equipmentId, nameOrId);
         this.visible = visible;
     }

--- a/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
+++ b/src/main/java/com/powsybl/nad/model/VoltageLevelNode.java
@@ -14,7 +14,6 @@ import java.util.List;
  */
 public class VoltageLevelNode extends AbstractNode {
 
-    private final double nominalV;
     private final List<BusInnerNode> busInnerNodes = new ArrayList<>();
     private final boolean visible;
 
@@ -24,12 +23,7 @@ public class VoltageLevelNode extends AbstractNode {
 
     public VoltageLevelNode(String diagramId, String equipmentId, String nameOrId, double nominalV, boolean visible) {
         super(diagramId, equipmentId, nameOrId);
-        this.nominalV = nominalV;
         this.visible = visible;
-    }
-
-    public double getNominalV() {
-        return nominalV;
     }
 
     public void addBusNode(BusInnerNode busInnerNode) {

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -55,12 +55,7 @@ public abstract class AbstractStyleProvider implements StyleProvider {
 
     @Override
     public List<String> getNodeStyleClasses(Node node) {
-        List<String> styles = new ArrayList<>();
-        if (node instanceof VoltageLevelNode) {
-            double nominalV = ((VoltageLevelNode) node).getNominalV();
-            getBaseVoltageStyle(nominalV).ifPresent(styles::add);
-        }
-        return styles;
+        return Collections.emptyList();
     }
 
     @Override
@@ -82,7 +77,17 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
+    public List<String> getEdgeInfoStyles(EdgeInfo info) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public Optional<String> getThreeWtNodeBackgroundStyle(ThreeWtNode threeWtNode) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getThreeWtNodeStyle(ThreeWtNode threeWtNode, ThreeWtEdge.Side one) {
         return Optional.empty();
     }
 

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -124,8 +124,8 @@ public class SvgWriter {
 
     private void drawConverterStation(XMLStreamWriter writer, BranchEdge edge) throws XMLStreamException {
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-        List<Point> line1 = edge.getLine(BranchEdge.Side.ONE);
-        List<Point> line2 = edge.getLine(BranchEdge.Side.TWO);
+        List<Point> line1 = edge.getPoints(BranchEdge.Side.ONE);
+        List<Point> line2 = edge.getPoints(BranchEdge.Side.TWO);
         List<Point> points = new ArrayList<>(2);
         double halfWidth = svgParameters.getConverterStationWidth() / 2;
         if (line1.size() > 2) {
@@ -167,7 +167,7 @@ public class SvgWriter {
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         addStylesIfAny(writer, styleProvider.getSideEdgeStyleClasses(edge, side));
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-        List<Point> half = edge.getLine(side);
+        List<Point> half = edge.getPoints(side);
         if (edge.isVisible(side)) {
             String lineFormatted = half.stream()
                 .map(point -> getFormattedValue(point.getX()) + "," + getFormattedValue(point.getY()))

--- a/src/main/java/com/powsybl/nad/svg/iidm/DefaultStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/iidm/DefaultStyleProvider.java
@@ -8,10 +8,7 @@ package com.powsybl.nad.svg.iidm;
 
 import com.powsybl.commons.config.BaseVoltagesConfig;
 import com.powsybl.iidm.network.*;
-import com.powsybl.nad.model.BranchEdge;
-import com.powsybl.nad.model.Edge;
-import com.powsybl.nad.model.ThreeWtEdge;
-import com.powsybl.nad.model.ThreeWtNode;
+import com.powsybl.nad.model.*;
 import com.powsybl.nad.svg.AbstractStyleProvider;
 import com.powsybl.nad.svg.EdgeInfo;
 
@@ -37,6 +34,16 @@ public class DefaultStyleProvider extends AbstractStyleProvider {
     @Override
     public List<String> getCssFilenames() {
         return Collections.singletonList("defaultStyle.css");
+    }
+
+    @Override
+    public List<String> getNodeStyleClasses(Node node) {
+        List<String> styles = new ArrayList<>();
+        if (node instanceof VoltageLevelNode) {
+            double nominalV = network.getVoltageLevel(node.getEquipmentId()).getNominalV();
+            getBaseVoltageStyle(nominalV).ifPresent(styles::add);
+        }
+        return styles;
     }
 
     @Override

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -1085,25 +1085,6 @@
         </g>
         <g id="74" class="nad-vl180to300" title="L-21-15-2 ">
             <g>
-                <polyline points="-3.06,-8.50 -3.84,-8.67 -4.96,-9.70"/>
-                <g class="nad-edge-infos" transform="translate(-4.06,-8.87)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-47.36)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-47.36)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                </g>
-            </g>
-            <g>
                 <polyline points="-6.32,-11.50 -6.09,-10.74 -4.96,-9.70"/>
                 <g class="nad-edge-infos" transform="translate(-5.86,-10.53)">
                     <g class="nad-active nad-state-out">
@@ -1115,6 +1096,25 @@
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <polyline points="-3.06,-8.50 -3.84,-8.67 -4.96,-9.70"/>
+                <g class="nad-edge-infos" transform="translate(-4.06,-8.87)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-47.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-47.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -155,25 +155,6 @@
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-4.74,-2.08 -4.47,-1.33 -4.75,0.19"/>
-                <g class="nad-edge-infos" transform="translate(-4.53,-1.03)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-169.70)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-169.70)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                </g>
-            </g>
-            <g>
                 <polyline points="-5.54,2.31 -5.02,1.70 -4.75,0.19"/>
                 <g class="nad-edge-infos" transform="translate(-4.97,1.41)">
                     <g class="nad-active nad-state-out">
@@ -185,6 +166,25 @@
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
+            </g>
+            <g>
+                <polyline points="-4.74,-2.08 -4.47,-1.33 -4.75,0.19"/>
+                <g class="nad-edge-infos" transform="translate(-4.53,-1.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-169.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Bug fix


**What is the current behavior?**
- nominalV is still in VoltageLevelNode
- edges direction is not guaranteed in multi-branch edges 


**What is the new behavior (if this is a feature change)?**
- nominalV deleted from VoltageLevelNode, the `DefaultStyleProvider` looks for it in the `Network`
- edges direction 1 -> 2 is guaranteed in multi-branch edges


**Does this PR introduce a breaking change or deprecate an API?**
Yes

