### PR TITLE
Draw loops

### DIFF
--- a/src/main/java/com/powsybl/nad/model/AbstractEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractEdge.java
@@ -37,4 +37,10 @@ public abstract class AbstractEdge implements Edge {
     public Optional<String> getName() {
         return Optional.ofNullable(name);
     }
+
+    protected double getEdgeStartAngle(List<Point> line) {
+        Point point1 = line.get(1);
+        Point point0 = line.get(0);
+        return Math.atan2(point1.getY() - point0.getY(), point1.getX() - point0.getX());
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/AbstractEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractEdge.java
@@ -38,9 +38,7 @@ public abstract class AbstractEdge implements Edge {
         return Optional.ofNullable(name);
     }
 
-    protected double getEdgeStartAngle(List<Point> line) {
-        Point point1 = line.get(1);
-        Point point0 = line.get(0);
+    protected double getAngle(Point point0, Point point1) {
         return Math.atan2(point1.getY() - point0.getY(), point1.getX() - point0.getX());
     }
 }

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -85,6 +85,12 @@ public class BranchEdge extends AbstractEdge {
     }
 
     public double getEdgeStartAngle(Side side) {
-        return getEdgeStartAngle(getPoints(side));
+        List<Point> points = getPoints(side);
+        return getAngle(points.get(0), points.get(1));
+    }
+
+    public double getEdgeEndAngle(Side side) {
+        List<Point> points = getPoints(side);
+        return getAngle(points.get(points.size() - 2), points.get(points.size() - 1));
     }
 }

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -83,4 +83,8 @@ public class BranchEdge extends AbstractEdge {
         Objects.requireNonNull(side);
         this.visible[side.ordinal()] = visible;
     }
+
+    public double getEdgeStartAngle(Side side) {
+        return getEdgeStartAngle(getPoints(side));
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -119,6 +119,12 @@ public class Graph {
         return voltageLevelGraph.edgesOf(node).stream();
     }
 
+    public Stream<BranchEdge> getBranchEdgeStream(Node node) {
+        return getEdgeStream(node)
+                .filter(BranchEdge.class::isInstance)
+                .map(BranchEdge.class::cast);
+    }
+
     public Collection<Edge> getBusEdges(BusNode busNode) {
         return busGraph.edgesOf(busNode);
     }
@@ -154,11 +160,22 @@ public class Graph {
 
     public Stream<List<BranchEdge>> getMultiBranchEdgesStream() {
         return voltageLevelGraph.edgeSet().stream()
+                .filter(e -> !isLoop(e))
                 .map(e -> voltageLevelGraph.getAllEdges(voltageLevelGraph.getEdgeSource(e), voltageLevelGraph.getEdgeTarget(e)))
                 .filter(e -> e.size() > 1)
                 .distinct()
                 .map(e -> e.stream().filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast).collect(Collectors.toList()))
                 .filter(e -> e.size() > 1);
+    }
+
+    public Stream<Set<BranchEdge>> getLoopBranchEdgesStream() {
+        return voltageLevelGraph.edgeSet().stream()
+                .filter(BranchEdge.class::isInstance)
+                .filter(this::isLoop)
+                .map(voltageLevelGraph::getEdgeSource)
+                .map(n -> voltageLevelGraph.getAllEdges(n, n))
+                .map(set -> set.stream().filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast).collect(Collectors.toSet()))
+                .distinct();
     }
 
     public Stream<ThreeWtEdge> getThreeWtEdgesStream() {
@@ -252,5 +269,9 @@ public class Graph {
 
     public boolean containsNode(String equipmentId) {
         return nodes.containsKey(equipmentId);
+    }
+
+    public boolean isLoop(Edge edge) {
+        return getNode1(edge) == getNode2(edge);
     }
 }

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -168,14 +168,16 @@ public class Graph {
                 .filter(e -> e.size() > 1);
     }
 
-    public Stream<Set<BranchEdge>> getLoopBranchEdgesStream() {
+    public Map<Node, Set<BranchEdge>> getLoopBranchEdgesMap() {
         return voltageLevelGraph.edgeSet().stream()
                 .filter(BranchEdge.class::isInstance)
                 .filter(this::isLoop)
                 .map(voltageLevelGraph::getEdgeSource)
-                .map(n -> voltageLevelGraph.getAllEdges(n, n))
-                .map(set -> set.stream().filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast).collect(Collectors.toSet()))
-                .distinct();
+                .collect(Collectors.toMap(
+                    n -> n,
+                    n -> voltageLevelGraph.getAllEdges(n, n).stream().filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast).collect(Collectors.toSet()),
+                    (v1, v2) -> Stream.concat(v1.stream(), v2.stream()).collect(Collectors.toSet())
+                ));
     }
 
     public Stream<ThreeWtEdge> getThreeWtEdgesStream() {

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -168,16 +168,13 @@ public class Graph {
                 .filter(e -> e.size() > 1);
     }
 
-    public Map<Node, Set<BranchEdge>> getLoopBranchEdgesMap() {
-        return voltageLevelGraph.edgeSet().stream()
-                .filter(BranchEdge.class::isInstance)
-                .filter(this::isLoop)
-                .map(voltageLevelGraph::getEdgeSource)
-                .collect(Collectors.toMap(
-                    n -> n,
-                    n -> voltageLevelGraph.getAllEdges(n, n).stream().filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast).collect(Collectors.toSet()),
-                    (v1, v2) -> Stream.concat(v1.stream(), v2.stream()).collect(Collectors.toSet())
-                ));
+    public Map<Node, List<BranchEdge>> getLoopBranchEdgesMap() {
+        return voltageLevelGraph.vertexSet().stream()
+                .map(n -> voltageLevelGraph.getAllEdges(n, n).stream()
+                        .filter(BranchEdge.class::isInstance).map(BranchEdge.class::cast)
+                        .collect(Collectors.toList()))
+                .filter(l -> !l.isEmpty())
+                .collect(Collectors.toMap(l -> voltageLevelGraph.getEdgeSource(l.get(0)), l -> l));
     }
 
     public Stream<ThreeWtEdge> getThreeWtEdgesStream() {

--- a/src/main/java/com/powsybl/nad/model/Point.java
+++ b/src/main/java/com/powsybl/nad/model/Point.java
@@ -65,4 +65,9 @@ public class Point {
         return new Point(x + r * (direction.x - x),
                 y + r * (direction.y - y));
     }
+
+    public Point atDistance(double dist, double angle) {
+        return new Point(x + dist * Math.cos(angle),
+                y + dist * Math.sin(angle));
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
+++ b/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
@@ -46,4 +46,8 @@ public class ThreeWtEdge extends AbstractEdge {
     public Side getSide() {
         return side;
     }
+
+    public double getEdgeStartAngle() {
+        return getEdgeStartAngle(points);
+    }
 }

--- a/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
+++ b/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
@@ -47,7 +47,7 @@ public class ThreeWtEdge extends AbstractEdge {
         return side;
     }
 
-    public double getEdgeStartAngle() {
-        return getEdgeStartAngle(points);
+    public double getEdgeAngle() {
+        return getAngle(points.get(0), points.get(1));
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.nad.model.*;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class DefaultEdgeRendering implements EdgeRendering {
+
+    @Override
+    public void run(Graph graph, SvgParameters svgParameters) {
+        graph.getNonMultiBranchEdgesStream().forEach(edge -> computeSingleBranchEdgeCoordinates(graph, edge, svgParameters));
+        graph.getMultiBranchEdgesStream().forEach(edges -> computeMultiBranchEdgesCoordinates(graph, edges, svgParameters));
+        graph.getLoopBranchEdgesMap().forEach((node, edges) -> loopEdgesLayout(graph, node, edges, svgParameters));
+        graph.getThreeWtEdgesStream().forEach(edge -> computeThreeWtEdgeCoordinates(graph, edge, svgParameters));
+        graph.getTextEdgesMap().forEach((edge, nodes) -> computeTextEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
+    }
+
+    private void computeTextEdgeLayoutCoordinates(Node node1, Node node2, TextEdge edge) {
+        edge.setPoints(node1.getPosition(), node2.getPosition());
+    }
+
+    private void computeSingleBranchEdgeCoordinates(Graph graph, BranchEdge edge, SvgParameters svgParameters) {
+        Node node1 = graph.getBusGraphNode1(edge);
+        Node node2 = graph.getBusGraphNode2(edge);
+
+        Point direction1 = getDirection(node2, () -> graph.getNode2(edge));
+        Point edgeStart1 = computeEdgeStart(node1, direction1, () -> graph.getNode1(edge), svgParameters);
+
+        Point direction2 = getDirection(node1, () -> graph.getNode1(edge));
+        Point edgeStart2 = computeEdgeStart(node2, direction2, () -> graph.getNode2(edge), svgParameters);
+
+        Point middle = Point.createMiddlePoint(edgeStart1, edgeStart2);
+        edge.setPoints1(edgeStart1, middle);
+        edge.setPoints2(edgeStart2, middle);
+    }
+
+    private Point getDirection(Node directionBusGraphNode, Supplier<Node> vlNodeSupplier) {
+        if (directionBusGraphNode == BusNode.UNKNOWN) {
+            return vlNodeSupplier.get().getPosition();
+        }
+        return directionBusGraphNode.getPosition();
+    }
+
+    private Point computeEdgeStart(Node node, Point direction, Supplier<Node> vlNodeSupplier, SvgParameters svgParameters) {
+        // If edge not connected to a bus node on that side, we use corresponding voltage level with specific extra radius
+        if (node == BusNode.UNKNOWN) {
+            double unknownBusRadius = svgParameters.getVoltageLevelCircleRadius() + svgParameters.getUnknownBusNodeExtraRadius();
+            return vlNodeSupplier.get().getPosition().atDistance(unknownBusRadius, direction);
+        }
+
+        Point edgeStart = node.getPosition();
+        if (node instanceof BusNode) {
+            int nbNeighbours = ((BusNode) node).getNbNeighbouringBusNodes();
+            double unitaryRadius = svgParameters.getVoltageLevelCircleRadius() / (nbNeighbours + 1);
+            double busAnnulusOuterRadius = (((BusNode) node).getIndex() + 1) * unitaryRadius - svgParameters.getEdgeStartShift();
+            edgeStart = edgeStart.atDistance(busAnnulusOuterRadius, direction);
+        }
+        return edgeStart;
+    }
+
+    private void computeMultiBranchEdgesCoordinates(Graph graph, List<BranchEdge> edges, SvgParameters svgParameters) {
+        Edge firstEdge = edges.iterator().next();
+        Node nodeA = graph.getNode1(firstEdge);
+        Node nodeB = graph.getNode2(firstEdge);
+        Point pointA = nodeA.getPosition();
+        Point pointB = nodeB.getPosition();
+
+        double dx = pointB.getX() - pointA.getX();
+        double dy = pointB.getY() - pointA.getY();
+        double angle = Math.atan2(dy, dx);
+
+        int nbForks = edges.size();
+        double forkAperture = svgParameters.getEdgesForkAperture();
+        double forkLength = svgParameters.getEdgesForkLength();
+        double angleStep = forkAperture / (nbForks - 1);
+
+        int i = 0;
+        for (BranchEdge edge : edges) {
+            if (2 * i + 1 == nbForks) { // in the middle, hence alpha = 0
+                computeSingleBranchEdgeCoordinates(graph, edge, svgParameters);
+            } else {
+                double alpha = -forkAperture / 2 + i * angleStep;
+                double angleForkA = angle - alpha;
+                double angleForkB = angle + Math.PI + alpha;
+                Point forkA = pointA.shift(forkLength * Math.cos(angleForkA), forkLength * Math.sin(angleForkA));
+                Point forkB = pointB.shift(forkLength * Math.cos(angleForkB), forkLength * Math.sin(angleForkB));
+                Point middle = Point.createMiddlePoint(forkA, forkB);
+
+                BranchEdge.Side sideA = graph.getNode1(edge) == nodeA ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
+                BranchEdge.Side sideB = sideA.getOpposite();
+
+                Node busNodeA = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode1(edge) : graph.getBusGraphNode2(edge);
+                Node busNodeB = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode2(edge) : graph.getBusGraphNode1(edge);
+
+                Point edgeStartA = computeEdgeStart(busNodeA, forkA, () -> nodeA, svgParameters);
+                edge.setPoints(sideA, edgeStartA, forkA, middle);
+
+                Point edgeStartB = computeEdgeStart(busNodeB, forkB, () -> nodeB, svgParameters);
+                edge.setPoints(sideB, edgeStartB, forkB, middle);
+            }
+            i++;
+        }
+    }
+
+    private void loopEdgesLayout(Graph graph, Node node, List<BranchEdge> loopEdges, SvgParameters svgParameters) {
+        List<Double> angles = computeLoopAngles(graph, loopEdges, node, svgParameters);
+
+        int i = 0;
+        Point nodePoint = node.getPosition();
+        for (BranchEdge edge : loopEdges) {
+            double angle = angles.get(i++);
+            Point middle = nodePoint.atDistance(svgParameters.getLoopDistance(), angle);
+            Point fork1 = nodePoint.atDistance(svgParameters.getEdgesForkLength(), angle - svgParameters.getLoopEdgesAperture() / 2);
+            Point fork2 = nodePoint.atDistance(svgParameters.getEdgesForkLength(), angle + svgParameters.getLoopEdgesAperture() / 2);
+
+            Node busNode1 = graph.getBusGraphNode1(edge);
+            Node busNode2 = graph.getBusGraphNode2(edge);
+
+            Point edgeStart1 = computeEdgeStart(busNode1, fork1, () -> node, svgParameters);
+            edge.setPoints(BranchEdge.Side.ONE, edgeStart1, fork1, middle);
+
+            Point edgeStart2 = computeEdgeStart(busNode2, fork2, () -> node, svgParameters);
+            edge.setPoints(BranchEdge.Side.TWO, edgeStart2, fork2, middle);
+        }
+    }
+
+    private List<Double> computeLoopAngles(Graph graph, List<BranchEdge> loopEdges, Node node, SvgParameters svgParameters) {
+        int nbLoops = loopEdges.size();
+
+        List<Double> anglesOtherEdges = graph.getBranchEdgeStream(node)
+                .filter(e -> !loopEdges.contains(e))
+                .mapToDouble(e -> getAngle(e, graph, node))
+                .sorted().boxed().collect(Collectors.toList());
+
+        List<Double> loopAngles = new ArrayList<>();
+        if (anglesOtherEdges.size() > 0) {
+            anglesOtherEdges.add(anglesOtherEdges.get(0) + 2 * Math.PI);
+            double apertureWithMargin = svgParameters.getLoopEdgesAperture() * 1.2;
+
+            double[] deltaAngles = new double[anglesOtherEdges.size() - 1];
+            int nbSeparatedSlots = 0;
+            int nbSharedSlots = 0;
+            for (int i = 0; i < anglesOtherEdges.size() - 1; i++) {
+                deltaAngles[i] = anglesOtherEdges.get(i + 1) - anglesOtherEdges.get(i);
+                nbSeparatedSlots += deltaAngles[i] > apertureWithMargin ? 1 : 0;
+                nbSharedSlots += Math.floor(deltaAngles[i] / apertureWithMargin);
+            }
+
+            List<Integer> sortedIndices = IntStream.range(0, deltaAngles.length)
+                    .boxed().sorted(Comparator.comparingDouble(i -> deltaAngles[i]))
+                    .collect(Collectors.toList());
+
+            if (nbLoops <= nbSeparatedSlots) {
+                // Place loops in "slots" separated by non-loop edges
+                for (int i = sortedIndices.size() - nbLoops; i < sortedIndices.size(); i++) {
+                    int iSorted = sortedIndices.get(i);
+                    loopAngles.add((anglesOtherEdges.get(iSorted) + anglesOtherEdges.get(iSorted + 1)) / 2);
+                }
+            } else if (nbLoops <= nbSharedSlots) {
+                // Place the maximum of loops in "slots" separated by non-loop edges, and put the excessive ones in the bigger "slots"
+                int nbExcessiveRemaining = nbLoops - nbSeparatedSlots;
+                for (int i = sortedIndices.size() - 1; i >= 0; i--) {
+                    int iSorted = sortedIndices.get(i);
+                    int nbAvailableSlots = (int) Math.floor(deltaAngles[iSorted] / apertureWithMargin);
+                    if (nbAvailableSlots == 0) {
+                        break;
+                    }
+                    int nbLoopsInDelta = Math.min(nbAvailableSlots, nbExcessiveRemaining + 1);
+                    double extraSpace = deltaAngles[iSorted] - svgParameters.getLoopEdgesAperture() * nbLoopsInDelta; // extra space without margins
+                    double intraSpace = extraSpace / (nbLoopsInDelta + 1); // space between two loops and between non-loop edges and first/last loop
+                    double angleStep = (anglesOtherEdges.get(iSorted + 1) - anglesOtherEdges.get(iSorted) - intraSpace) / nbLoopsInDelta;
+                    double startAngle = anglesOtherEdges.get(iSorted) + intraSpace / 2 + angleStep / 2;
+                    IntStream.range(0, nbLoopsInDelta).mapToDouble(iLoop -> startAngle + iLoop * angleStep).forEach(loopAngles::add);
+                    nbExcessiveRemaining -= nbLoopsInDelta - 1;
+                }
+            } else {
+                // Not enough place in the slots: dividing the circle in nbLoops, starting in the middle of the biggest slot
+                int iMaxDelta = sortedIndices.get(sortedIndices.size() - 1);
+                double startAngle = (anglesOtherEdges.get(iMaxDelta) + anglesOtherEdges.get(iMaxDelta + 1)) / 2;
+                IntStream.range(0, nbLoops).mapToDouble(i -> startAngle + i * 2 * Math.PI / nbLoops).forEach(loopAngles::add);
+            }
+
+        } else {
+            // No other edges: dividing the circle in nbLoops
+            IntStream.range(0, nbLoops).mapToDouble(i -> i * 2 * Math.PI / nbLoops).forEach(loopAngles::add);
+        }
+
+        return loopAngles;
+    }
+
+    private double getAngle(BranchEdge edge, Graph graph, Node node) {
+        BranchEdge.Side side = graph.getNode1(edge) == node ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
+        return edge.getEdgeStartAngle(side);
+    }
+
+    private void computeThreeWtEdgeCoordinates(Graph graph, ThreeWtEdge edge, SvgParameters svgParameters) {
+        Node node1 = graph.getBusGraphNode1(edge);
+        Node node2 = graph.getBusGraphNode2(edge);
+
+        Point direction1 = getDirection(node2, () -> graph.getNode2(edge));
+        Point edgeStart1 = computeEdgeStart(node1, direction1, () -> graph.getNode1(edge), svgParameters);
+
+        Point direction2 = getDirection(node1, () -> graph.getNode1(edge));
+        Point edgeStart2 = computeEdgeStart(node2, direction2, () -> graph.getNode2(edge), svgParameters);
+
+        edge.setPoints(edgeStart1, edgeStart2);
+    }
+}

--- a/src/main/java/com/powsybl/nad/svg/EdgeRendering.java
+++ b/src/main/java/com/powsybl/nad/svg/EdgeRendering.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.nad.model.Graph;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public interface EdgeRendering {
+    void run(Graph graph, SvgParameters svgParameters);
+}

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -30,6 +30,8 @@ public class SvgParameters {
     private double edgesForkAperture = Math.toRadians(60);
     private double edgeStartShift = 0.03;
     private double unknownBusNodeExtraRadius = 0.1;
+    private double loopDistance = 1.2;
+    private double loopEdgesAperture = Math.toRadians(60);
 
     public enum CssLocation {
         INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT
@@ -167,6 +169,15 @@ public class SvgParameters {
         return this;
     }
 
+    public double getLoopEdgesAperture() {
+        return loopEdgesAperture;
+    }
+
+    public SvgParameters setLoopEdgesAperture(double loopEdgesApertureDegrees) {
+        this.loopEdgesAperture = Math.toRadians(loopEdgesApertureDegrees);
+        return this;
+    }
+
     public double getEdgesForkLength() {
         return edgesForkLength;
     }
@@ -191,6 +202,15 @@ public class SvgParameters {
 
     public SvgParameters setUnknownBusNodeExtraRadius(double unknownBusNodeExtraRadius) {
         this.unknownBusNodeExtraRadius = unknownBusNodeExtraRadius;
+        return this;
+    }
+
+    public double getLoopDistance() {
+        return loopDistance;
+    }
+
+    public SvgParameters setLoopDistance(double loopDistance) {
+        this.loopDistance = loopDistance;
         return this;
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -20,7 +20,6 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
@@ -53,11 +52,13 @@ public class SvgWriter {
     private final SvgParameters svgParameters;
     private final StyleProvider styleProvider;
     private final LabelProvider labelProvider;
+    private final EdgeRendering edgeRendering;
 
     public SvgWriter(SvgParameters svgParameters, StyleProvider styleProvider, LabelProvider labelProvider) {
         this.svgParameters = Objects.requireNonNull(svgParameters);
         this.styleProvider = Objects.requireNonNull(styleProvider);
         this.labelProvider = Objects.requireNonNull(labelProvider);
+        this.edgeRendering = new DefaultEdgeRendering();
     }
 
     public void writeSvg(Graph graph, Path svgFile) {
@@ -87,7 +88,7 @@ public class SvgWriter {
         Objects.requireNonNull(svgOs);
 
         // Edge coordinates need to be computed first, based on svg parameters
-        computeBranchEdgesCoordinates(graph);
+        edgeRendering.run(graph, svgParameters);
 
         try {
             XMLStreamWriter writer = XmlUtil.initializeWriter(true, INDENT, svgOs);
@@ -104,205 +105,6 @@ public class SvgWriter {
         } catch (XMLStreamException e) {
             throw new UncheckedXmlStreamException(e);
         }
-    }
-
-    private void computeBranchEdgesCoordinates(Graph graph) {
-        graph.getNonMultiBranchEdgesStream().forEach(edge -> computeSingleBranchEdgeCoordinates(graph, edge));
-        graph.getMultiBranchEdgesStream().forEach(edges -> computeMultiBranchEdgesCoordinates(graph, edges));
-        graph.getLoopBranchEdgesMap().forEach((node, edges) -> loopEdgesLayout(graph, node, edges));
-        graph.getThreeWtEdgesStream().forEach(edge -> computeThreeWtEdgeCoordinates(graph, edge));
-        graph.getTextEdgesMap().forEach((edge, nodes) -> computeTextEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
-    }
-
-    private void computeTextEdgeLayoutCoordinates(Node node1, Node node2, TextEdge edge) {
-        edge.setPoints(node1.getPosition(), node2.getPosition());
-    }
-
-    private void computeSingleBranchEdgeCoordinates(Graph graph, BranchEdge edge) {
-        Node node1 = graph.getBusGraphNode1(edge);
-        Node node2 = graph.getBusGraphNode2(edge);
-
-        Point direction1 = getDirection(node2, () -> graph.getNode2(edge));
-        Point edgeStart1 = computeEdgeStart(node1, direction1, () -> graph.getNode1(edge));
-
-        Point direction2 = getDirection(node1, () -> graph.getNode1(edge));
-        Point edgeStart2 = computeEdgeStart(node2, direction2, () -> graph.getNode2(edge));
-
-        Point middle = Point.createMiddlePoint(edgeStart1, edgeStart2);
-        edge.setPoints1(edgeStart1, middle);
-        edge.setPoints2(edgeStart2, middle);
-    }
-
-    private Point getDirection(Node directionBusGraphNode, Supplier<Node> vlNodeSupplier) {
-        if (directionBusGraphNode == BusNode.UNKNOWN) {
-            return vlNodeSupplier.get().getPosition();
-        }
-        return directionBusGraphNode.getPosition();
-    }
-
-    private Point computeEdgeStart(Node node, Point direction, Supplier<Node> vlNodeSupplier) {
-        // If edge not connected to a bus node on that side, we use corresponding voltage level with specific extra radius
-        if (node == BusNode.UNKNOWN) {
-            double unknownBusRadius = svgParameters.getVoltageLevelCircleRadius() + svgParameters.getUnknownBusNodeExtraRadius();
-            return vlNodeSupplier.get().getPosition().atDistance(unknownBusRadius, direction);
-        }
-
-        Point edgeStart = node.getPosition();
-        if (node instanceof BusNode) {
-            int nbNeighbours = ((BusNode) node).getNbNeighbouringBusNodes();
-            double unitaryRadius = svgParameters.getVoltageLevelCircleRadius() / (nbNeighbours + 1);
-            double busAnnulusOuterRadius = (((BusNode) node).getIndex() + 1) * unitaryRadius - svgParameters.getEdgeStartShift();
-            edgeStart = edgeStart.atDistance(busAnnulusOuterRadius, direction);
-        }
-        return edgeStart;
-    }
-
-    private void computeMultiBranchEdgesCoordinates(Graph graph, List<BranchEdge> edges) {
-        Edge firstEdge = edges.iterator().next();
-        Node nodeA = graph.getNode1(firstEdge);
-        Node nodeB = graph.getNode2(firstEdge);
-        Point pointA = nodeA.getPosition();
-        Point pointB = nodeB.getPosition();
-
-        double dx = pointB.getX() - pointA.getX();
-        double dy = pointB.getY() - pointA.getY();
-        double angle = Math.atan2(dy, dx);
-
-        int nbForks = edges.size();
-        double forkAperture = svgParameters.getEdgesForkAperture();
-        double forkLength = svgParameters.getEdgesForkLength();
-        double angleStep = forkAperture / (nbForks - 1);
-
-        int i = 0;
-        for (BranchEdge edge : edges) {
-            if (2 * i + 1 == nbForks) { // in the middle, hence alpha = 0
-                computeSingleBranchEdgeCoordinates(graph, edge);
-            } else {
-                double alpha = -forkAperture / 2 + i * angleStep;
-                double angleForkA = angle - alpha;
-                double angleForkB = angle + Math.PI + alpha;
-                Point forkA = pointA.shift(forkLength * Math.cos(angleForkA), forkLength * Math.sin(angleForkA));
-                Point forkB = pointB.shift(forkLength * Math.cos(angleForkB), forkLength * Math.sin(angleForkB));
-                Point middle = Point.createMiddlePoint(forkA, forkB);
-
-                BranchEdge.Side sideA = graph.getNode1(edge) == nodeA ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
-                BranchEdge.Side sideB = sideA.getOpposite();
-
-                Node busNodeA = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode1(edge) : graph.getBusGraphNode2(edge);
-                Node busNodeB = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode2(edge) : graph.getBusGraphNode1(edge);
-
-                Point edgeStartA = computeEdgeStart(busNodeA, forkA, () -> nodeA);
-                edge.setPoints(sideA, edgeStartA, forkA, middle);
-
-                Point edgeStartB = computeEdgeStart(busNodeB, forkB, () -> nodeB);
-                edge.setPoints(sideB, edgeStartB, forkB, middle);
-            }
-            i++;
-        }
-    }
-
-    private void loopEdgesLayout(Graph graph, Node node, List<BranchEdge> loopEdges) {
-        List<Double> angles = computeLoopAngles(graph, loopEdges, node);
-
-        int i = 0;
-        Point nodePoint = node.getPosition();
-        for (BranchEdge edge : loopEdges) {
-            double angle = angles.get(i++);
-            Point middle = nodePoint.atDistance(svgParameters.getLoopDistance(), angle);
-            Point fork1 = nodePoint.atDistance(svgParameters.getEdgesForkLength(), angle - svgParameters.getLoopEdgesAperture() / 2);
-            Point fork2 = nodePoint.atDistance(svgParameters.getEdgesForkLength(), angle + svgParameters.getLoopEdgesAperture() / 2);
-
-            Node busNode1 = graph.getBusGraphNode1(edge);
-            Node busNode2 = graph.getBusGraphNode2(edge);
-
-            Point edgeStart1 = computeEdgeStart(busNode1, fork1, () -> node);
-            edge.setPoints(BranchEdge.Side.ONE, edgeStart1, fork1, middle);
-
-            Point edgeStart2 = computeEdgeStart(busNode2, fork2, () -> node);
-            edge.setPoints(BranchEdge.Side.TWO, edgeStart2, fork2, middle);
-        }
-    }
-
-    private List<Double> computeLoopAngles(Graph graph, List<BranchEdge> loopEdges, Node node) {
-        int nbLoops = loopEdges.size();
-
-        List<Double> anglesOtherEdges = graph.getBranchEdgeStream(node)
-                .filter(e -> !loopEdges.contains(e))
-                .mapToDouble(e -> getAngle(e, graph, node))
-                .sorted().boxed().collect(Collectors.toList());
-
-        List<Double> loopAngles = new ArrayList<>();
-        if (anglesOtherEdges.size() > 0) {
-            anglesOtherEdges.add(anglesOtherEdges.get(0) + 2 * Math.PI);
-            double apertureWithMargin = svgParameters.getLoopEdgesAperture() * 1.2;
-
-            double[] deltaAngles = new double[anglesOtherEdges.size() - 1];
-            int nbSeparatedSlots = 0;
-            int nbSharedSlots = 0;
-            for (int i = 0; i < anglesOtherEdges.size() - 1; i++) {
-                deltaAngles[i] = anglesOtherEdges.get(i + 1) - anglesOtherEdges.get(i);
-                nbSeparatedSlots += deltaAngles[i] > apertureWithMargin ? 1 : 0;
-                nbSharedSlots += Math.floor(deltaAngles[i] / apertureWithMargin);
-            }
-
-            List<Integer> sortedIndices = IntStream.range(0, deltaAngles.length)
-                    .boxed().sorted(Comparator.comparingDouble(i -> deltaAngles[i]))
-                    .collect(Collectors.toList());
-
-            if (nbLoops <= nbSeparatedSlots) {
-                // Place loops in "slots" separated by non-loop edges
-                for (int i = sortedIndices.size() - nbLoops; i < sortedIndices.size(); i++) {
-                    int iSorted = sortedIndices.get(i);
-                    loopAngles.add((anglesOtherEdges.get(iSorted) + anglesOtherEdges.get(iSorted + 1)) / 2);
-                }
-            } else if (nbLoops <= nbSharedSlots) {
-                // Place the maximum of loops in "slots" separated by non-loop edges, and put the excessive ones in the bigger "slots"
-                int nbExcessiveRemaining = nbLoops - nbSeparatedSlots;
-                for (int i = sortedIndices.size() - 1; i >= 0; i--) {
-                    int iSorted = sortedIndices.get(i);
-                    int nbAvailableSlots = (int) Math.floor(deltaAngles[iSorted] / apertureWithMargin);
-                    if (nbAvailableSlots == 0) {
-                        break;
-                    }
-                    int nbLoopsInDelta = Math.min(nbAvailableSlots, nbExcessiveRemaining + 1);
-                    double extraSpace = deltaAngles[iSorted] - svgParameters.getLoopEdgesAperture() * nbLoopsInDelta; // extra space without margins
-                    double intraSpace = extraSpace / (nbLoopsInDelta + 1); // space between two loops and between non-loop edges and first/last loop
-                    double angleStep = (anglesOtherEdges.get(iSorted + 1) - anglesOtherEdges.get(iSorted) - intraSpace) / nbLoopsInDelta;
-                    double startAngle = anglesOtherEdges.get(iSorted) + intraSpace / 2 + angleStep / 2;
-                    IntStream.range(0, nbLoopsInDelta).mapToDouble(iLoop -> startAngle + iLoop * angleStep).forEach(loopAngles::add);
-                    nbExcessiveRemaining -= nbLoopsInDelta - 1;
-                }
-            } else {
-                // Not enough place in the slots: dividing the circle in nbLoops, starting in the middle of the biggest slot
-                int iMaxDelta = sortedIndices.get(sortedIndices.size() - 1);
-                double startAngle = (anglesOtherEdges.get(iMaxDelta) + anglesOtherEdges.get(iMaxDelta + 1)) / 2;
-                IntStream.range(0, nbLoops).mapToDouble(i -> startAngle + i * 2 * Math.PI / nbLoops).forEach(loopAngles::add);
-            }
-
-        } else {
-            // No other edges: dividing the circle in nbLoops
-            IntStream.range(0, nbLoops).mapToDouble(i -> i * 2 * Math.PI / nbLoops).forEach(loopAngles::add);
-        }
-
-        return loopAngles;
-    }
-
-    private double getAngle(BranchEdge edge, Graph graph, Node node) {
-        BranchEdge.Side side = graph.getNode1(edge) == node ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
-        return getEdgeStartAngle(edge.getPoints(side));
-    }
-
-    private void computeThreeWtEdgeCoordinates(Graph graph, ThreeWtEdge edge) {
-        Node node1 = graph.getBusGraphNode1(edge);
-        Node node2 = graph.getBusGraphNode2(edge);
-
-        Point direction1 = getDirection(node2, () -> graph.getNode2(edge));
-        Point edgeStart1 = computeEdgeStart(node1, direction1, () -> graph.getNode1(edge));
-
-        Point direction2 = getDirection(node1, () -> graph.getNode1(edge));
-        Point edgeStart2 = computeEdgeStart(node2, direction2, () -> graph.getNode2(edge));
-
-        edge.setPoints(edgeStart1, edgeStart2);
     }
 
     private void drawBranchEdges(Graph graph, XMLStreamWriter writer) throws XMLStreamException {
@@ -355,9 +157,6 @@ public class SvgWriter {
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.THREE_WT_EDGES_CLASS);
         for (ThreeWtEdge edge : threeWtEdges) {
-            if (!edge.isVisible()) {
-                continue;
-            }
             drawThreeWtEdge(graph, writer, edge);
         }
         writer.writeEndElement();
@@ -370,30 +169,40 @@ public class SvgWriter {
         }
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         addStylesIfAny(writer, styleProvider.getSideEdgeStyleClasses(edge, side));
-        List<Point> half = edge.getPoints(side);
         if (edge.isVisible(side)) {
             if (!graph.isLoop(edge)) {
                 writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-                String lineFormatted = half.stream()
-                        .map(point -> getFormattedValue(point.getX()) + "," + getFormattedValue(point.getY()))
-                        .collect(Collectors.joining(" "));
-                writer.writeAttribute(POINTS_ATTRIBUTE, lineFormatted);
-                drawEdgeInfo(writer, half, labelProvider.getEdgeInfos(graph, edge, side));
+                writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge, side));
+                drawBranchEdgeInfo(writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             } else {
                 writer.writeEmptyElement(PATH_ELEMENT_NAME);
-                String loopFormatted = getLoopPathD(half, side);
-                writer.writeAttribute(PATH_D_ATTRIBUTE, loopFormatted);
-                drawLoopEdgeInfo(writer, half, labelProvider.getEdgeInfos(graph, edge, side));
+                writer.writeAttribute(PATH_D_ATTRIBUTE, getLoopPathString(edge, side));
+                drawLoopEdgeInfo(writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             }
         }
         if (edge.getType().equals(BranchEdge.TWO_WT_EDGE)) {
-            draw2WtWinding(writer, half);
+            draw2WtWinding(writer, edge.getPoints(side));
         }
         writer.writeEndElement();
     }
 
-    private String getLoopPathD(List<Point> points, BranchEdge.Side side) {
-        double edgeStartAngle = getEdgeStartAngle(points);
+    private String getPolylinePointsString(BranchEdge edge, BranchEdge.Side side) {
+        return getPolylinePointsString(edge.getPoints(side));
+    }
+
+    private String getPolylinePointsString(ThreeWtEdge edge) {
+        return getPolylinePointsString(edge.getPoints());
+    }
+
+    private String getPolylinePointsString(List<Point> points) {
+        return points.stream()
+                .map(point -> getFormattedValue(point.getX()) + "," + getFormattedValue(point.getY()))
+                .collect(Collectors.joining(" "));
+    }
+
+    private String getLoopPathString(BranchEdge edge, BranchEdge.Side side) {
+        List<Point> points = edge.getPoints(side);
+        double edgeStartAngle = edge.getEdgeStartAngle(side);
         double controlsDist = 2 * (svgParameters.getEdgesForkLength() - svgParameters.getVoltageLevelCircleRadius());
         Point control1 = points.get(1).atDistance(controlsDist, edgeStartAngle);
 
@@ -410,17 +219,16 @@ public class SvgWriter {
     }
 
     private void drawThreeWtEdge(Graph graph, XMLStreamWriter writer, ThreeWtEdge edge) throws XMLStreamException {
+        if (!edge.isVisible()) {
+            return;
+        }
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         writer.writeAttribute(ID_ATTRIBUTE, edge.getDiagramId());
         addStylesIfAny(writer, styleProvider.getEdgeStyleClasses(edge));
         insertName(writer, edge::getName);
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
-        List<Point> points = edge.getPoints();
-        String lineFormatted = points.stream()
-                .map(point -> getFormattedValue(point.getX()) + "," + getFormattedValue(point.getY()))
-                .collect(Collectors.joining(" "));
-        writer.writeAttribute(POINTS_ATTRIBUTE, lineFormatted);
-        drawEdgeInfo(writer, points, labelProvider.getEdgeInfos(graph, edge));
+        writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge));
+        drawThreeWtEdgeInfo(writer, edge, labelProvider.getEdgeInfos(graph, edge));
         writer.writeEndElement();
     }
 
@@ -468,12 +276,16 @@ public class SvgWriter {
         writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(svgParameters.getTransformerCircleRadius()));
     }
 
-    private void drawLoopEdgeInfo(XMLStreamWriter writer, List<Point> line, List<EdgeInfo> edgeInfos) throws XMLStreamException {
-        drawEdgeInfo(writer, edgeInfos, line.get(1), getEdgeStartAngle(line) - Math.PI / 2);
+    private void drawLoopEdgeInfo(XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side, List<EdgeInfo> edgeInfos) throws XMLStreamException {
+        drawEdgeInfo(writer, edgeInfos, edge.getPoints(side).get(1), edge.getEdgeStartAngle(side) - Math.PI / 2);
     }
 
-    private void drawEdgeInfo(XMLStreamWriter writer, List<Point> line, List<EdgeInfo> edgeInfos) throws XMLStreamException {
-        drawEdgeInfo(writer, edgeInfos, getArrowCenter(line), getEdgeEndYAxisAngle(line));
+    private void drawBranchEdgeInfo(XMLStreamWriter writer, BranchEdge edge, BranchEdge.Side side, List<EdgeInfo> edgeInfos) throws XMLStreamException {
+        drawEdgeInfo(writer, edgeInfos, getArrowCenter(edge.getPoints(side)), getEdgeEndYAxisAngle(edge.getPoints(side)));
+    }
+
+    private void drawThreeWtEdgeInfo(XMLStreamWriter writer, ThreeWtEdge edge, List<EdgeInfo> edgeInfos) throws XMLStreamException {
+        drawEdgeInfo(writer, edgeInfos, getArrowCenter(edge.getPoints()), getEdgeEndYAxisAngle(edge.getPoints()));
     }
 
     private void drawEdgeInfo(XMLStreamWriter writer, List<EdgeInfo> edgeInfos, Point infoCenter, double infoAngle) throws XMLStreamException {
@@ -531,12 +343,6 @@ public class SvgWriter {
         Point point1 = line.get(line.size() - 1);
         Point point0 = line.get(line.size() - 2);
         return Math.atan2(point1.getX() - point0.getX(), -(point1.getY() - point0.getY()));
-    }
-
-    private double getEdgeStartAngle(List<Point> line) {
-        Point point1 = line.get(1);
-        Point point0 = line.get(0);
-        return Math.atan2(point1.getY() - point0.getY(), point1.getX() - point0.getX());
     }
 
     private void draw2WtWinding(XMLStreamWriter writer, List<Point> half) throws XMLStreamException {
@@ -695,9 +501,9 @@ public class SvgWriter {
 
     private double getEdgeStartAngle(Edge edge, BranchEdge.Side side) {
         if (edge instanceof ThreeWtEdge) {
-            return getEdgeStartAngle(((ThreeWtEdge) edge).getPoints());
+            return ((ThreeWtEdge) edge).getEdgeStartAngle();
         } else if (edge instanceof BranchEdge) {
-            return getEdgeStartAngle(((BranchEdge) edge).getPoints(side));
+            return ((BranchEdge) edge).getEdgeStartAngle(side);
         }
         return 0;
     }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -201,7 +201,7 @@ public class SvgWriter {
         }
     }
 
-    private void loopEdgesLayout(Graph graph, Node node, Set<BranchEdge> loopEdges) {
+    private void loopEdgesLayout(Graph graph, Node node, List<BranchEdge> loopEdges) {
         List<Double> angles = computeLoopAngles(graph, loopEdges, node);
 
         int i = 0;
@@ -223,7 +223,7 @@ public class SvgWriter {
         }
     }
 
-    private List<Double> computeLoopAngles(Graph graph, Set<BranchEdge> loopEdges, Node node) {
+    private List<Double> computeLoopAngles(Graph graph, List<BranchEdge> loopEdges, Node node) {
         int nbLoops = loopEdges.size();
 
         List<Double> anglesOtherEdges = graph.getBranchEdgeStream(node)

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -109,7 +109,7 @@ public class SvgWriter {
     private void computeBranchEdgesCoordinates(Graph graph) {
         graph.getNonMultiBranchEdgesStream().forEach(edge -> computeSingleBranchEdgeCoordinates(graph, edge));
         graph.getMultiBranchEdgesStream().forEach(edges -> computeMultiBranchEdgesCoordinates(graph, edges));
-        graph.getLoopBranchEdgesStream().forEach(edges -> loopEdgesLayout(graph, edges));
+        graph.getLoopBranchEdgesMap().forEach((node, edges) -> loopEdgesLayout(graph, node, edges));
         graph.getThreeWtEdgesStream().forEach(edge -> computeThreeWtEdgeCoordinates(graph, edge));
         graph.getTextEdgesMap().forEach((edge, nodes) -> computeTextEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
     }
@@ -201,10 +201,7 @@ public class SvgWriter {
         }
     }
 
-    private void loopEdgesLayout(Graph graph, Set<BranchEdge> loopEdges) {
-        BranchEdge firstLoop = loopEdges.iterator().next();
-        Node node = graph.getNode1(firstLoop);
-
+    private void loopEdgesLayout(Graph graph, Node node, Set<BranchEdge> loopEdges) {
         List<Double> angles = computeLoopAngles(graph, loopEdges, node);
 
         int i = 0;

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -1,4 +1,4 @@
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -1,4 +1,4 @@
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}

--- a/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -30,11 +30,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class NominalVoltageStyleTest extends AbstractTest {
 
+    private SvgParameters svgParameters;
+
     private LayoutParameters layoutParameters;
 
     @BeforeEach
     public void setup() {
         this.layoutParameters = new LayoutParameters();
+        this.svgParameters = new SvgParameters()
+                .setInsertName(true)
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800);
     }
 
     @Override
@@ -44,10 +50,7 @@ class NominalVoltageStyleTest extends AbstractTest {
 
     @Override
     protected SvgParameters getSvgParameters() {
-        return new SvgParameters()
-                .setInsertName(true)
-                .setSvgWidthAndHeightAdded(true)
-                .setFixedWidth(800);
+        return svgParameters;
     }
 
     @Override
@@ -100,6 +103,20 @@ class NominalVoltageStyleTest extends AbstractTest {
     void testEurope() {
         Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
         assertEquals(toString("/simple-eu.svg"), generateSvgString(network, "/simple-eu.svg"));
+    }
+
+    @Test
+    void testEuropeLoopAperture80() {
+        Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
+        svgParameters.setLoopEdgesAperture(80);
+        assertEquals(toString("/simple-eu-loop80.svg"), generateSvgString(network, "/simple-eu-loop80.svg"));
+    }
+
+    @Test
+    void testEuropeLoopAperture100() {
+        Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
+        svgParameters.setLoopEdgesAperture(100);
+        assertEquals(toString("/simple-eu-loop100.svg"), generateSvgString(network, "/simple-eu-loop100.svg"));
     }
 
     @Test

--- a/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -102,6 +102,7 @@ class NominalVoltageStyleTest extends AbstractTest {
     @Test
     void testEurope() {
         Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
+        LoadFlow.run(network);
         assertEquals(toString("/simple-eu.svg"), generateSvgString(network, "/simple-eu.svg"));
     }
 

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="680.96" viewBox="-3.99 -4.23 11.54 9.82" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="770.68" viewBox="-5.78 -4.98 10.39 10.01" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="605.61" viewBox="-42.29 -28.50 77.81 58.90" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="986.50" viewBox="-15.40 -16.21 29.52 36.40" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}
@@ -1572,7 +1572,6 @@
         </g>
         <g id="91" title="T64-61-1">
             <g class="nad-vl120to180-1">
-                <polyline/>
                 <circle cx="-6.09" cy="-12.14" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
@@ -1640,7 +1639,6 @@
         </g>
         <g id="96" title="T65-66-1">
             <g class="nad-vl120to180-1">
-                <polyline/>
                 <circle cx="-9.46" cy="5.16" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
@@ -1687,7 +1685,6 @@
         </g>
         <g id="102" title="T68-69-1">
             <g class="nad-vl120to180-1">
-                <polyline/>
                 <circle cx="1.60" cy="14.46" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="773.52" viewBox="-8.76 -9.98 22.20 21.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="773.52" viewBox="-8.76 -9.98 22.20 21.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="1008.31" viewBox="-13.41 -15.92 27.08 34.13" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="969.43" viewBox="-13.03 -15.46 26.51 32.13" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="669.87" viewBox="-14.96 -13.42 33.95 28.43" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="925.00" viewBox="-19.69 -24.02 45.09 52.14" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; ; stroke-dasharray: .1,.1}

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="394.38" viewBox="-7.73 -4.20 17.06 8.41" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, black); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: grey; stroke-width: 0.02; stroke-dasharray: .1,.1}

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -112,14 +112,14 @@
                 <path d="M-5.01,-2.04 L-5.54,-1.98 C-5.93,-1.92 -5.90,-2.60 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-5.54,-1.98)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(82.56)">
+                        <g transform="rotate(-97.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(82.56)">
+                        <g transform="rotate(-97.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -131,14 +131,14 @@
                 <path d="M-4.72,-2.65 L-4.71,-2.88 C-4.69,-3.28 -5.36,-3.19 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-4.71,-2.88)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-177.44)">
+                        <g transform="rotate(2.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-177.44)">
+                        <g transform="rotate(2.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -152,14 +152,14 @@
                 <path d="M-4.18,-2.15 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.86,-1.27"/>
                 <g class="nad-edge-infos" transform="translate(-3.95,-2.18)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-97.44)">
+                        <g transform="rotate(82.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-97.44)">
+                        <g transform="rotate(82.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -172,14 +172,14 @@
                 <path d="M-4.75,-1.81 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -3.86,-1.27"/>
                 <g class="nad-edge-infos" transform="translate(-4.78,-1.28)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(2.56)">
+                        <g transform="rotate(-177.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(2.56)">
+                        <g transform="rotate(-177.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -514,14 +514,14 @@
                 <path d="M0.63,7.37 L1.15,7.48 C1.54,7.56 1.28,8.18 0.93,8.37"/>
                 <g class="nad-edge-infos" transform="translate(1.15,7.48)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-78.28)">
+                        <g transform="rotate(101.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-78.28)">
+                        <g transform="rotate(101.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -533,14 +533,14 @@
                 <path d="M0.15,7.85 L0.07,8.06 C-0.08,8.43 0.58,8.56 0.93,8.37"/>
                 <g class="nad-edge-infos" transform="translate(0.07,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(21.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(21.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -594,14 +594,14 @@
                 <path d="M-0.19,7.20 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.20,6.26"/>
                 <g class="nad-edge-infos" transform="translate(-0.42,7.15)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-258.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-258.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -614,14 +614,14 @@
                 <path d="M0.46,7.07 L0.66,6.57 C0.81,6.20 0.15,6.07 -0.20,6.26"/>
                 <g class="nad-edge-infos" transform="translate(0.66,6.57)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-158.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-158.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -35,7 +35,7 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-4.74,-2.08)" id="0" class="nad-vl300to500" title="BBE1AA1">
             <circle r="0.30" id="1"/>
-            <path d="M-0.132,-0.585 A0.600,0.600 80.451 0 1 0.555,-0.227 L0.267,-0.136 A0.300,0.300 -70.901 0 0 -0.041,-0.297 Z M0.585,-0.132 A0.600,0.600 138.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -128.646 0 0 0.297,-0.041 Z M-0.425,0.424 A0.600,0.600 112.706 0 1 -0.227,-0.555 L-0.136,-0.267 A0.300,0.300 -103.157 0 0 -0.229,0.193 Z " id="2"/>
+            <path d="M0.077,-0.595 A0.600,0.600 70.451 0 1 0.586,-0.127 L0.287,-0.088 A0.300,0.300 -60.901 0 0 0.063,-0.293 Z M0.599,-0.028 A0.600,0.600 128.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -118.646 0 0 0.300,0.011 Z M-0.425,0.424 A0.600,0.600 132.706 0 1 -0.023,-0.600 L-0.037,-0.298 A0.300,0.300 -123.157 0 0 -0.229,0.193 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
             <circle r="0.60" id="4"/>
@@ -51,7 +51,7 @@
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
-            <path d="M-0.392,-0.455 A0.600,0.600 67.675 0 1 0.272,-0.535 L0.113,-0.278 A0.300,0.300 -58.126 0 0 -0.176,-0.243 Z M0.357,-0.482 A0.600,0.600 80.451 0 1 0.535,0.272 L0.278,0.113 A0.300,0.300 -70.901 0 0 0.198,-0.225 Z M0.482,0.357 A0.600,0.600 183.226 1 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -173.677 0 0 0.225,0.198 Z " id="13"/>
+            <path d="M-0.575,-0.170 A0.600,0.600 23.226 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -13.677 0 0 -0.280,-0.109 Z M-0.392,-0.455 A0.600,0.600 237.675 1 1 -0.175,0.574 L-0.063,0.293 A0.300,0.300 -228.126 1 0 -0.176,-0.243 Z M-0.268,0.537 A0.600,0.600 70.451 0 1 -0.596,-0.073 L-0.300,-0.011 A0.300,0.300 -60.901 0 0 -0.156,0.256 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
             <circle r="0.60" id="15"/>
@@ -109,84 +109,84 @@
         </g>
         <g id="23" class="nad-vl300to500" title="BBE1AA1  BBE3AA1  1">
             <g>
-                <path d="M-4.48,-2.16 L-3.98,-2.32 C-3.60,-2.44 -3.48,-2.21 -3.57,-1.82"/>
-                <g class="nad-edge-infos" transform="translate(-3.98,-2.32)">
+                <path d="M-4.47,-2.11 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.86,-1.27"/>
+                <g class="nad-edge-infos" transform="translate(-3.95,-2.18)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-107.44)">
+                        <g transform="rotate(-97.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-107.44)">
+                        <g transform="rotate(-97.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M-4.32,-1.69 L-4.15,-1.54 C-3.86,-1.27 -3.66,-1.43 -3.57,-1.82"/>
-                <g class="nad-edge-infos" transform="translate(-4.15,-1.54)">
+                <path d="M-4.77,-1.51 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -3.86,-1.27"/>
+                <g class="nad-edge-infos" transform="translate(-4.78,-1.28)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(2.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(2.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="24" title="BBE1AA1  BBE3AA1  2">
             <g class="nad-vl300to500">
-                <path d="M-5.30,-2.20 L-5.52,-2.25 C-5.91,-2.34 -5.90,-2.60 -5.63,-2.89"/>
-                <g class="nad-edge-infos" transform="translate(-5.52,-2.25)">
+                <path d="M-5.31,-2.01 L-5.54,-1.98 C-5.93,-1.92 -5.90,-2.60 -5.63,-2.89"/>
+                <g class="nad-edge-infos" transform="translate(-5.54,-1.98)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-257.44)">
+                        <g transform="rotate(82.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-257.44)">
+                        <g transform="rotate(82.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.61" cy="-2.79" r="0.20"/>
+                <circle cx="-5.62" cy="-2.79" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-4.82,-2.34 L-4.98,-2.84 C-5.10,-3.22 -5.36,-3.19 -5.63,-2.89"/>
-                <g class="nad-edge-infos" transform="translate(-4.98,-2.84)">
+                <path d="M-4.73,-2.35 L-4.71,-2.88 C-4.69,-3.28 -5.36,-3.19 -5.63,-2.89"/>
+                <g class="nad-edge-infos" transform="translate(-4.71,-2.88)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-177.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-177.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.53" cy="-2.88" r="0.20"/>
+                <circle cx="-5.53" cy="-2.89" r="0.20"/>
             </g>
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
@@ -511,40 +511,40 @@
         </g>
         <g id="33" class="nad-vl300to500" title="FFR1AA1  FFR2AA1  1">
             <g>
-                <path d="M0.59,7.46 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(1.04,7.74)">
+                <path d="M0.10,7.26 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.20,6.26"/>
+                <g class="nad-edge-infos" transform="translate(-0.42,7.15)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-258.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-258.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M0.35,7.89 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(0.34,8.12)">
+                <path d="M0.57,6.79 L0.66,6.57 C0.81,6.20 0.15,6.07 -0.20,6.26"/>
+                <g class="nad-edge-infos" transform="translate(0.66,6.57)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
@@ -591,44 +591,44 @@
         </g>
         <g id="35" title="FFR1AA1  FFR2AA1  2">
             <g class="nad-vl300to500">
-                <path d="M0.09,6.81 L-0.02,6.61 C-0.20,6.26 0.00,6.11 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(-0.02,6.61)">
+                <path d="M0.92,7.43 L1.15,7.48 C1.54,7.56 1.28,8.18 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(1.15,7.48)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.34" cy="6.19" r="0.20"/>
+                <circle cx="0.96" cy="8.28" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.51,7.09 L0.78,6.64 C0.99,6.30 0.80,6.13 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(0.78,6.64)">
+                <path d="M0.26,7.57 L0.07,8.06 C-0.08,8.43 0.58,8.56 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(0.07,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.46" cy="6.20" r="0.20"/>
+                <circle cx="0.84" cy="8.34" r="0.20"/>
             </g>
         </g>
         <g id="36" class="nad-vl300to500" title="FFR2AA1  FFR3AA1  1">

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -35,7 +35,7 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-4.74,-2.08)" id="0" class="nad-vl300to500" title="BBE1AA1">
             <circle r="0.30" id="1"/>
-            <path d="M0.077,-0.595 A0.600,0.600 70.451 0 1 0.586,-0.127 L0.287,-0.088 A0.300,0.300 -60.901 0 0 0.063,-0.293 Z M0.599,-0.028 A0.600,0.600 128.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -118.646 0 0 0.300,0.011 Z M-0.425,0.424 A0.600,0.600 132.706 0 1 -0.023,-0.600 L-0.037,-0.298 A0.300,0.300 -123.157 0 0 -0.229,0.193 Z " id="2"/>
+            <path d="M-0.077,0.595 A0.600,0.600 28.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -18.646 0 0 -0.063,0.293 Z M-0.425,0.424 A0.600,0.600 32.706 0 1 -0.586,0.127 L-0.287,0.088 A0.300,0.300 -23.157 0 0 -0.229,0.193 Z M-0.599,0.028 A0.600,0.600 270.451 1 1 0.023,0.600 L0.037,0.298 A0.300,0.300 -260.901 1 0 -0.300,-0.011 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
             <circle r="0.60" id="4"/>
@@ -51,7 +51,7 @@
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
-            <path d="M-0.575,-0.170 A0.600,0.600 23.226 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -13.677 0 0 -0.280,-0.109 Z M-0.392,-0.455 A0.600,0.600 237.675 1 1 -0.175,0.574 L-0.063,0.293 A0.300,0.300 -228.126 1 0 -0.176,-0.243 Z M-0.268,0.537 A0.600,0.600 70.451 0 1 -0.596,-0.073 L-0.300,-0.011 A0.300,0.300 -60.901 0 0 -0.156,0.256 Z " id="13"/>
+            <path d="M-0.392,-0.455 A0.600,0.600 57.675 0 1 0.175,-0.574 L0.063,-0.293 A0.300,0.300 -48.126 0 0 -0.176,-0.243 Z M0.268,-0.537 A0.600,0.600 70.451 0 1 0.596,0.073 L0.300,0.011 A0.300,0.300 -60.901 0 0 0.156,-0.256 Z M0.575,0.170 A0.600,0.600 203.226 1 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -193.677 1 0 0.280,0.109 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
             <circle r="0.60" id="15"/>
@@ -109,47 +109,7 @@
         </g>
         <g id="23" class="nad-vl300to500" title="BBE1AA1  BBE3AA1  1">
             <g>
-                <path d="M-4.47,-2.11 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.86,-1.27"/>
-                <g class="nad-edge-infos" transform="translate(-3.95,-2.18)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-97.44)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-97.44)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                </g>
-            </g>
-            <g>
-                <path d="M-4.77,-1.51 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -3.86,-1.27"/>
-                <g class="nad-edge-infos" transform="translate(-4.78,-1.28)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(2.56)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(2.56)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="24" title="BBE1AA1  BBE3AA1  2">
-            <g class="nad-vl300to500">
-                <path d="M-5.31,-2.01 L-5.54,-1.98 C-5.93,-1.92 -5.90,-2.60 -5.63,-2.89"/>
+                <path d="M-5.01,-2.04 L-5.54,-1.98 C-5.93,-1.92 -5.90,-2.60 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-5.54,-1.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.56)">
@@ -166,10 +126,9 @@
                         <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.62" cy="-2.79" r="0.20"/>
             </g>
-            <g class="nad-vl300to500">
-                <path d="M-4.73,-2.35 L-4.71,-2.88 C-4.69,-3.28 -5.36,-3.19 -5.63,-2.89"/>
+            <g>
+                <path d="M-4.72,-2.65 L-4.71,-2.88 C-4.69,-3.28 -5.36,-3.19 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-4.71,-2.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.44)">
@@ -186,7 +145,48 @@
                         <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.53" cy="-2.89" r="0.20"/>
+            </g>
+        </g>
+        <g id="24" title="BBE1AA1  BBE3AA1  2">
+            <g class="nad-vl300to500">
+                <path d="M-4.18,-2.15 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.86,-1.27"/>
+                <g class="nad-edge-infos" transform="translate(-3.95,-2.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-97.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-97.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
+                <circle cx="-3.87" cy="-1.37" r="0.20"/>
+            </g>
+            <g class="nad-vl300to500">
+                <path d="M-4.75,-1.81 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -3.86,-1.27"/>
+                <g class="nad-edge-infos" transform="translate(-4.78,-1.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(2.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(2.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                    </g>
+                </g>
+                <circle cx="-3.96" cy="-1.27" r="0.20"/>
             </g>
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
@@ -511,17 +511,17 @@
         </g>
         <g id="33" class="nad-vl300to500" title="FFR1AA1  FFR2AA1  1">
             <g>
-                <path d="M0.10,7.26 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.20,6.26"/>
-                <g class="nad-edge-infos" transform="translate(-0.42,7.15)">
+                <path d="M0.63,7.37 L1.15,7.48 C1.54,7.56 1.28,8.18 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(1.15,7.48)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-258.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-258.28)">
+                        <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -530,17 +530,17 @@
                 </g>
             </g>
             <g>
-                <path d="M0.57,6.79 L0.66,6.57 C0.81,6.20 0.15,6.07 -0.20,6.26"/>
-                <g class="nad-edge-infos" transform="translate(0.66,6.57)">
+                <path d="M0.15,7.85 L0.07,8.06 C-0.08,8.43 0.58,8.56 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(0.07,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-158.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-158.28)">
+                        <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -591,44 +591,44 @@
         </g>
         <g id="35" title="FFR1AA1  FFR2AA1  2">
             <g class="nad-vl300to500">
-                <path d="M0.92,7.43 L1.15,7.48 C1.54,7.56 1.28,8.18 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(1.15,7.48)">
+                <path d="M-0.19,7.20 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.20,6.26"/>
+                <g class="nad-edge-infos" transform="translate(-0.42,7.15)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-78.28)">
+                        <g transform="rotate(-258.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-78.28)">
+                        <g transform="rotate(-258.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.96" cy="8.28" r="0.20"/>
+                <circle cx="-0.23" cy="6.36" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.26,7.57 L0.07,8.06 C-0.08,8.43 0.58,8.56 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(0.07,8.06)">
+                <path d="M0.46,7.07 L0.66,6.57 C0.81,6.20 0.15,6.07 -0.20,6.26"/>
+                <g class="nad-edge-infos" transform="translate(0.66,6.57)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(21.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(21.72)">
+                        <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.84" cy="8.34" r="0.20"/>
+                <circle cx="-0.11" cy="6.29" r="0.20"/>
             </g>
         </g>
         <g id="36" class="nad-vl300to500" title="FFR2AA1  FFR3AA1  1">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -51,7 +51,7 @@
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
-            <path d="M-0.392,-0.455 A0.600,0.600 180.084 1 1 0.391,0.455 L0.214,0.211 A0.300,0.300 -170.534 0 0 -0.176,-0.243 Z M0.165,0.577 A0.600,0.600 145.634 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -136.085 0 0 0.058,0.294 Z " id="13"/>
+            <path d="M-0.392,-0.455 A0.600,0.600 100.084 0 1 0.516,-0.306 L0.244,-0.174 A0.300,0.300 -90.534 0 0 -0.176,-0.243 Z M0.560,-0.216 A0.600,0.600 165.634 0 1 -0.489,0.348 L-0.229,0.194 A0.300,0.300 -156.085 0 0 0.288,-0.084 Z M-0.540,0.262 A0.600,0.600 65.634 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -56.085 0 0 -0.280,0.108 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
             <circle r="0.60" id="15"/>
@@ -511,40 +511,40 @@
         </g>
         <g id="33" class="nad-vl300to500" title="FFR1AA1  FFR2AA1  1">
             <g>
-                <path d="M0.46,7.57 L0.65,8.06 C0.79,8.44 0.34,8.58 -0.03,8.45"/>
-                <g class="nad-edge-infos" transform="translate(0.65,8.06)">
+                <path d="M0.61,7.20 L1.08,6.97 C1.44,6.79 1.63,7.22 1.53,7.61"/>
+                <g class="nad-edge-infos" transform="translate(1.08,6.97)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-20.69)">
+                        <g transform="rotate(-115.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-20.69)">
+                        <g transform="rotate(-115.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M-0.13,7.61 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.03,8.45"/>
-                <g class="nad-edge-infos" transform="translate(-0.32,7.72)">
+                <path d="M0.70,7.78 L0.83,7.96 C1.07,8.29 1.43,8.00 1.53,7.61"/>
+                <g class="nad-edge-infos" transform="translate(0.83,7.96)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(59.31)">
+                        <g transform="rotate(-35.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(59.31)">
+                        <g transform="rotate(-35.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
@@ -591,44 +591,44 @@
         </g>
         <g id="35" title="FFR1AA1  FFR2AA1  2">
             <g class="nad-vl300to500">
-                <path d="M0.88,7.07 L1.08,6.97 C1.44,6.79 1.63,7.22 1.53,7.61"/>
-                <g class="nad-edge-infos" transform="translate(1.08,6.97)">
+                <path d="M0.57,7.85 L0.65,8.06 C0.79,8.44 0.34,8.58 -0.03,8.45"/>
+                <g class="nad-edge-infos" transform="translate(0.65,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-115.87)">
+                        <g transform="rotate(-20.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-115.87)">
+                        <g transform="rotate(-20.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="1.47" cy="7.53" r="0.20"/>
+                <circle cx="0.05" cy="8.40" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.52,7.54 L0.83,7.96 C1.07,8.29 1.43,8.00 1.53,7.61"/>
-                <g class="nad-edge-infos" transform="translate(0.83,7.96)">
+                <path d="M0.13,7.45 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.03,8.45"/>
+                <g class="nad-edge-infos" transform="translate(-0.32,7.72)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-35.87)">
+                        <g transform="rotate(59.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-35.87)">
+                        <g transform="rotate(59.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="1.44" cy="7.65" r="0.20"/>
+                <circle cx="-0.07" cy="8.36" r="0.20"/>
             </g>
         </g>
         <g id="36" class="nad-vl300to500" title="FFR2AA1  FFR3AA1  1">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -35,7 +35,7 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-4.74,-2.08)" id="0" class="nad-vl300to500" title="BBE1AA1">
             <circle r="0.30" id="1"/>
-            <path d="M-0.132,-0.585 A0.600,0.600 80.451 0 1 0.555,-0.227 L0.267,-0.136 A0.300,0.300 -70.901 0 0 -0.041,-0.297 Z M0.585,-0.132 A0.600,0.600 138.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -128.646 0 0 0.297,-0.041 Z M-0.425,0.424 A0.600,0.600 112.706 0 1 -0.227,-0.555 L-0.136,-0.267 A0.300,0.300 -103.157 0 0 -0.229,0.193 Z " id="2"/>
+            <path d="M-0.028,-0.599 A0.600,0.600 60.451 0 1 0.508,-0.320 L0.240,-0.181 A0.300,0.300 -50.901 0 0 0.011,-0.300 Z M0.554,-0.231 A0.600,0.600 148.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -138.646 0 0 0.285,-0.092 Z M-0.425,0.424 A0.600,0.600 122.706 0 1 -0.127,-0.586 L-0.088,-0.287 A0.300,0.300 -113.157 0 0 -0.229,0.193 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
             <circle r="0.60" id="4"/>
@@ -51,7 +51,7 @@
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
-            <path d="M-0.392,-0.455 A0.600,0.600 67.675 0 1 0.272,-0.535 L0.113,-0.278 A0.300,0.300 -58.126 0 0 -0.176,-0.243 Z M0.357,-0.482 A0.600,0.600 80.451 0 1 0.535,0.272 L0.278,0.113 A0.300,0.300 -70.901 0 0 0.198,-0.225 Z M0.482,0.357 A0.600,0.600 183.226 1 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -173.677 0 0 0.225,0.198 Z " id="13"/>
+            <path d="M-0.392,-0.455 A0.600,0.600 180.084 1 1 0.391,0.455 L0.214,0.211 A0.300,0.300 -170.534 0 0 -0.176,-0.243 Z M0.165,0.577 A0.600,0.600 145.634 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -136.085 0 0 0.058,0.294 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
             <circle r="0.60" id="15"/>
@@ -109,84 +109,84 @@
         </g>
         <g id="23" class="nad-vl300to500" title="BBE1AA1  BBE3AA1  1">
             <g>
-                <path d="M-4.48,-2.16 L-3.98,-2.32 C-3.60,-2.44 -3.48,-2.21 -3.57,-1.82"/>
-                <g class="nad-edge-infos" transform="translate(-3.98,-2.32)">
+                <path d="M-4.50,-2.20 L-4.03,-2.45 C-3.68,-2.63 -3.48,-2.21 -3.57,-1.82"/>
+                <g class="nad-edge-infos" transform="translate(-4.03,-2.45)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-107.44)">
+                        <g transform="rotate(-117.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(62.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-107.44)">
+                        <g transform="rotate(-117.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(62.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M-4.32,-1.69 L-4.15,-1.54 C-3.86,-1.27 -3.66,-1.43 -3.57,-1.82"/>
-                <g class="nad-edge-infos" transform="translate(-4.15,-1.54)">
+                <path d="M-4.40,-1.63 L-4.26,-1.44 C-4.01,-1.13 -3.66,-1.43 -3.57,-1.82"/>
+                <g class="nad-edge-infos" transform="translate(-4.26,-1.44)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(-37.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(-37.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="24" title="BBE1AA1  BBE3AA1  2">
             <g class="nad-vl300to500">
-                <path d="M-5.30,-2.20 L-5.52,-2.25 C-5.91,-2.34 -5.90,-2.60 -5.63,-2.89"/>
-                <g class="nad-edge-infos" transform="translate(-5.52,-2.25)">
+                <path d="M-5.31,-2.10 L-5.54,-2.12 C-5.94,-2.13 -5.90,-2.60 -5.63,-2.89"/>
+                <g class="nad-edge-infos" transform="translate(-5.54,-2.12)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-257.44)">
+                        <g transform="rotate(-267.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-257.44)">
+                        <g transform="rotate(-267.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.61" cy="-2.79" r="0.20"/>
+                <circle cx="-5.62" cy="-2.79" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-4.82,-2.34 L-4.98,-2.84 C-5.10,-3.22 -5.36,-3.19 -5.63,-2.89"/>
-                <g class="nad-edge-infos" transform="translate(-4.98,-2.84)">
+                <path d="M-4.78,-2.35 L-4.85,-2.87 C-4.90,-3.27 -5.36,-3.19 -5.63,-2.89"/>
+                <g class="nad-edge-infos" transform="translate(-4.85,-2.87)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-187.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-187.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="-5.53" cy="-2.88" r="0.20"/>
+                <circle cx="-5.53" cy="-2.89" r="0.20"/>
             </g>
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
@@ -511,40 +511,40 @@
         </g>
         <g id="33" class="nad-vl300to500" title="FFR1AA1  FFR2AA1  1">
             <g>
-                <path d="M0.59,7.46 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(1.04,7.74)">
+                <path d="M0.46,7.57 L0.65,8.06 C0.79,8.44 0.34,8.58 -0.03,8.45"/>
+                <g class="nad-edge-infos" transform="translate(0.65,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-20.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-20.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M0.35,7.89 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(0.34,8.12)">
+                <path d="M-0.13,7.61 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.03,8.45"/>
+                <g class="nad-edge-infos" transform="translate(-0.32,7.72)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(59.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(59.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
@@ -591,44 +591,44 @@
         </g>
         <g id="35" title="FFR1AA1  FFR2AA1  2">
             <g class="nad-vl300to500">
-                <path d="M0.09,6.81 L-0.02,6.61 C-0.20,6.26 0.00,6.11 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(-0.02,6.61)">
+                <path d="M0.88,7.07 L1.08,6.97 C1.44,6.79 1.63,7.22 1.53,7.61"/>
+                <g class="nad-edge-infos" transform="translate(1.08,6.97)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-115.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-115.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.34" cy="6.19" r="0.20"/>
+                <circle cx="1.47" cy="7.53" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.51,7.09 L0.78,6.64 C0.99,6.30 0.80,6.13 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(0.78,6.64)">
+                <path d="M0.52,7.54 L0.83,7.96 C1.07,8.29 1.43,8.00 1.53,7.61"/>
+                <g class="nad-edge-infos" transform="translate(0.83,7.96)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(-35.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(-35.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.46" cy="6.20" r="0.20"/>
+                <circle cx="1.44" cy="7.65" r="0.20"/>
             </g>
         </g>
         <g id="36" class="nad-vl300to500" title="FFR2AA1  FFR3AA1  1">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -112,14 +112,14 @@
                 <path d="M-4.50,-2.20 L-4.03,-2.45 C-3.68,-2.63 -3.48,-2.21 -3.57,-1.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.03,-2.45)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-117.44)">
+                        <g transform="rotate(62.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(62.56)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-117.44)">
+                        <g transform="rotate(62.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -131,14 +131,14 @@
                 <path d="M-4.40,-1.63 L-4.26,-1.44 C-4.01,-1.13 -3.66,-1.43 -3.57,-1.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.26,-1.44)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-37.44)">
+                        <g transform="rotate(142.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-37.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-37.44)">
+                        <g transform="rotate(142.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -152,14 +152,14 @@
                 <path d="M-5.31,-2.10 L-5.54,-2.12 C-5.94,-2.13 -5.90,-2.60 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-5.54,-2.12)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-267.44)">
+                        <g transform="rotate(-87.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-87.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-267.44)">
+                        <g transform="rotate(-87.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -172,14 +172,14 @@
                 <path d="M-4.78,-2.35 L-4.85,-2.87 C-4.90,-3.27 -5.36,-3.19 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-4.85,-2.87)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-187.44)">
+                        <g transform="rotate(-7.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-7.44)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-187.44)">
+                        <g transform="rotate(-7.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -514,14 +514,14 @@
                 <path d="M0.61,7.20 L1.08,6.97 C1.44,6.79 1.63,7.22 1.53,7.61"/>
                 <g class="nad-edge-infos" transform="translate(1.08,6.97)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-115.87)">
+                        <g transform="rotate(64.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-115.87)">
+                        <g transform="rotate(64.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -533,14 +533,14 @@
                 <path d="M0.70,7.78 L0.83,7.96 C1.07,8.29 1.43,8.00 1.53,7.61"/>
                 <g class="nad-edge-infos" transform="translate(0.83,7.96)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-35.87)">
+                        <g transform="rotate(144.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-35.87)">
+                        <g transform="rotate(144.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -594,14 +594,14 @@
                 <path d="M0.57,7.85 L0.65,8.06 C0.79,8.44 0.34,8.58 -0.03,8.45"/>
                 <g class="nad-edge-infos" transform="translate(0.65,8.06)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-20.69)">
+                        <g transform="rotate(159.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-20.69)">
+                        <g transform="rotate(159.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
@@ -614,14 +614,14 @@
                 <path d="M0.13,7.45 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.03,8.45"/>
                 <g class="nad-edge-infos" transform="translate(-0.32,7.72)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(59.31)">
+                        <g transform="rotate(-120.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
                         <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(59.31)">
+                        <g transform="rotate(-120.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -51,7 +51,7 @@
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
-            <path d="M-0.392,-0.455 A0.600,0.600 67.675 0 1 0.272,-0.535 L0.113,-0.278 A0.300,0.300 -58.126 0 0 -0.176,-0.243 Z M0.357,-0.482 A0.600,0.600 80.451 0 1 0.535,0.272 L0.278,0.113 A0.300,0.300 -70.901 0 0 0.198,-0.225 Z M0.482,0.357 A0.600,0.600 183.226 1 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -173.677 0 0 0.225,0.198 Z " id="13"/>
+            <path d="M-0.239,-0.550 A0.600,0.600 200.451 1 1 0.032,0.599 L0.041,0.297 A0.300,0.300 -190.901 1 0 -0.096,-0.284 Z M-0.068,0.596 A0.600,0.600 123.226 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -113.677 0 0 -0.059,0.294 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
             <circle r="0.60" id="15"/>
@@ -511,40 +511,40 @@
         </g>
         <g id="33" class="nad-vl300to500" title="FFR1AA1  FFR2AA1  1">
             <g>
-                <path d="M0.59,7.46 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(1.04,7.74)">
+                <path d="M0.24,7.08 L-0.02,6.61 C-0.20,6.26 0.00,6.11 0.40,6.12"/>
+                <g class="nad-edge-infos" transform="translate(-0.02,6.61)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-208.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(-208.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
             <g>
-                <path d="M0.35,7.89 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
-                <g class="nad-edge-infos" transform="translate(0.34,8.12)">
+                <path d="M0.66,6.83 L0.78,6.64 C0.99,6.30 0.80,6.13 0.40,6.12"/>
+                <g class="nad-edge-infos" transform="translate(0.78,6.64)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(-148.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(-148.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
             </g>
@@ -591,44 +591,44 @@
         </g>
         <g id="35" title="FFR1AA1  FFR2AA1  2">
             <g class="nad-vl300to500">
-                <path d="M0.09,6.81 L-0.02,6.61 C-0.20,6.26 0.00,6.11 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(-0.02,6.61)">
+                <path d="M0.85,7.62 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(1.04,7.74)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-58.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-58.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.34" cy="6.19" r="0.20"/>
+                <circle cx="0.95" cy="8.27" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.51,7.09 L0.78,6.64 C0.99,6.30 0.80,6.13 0.40,6.12"/>
-                <g class="nad-edge-infos" transform="translate(0.78,6.64)">
+                <path d="M0.36,7.59 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
+                <g class="nad-edge-infos" transform="translate(0.34,8.12)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(1.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(1.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
                     </g>
                 </g>
-                <circle cx="0.46" cy="6.20" r="0.20"/>
+                <circle cx="0.84" cy="8.33" r="0.20"/>
             </g>
         </g>
         <g id="36" class="nad-vl300to500" title="FFR2AA1  FFR3AA1  1">

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -71,19 +71,19 @@
             <g>
                 <polyline points="-4.92,-1.87 -5.26,-1.47 -5.53,0.04"/>
                 <g class="nad-edge-infos" transform="translate(-5.31,-1.17)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">-1150</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">41</text>
                     </g>
                 </g>
             </g>
@@ -95,14 +95,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">1150</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">41</text>
                     </g>
                 </g>
             </g>
@@ -111,19 +111,19 @@
             <g>
                 <path d="M-4.48,-2.16 L-3.98,-2.32 C-3.60,-2.44 -3.48,-2.21 -3.57,-1.82"/>
                 <g class="nad-edge-infos" transform="translate(-3.98,-2.32)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-107.44)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(72.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">-618</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-107.44)">
+                        <g transform="rotate(72.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">12</text>
                     </g>
                 </g>
             </g>
@@ -131,18 +131,18 @@
                 <path d="M-4.32,-1.69 L-4.15,-1.54 C-3.86,-1.27 -3.66,-1.43 -3.57,-1.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.15,-1.54)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(132.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">618</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-47.44)">
+                        <g transform="rotate(132.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">12</text>
                     </g>
                 </g>
             </g>
@@ -151,19 +151,19 @@
             <g class="nad-vl300to500">
                 <path d="M-5.30,-2.20 L-5.52,-2.25 C-5.91,-2.34 -5.90,-2.60 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-5.52,-2.25)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-257.44)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-77.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">-267</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-257.44)">
+                        <g transform="rotate(-77.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">8</text>
                     </g>
                 </g>
                 <circle cx="-5.61" cy="-2.79" r="0.20"/>
@@ -172,18 +172,18 @@
                 <path d="M-4.82,-2.34 L-4.98,-2.84 C-5.10,-3.22 -5.36,-3.19 -5.63,-2.89"/>
                 <g class="nad-edge-infos" transform="translate(-4.98,-2.84)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-17.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">267</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-197.44)">
+                        <g transform="rotate(-17.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">4</text>
                     </g>
                 </g>
                 <circle cx="-5.53" cy="-2.88" r="0.20"/>
@@ -198,33 +198,33 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">533</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">9</text>
                     </g>
                 </g>
             </g>
             <g>
                 <polyline points="-4.55,-1.54 -4.47,-1.33 -4.75,0.19"/>
                 <g class="nad-edge-infos" transform="translate(-4.53,-1.03)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">-533</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">9</text>
                     </g>
                 </g>
             </g>
@@ -233,19 +233,19 @@
             <g>
                 <polyline points="-1.90,-4.94 -3.12,-3.71"/>
                 <g class="nad-edge-infos" transform="translate(-2.11,-4.73)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">-1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">44</text>
                     </g>
                 </g>
             </g>
@@ -257,14 +257,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">44</text>
                     </g>
                 </g>
             </g>
@@ -278,33 +278,33 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">318</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">3</text>
                     </g>
                 </g>
             </g>
             <g>
                 <polyline points="-3.96,5.74 -4.63,4.29"/>
                 <g class="nad-edge-infos" transform="translate(-4.09,5.47)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">-318</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">3</text>
                     </g>
                 </g>
             </g>
@@ -313,19 +313,19 @@
             <g>
                 <polyline points="6.67,2.33 5.78,1.37"/>
                 <g class="nad-edge-infos" transform="translate(6.46,2.11)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">-394</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">5</text>
                     </g>
                 </g>
             </g>
@@ -337,14 +337,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">394</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">5</text>
                     </g>
                 </g>
             </g>
@@ -353,19 +353,19 @@
             <g>
                 <polyline points="6.54,2.99 5.40,3.55"/>
                 <g class="nad-edge-infos" transform="translate(6.28,3.13)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">-606</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">11</text>
                     </g>
                 </g>
             </g>
@@ -377,14 +377,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">606</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">11</text>
                     </g>
                 </g>
             </g>
@@ -393,19 +393,19 @@
             <g>
                 <polyline points="4.40,0.57 4.13,2.19"/>
                 <g class="nad-edge-infos" transform="translate(4.35,0.86)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">-212</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">1</text>
                     </g>
                 </g>
             </g>
@@ -417,14 +417,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">212</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">1</text>
                     </g>
                 </g>
             </g>
@@ -433,19 +433,19 @@
             <g>
                 <polyline points="4.27,-0.51 3.51,-2.21"/>
                 <g class="nad-edge-infos" transform="translate(4.15,-0.79)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">-1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">44</text>
                     </g>
                 </g>
             </g>
@@ -457,14 +457,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">44</text>
                     </g>
                 </g>
             </g>
@@ -478,33 +478,33 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">1317</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">54</text>
                     </g>
                 </g>
             </g>
             <g>
                 <polyline points="3.32,4.74 2.06,5.84"/>
                 <g class="nad-edge-infos" transform="translate(3.09,4.94)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">-1317</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">54</text>
                     </g>
                 </g>
             </g>
@@ -514,37 +514,37 @@
                 <path d="M0.24,7.08 L-0.02,6.61 C-0.20,6.26 0.00,6.11 0.40,6.12"/>
                 <g class="nad-edge-infos" transform="translate(-0.02,6.61)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-28.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">1523</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-208.28)">
+                        <g transform="rotate(-28.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">73</text>
                     </g>
                 </g>
             </g>
             <g>
                 <path d="M0.66,6.83 L0.78,6.64 C0.99,6.30 0.80,6.13 0.40,6.12"/>
                 <g class="nad-edge-infos" transform="translate(0.78,6.64)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-148.28)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(31.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">-1523</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-148.28)">
+                        <g transform="rotate(31.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">73</text>
                     </g>
                 </g>
             </g>
@@ -553,19 +553,19 @@
             <g>
                 <polyline points="0.17,7.13 -0.21,6.76 -1.58,6.40"/>
                 <g class="nad-edge-infos" transform="translate(-0.50,6.68)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">-148</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1</text>
                     </g>
                 </g>
             </g>
@@ -577,14 +577,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">148</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1</text>
                     </g>
                 </g>
             </g>
@@ -594,18 +594,18 @@
                 <path d="M0.85,7.62 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
                 <g class="nad-edge-infos" transform="translate(1.04,7.74)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(121.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">376</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-58.28)">
+                        <g transform="rotate(121.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">4</text>
                     </g>
                 </g>
                 <circle cx="0.95" cy="8.27" r="0.20"/>
@@ -613,19 +613,19 @@
             <g class="nad-vl300to500">
                 <path d="M0.36,7.59 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
                 <g class="nad-edge-infos" transform="translate(0.34,8.12)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(1.72)">
+                    <g class="nad-active nad-state-in">
+                        <g transform="rotate(-178.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">-376</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(1.72)">
+                        <g transform="rotate(-178.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">9</text>
                     </g>
                 </g>
                 <circle cx="0.84" cy="8.33" r="0.20"/>
@@ -635,19 +635,19 @@
             <g>
                 <polyline points="-0.19,7.47 -0.41,7.53 -1.78,7.18"/>
                 <g class="nad-edge-infos" transform="translate(-0.70,7.46)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">-1670</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">87</text>
                     </g>
                 </g>
             </g>
@@ -659,14 +659,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1670</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">87</text>
                     </g>
                 </g>
             </g>
@@ -675,12 +675,12 @@
             <g>
                 <polyline points="0.82,-7.63 -0.13,-6.69"/>
                 <g class="nad-edge-infos" transform="translate(0.61,-7.42)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">-61</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.58)">
@@ -699,7 +699,7 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">61</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.42)">
@@ -720,33 +720,33 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">561</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">10</text>
                     </g>
                 </g>
             </g>
             <g>
                 <polyline points="2.33,-4.96 1.88,-6.23"/>
                 <g class="nad-edge-infos" transform="translate(2.23,-5.24)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">-561</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">10</text>
                     </g>
                 </g>
             </g>
@@ -760,33 +760,33 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">622</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">12</text>
                     </g>
                 </g>
             </g>
             <g>
                 <polyline points="1.96,-4.55 0.51,-4.88"/>
                 <g class="nad-edge-infos" transform="translate(1.67,-4.62)">
-                    <g class="nad-active nad-state-out">
+                    <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">-622</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">12</text>
                     </g>
                 </g>
             </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
Yes fixes #28 

**What kind of change does this PR introduce?**
Feature / bug fix

**Does this PR introduce a breaking change or deprecate an API?** Yes
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
Loops are placed between non-loop edges if enough place, one in each interval if possible. If not the circle is divided in nbLoops part, starting in the middle of the largest interval. Loop aperture can be changed in `SvgParameters`. See for instance the 3 different cases in the unit tests:

* Loop aperture = 60°, enough place to put each loop in a separated interval:
![screenshot](https://user-images.githubusercontent.com/66690739/151567832-3bc29241-f3d8-4687-830d-9653d634bf29.png)

* Loop aperture = 80°, not enough place to put loops in separated intervals, but enough place in the largest interval to put them all:
![screenshot](https://user-images.githubusercontent.com/66690739/151567624-5f19f490-da38-4e82-87a7-9bad6541d7ab.png)

* Loop aperture = 100°, not enough place in the intervals, therefore dividing the circle in 2, starting in the middle of the largest interval:
![screenshot](https://user-images.githubusercontent.com/66690739/151567151-ba239ad4-d6c0-46ff-930e-f7491185fc83.png)


