### PR TITLE
Smaller node for single-bus voltage level

### DIFF
--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -23,7 +23,7 @@ public class SvgParameters {
     private double arrowShift = 0.3;
     private double arrowLabelShift = 0.12;
     private double converterStationWidth = 0.6;
-    private double voltageLevelCircleRadius = 0.6;
+    private double voltageLevelCircleRadius = 0.3;
     private double fictitiousVoltageLevelCircleRadius = 0.15;
     private double transformerCircleRadius = 0.2;
     private double nodeHollowWidth = 0.1;

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -665,6 +665,10 @@ public class SvgWriter {
     }
 
     protected static double getVoltageLevelCircleRadius(VoltageLevelNode vlNode, SvgParameters svgParameters) {
-        return vlNode.isFictitious() ? svgParameters.getFictitiousVoltageLevelCircleRadius() : svgParameters.getVoltageLevelCircleRadius();
+        if (vlNode.isFictitious()) {
+            return svgParameters.getFictitiousVoltageLevelCircleRadius();
+        }
+        int nbBuses = vlNode.getBusNodes().size();
+        return Math.min(Math.max(nbBuses, 1), 2) * svgParameters.getVoltageLevelCircleRadius();
     }
 }

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -40,20 +40,20 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1.99,-2.23)" id="0" class="nad-vl120to180" title="VL_132">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-1.80,3.59)" id="2" class="nad-vl30to50" title="VL_33">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(4.55,-0.65)" id="4" class="nad-vl0to30" title="VL_11">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl120to180" title="3WT">
-            <polyline points="-1.59,-1.82 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(-1.38,-1.61)">
+            <polyline points="-1.80,-2.03 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(-1.59,-1.82)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.46)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -71,8 +71,8 @@
             </g>
         </g>
         <g id="8" class="nad-vl30to50" title="3WT">
-            <polyline points="-1.44,3.15 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(-1.25,2.92)">
+            <polyline points="-1.63,3.38 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(-1.44,3.15)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(39.54)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -90,8 +90,8 @@
             </g>
         </g>
         <g id="9" class="nad-vl0to30" title="3WT">
-            <polyline points="4.00,-0.49 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(3.72,-0.40)">
+            <polyline points="4.29,-0.57 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(4.00,-0.49)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -122,9 +122,9 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-1.39,-2.23 -0.99,-2.23"/>
-        <polyline id="2_text_edge" points="-1.20,3.59 -0.80,3.59"/>
-        <polyline id="4_text_edge" points="5.15,-0.65 5.55,-0.65"/>
+        <polyline id="0_text_edge" points="-1.69,-2.23 -0.99,-2.23"/>
+        <polyline id="2_text_edge" points="-1.50,3.59 -0.80,3.59"/>
+        <polyline id="4_text_edge" points="4.85,-0.65 5.55,-0.65"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-0.99" y="-2.23" style="dominant-baseline:middle">VL_132</text>

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -40,14 +40,14 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-3.78,1.10)" id="0" class="nad-vl0to30" title="VL_11">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="3" class="nad-vl0to30" title="3WT">
-            <polyline points="-3.23,0.95 0.06,0.04"/>
-            <g class="nad-edge-infos" transform="translate(-2.94,0.87)">
+            <polyline points="-3.52,1.03 0.06,0.04"/>
+            <g class="nad-edge-infos" transform="translate(-3.23,0.95)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(74.59)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -78,7 +78,7 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-3.18,1.10 -2.78,1.10"/>
+        <polyline id="0_text_edge" points="-3.48,1.10 -2.78,1.10"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-2.78" y="1.10" style="dominant-baseline:middle">VL_11</text>

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -105,365 +105,365 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(19.40,-18.52)" id="0" title="VL1">
-            <circle r="0.60" id="1" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(24.21,-16.98)" id="2" title="VL2">
-            <circle r="0.60" id="3" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="3" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(22.20,-19.57)" id="4" title="VL3">
-            <circle r="0.60" id="5" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="5" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.75,-26.50)" id="6" title="VL4">
-            <circle r="0.60" id="7" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.05,-23.13)" id="8" title="VL5">
-            <circle r="0.60" id="9" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="9" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(25.69,-25.54)" id="10" title="VL6">
-            <circle r="0.60" id="11" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(29.00,-22.21)" id="12" title="VL7">
-            <circle r="0.60" id="13" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="13" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(14.60,-18.27)" id="14" title="VL8">
-            <circle r="0.60" id="15" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="15" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(10.49,-22.99)" id="16" title="VL9">
-            <circle r="0.60" id="17" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="17" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(7.60,-26.34)" id="18" title="VL10">
-            <circle r="0.60" id="19" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="19" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(23.47,-21.79)" id="20" title="VL11">
-            <circle r="0.60" id="21" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="21" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(27.35,-16.95)" id="22" title="VL12">
-            <circle r="0.60" id="23" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="23" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.82,-14.84)" id="24" title="VL13">
-            <circle r="0.60" id="25" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="25" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(25.02,-12.34)" id="26" title="VL14">
-            <circle r="0.60" id="27" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="27" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.28,-9.75)" id="28" title="VL15">
-            <circle r="0.60" id="29" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="29" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(28.26,-9.80)" id="30" title="VL16">
-            <circle r="0.60" id="31" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="31" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(24.15,-4.82)" id="32" title="VL17">
-            <circle r="0.60" id="33" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="33" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.49,-4.57)" id="34" title="VL18">
-            <circle r="0.60" id="35" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="35" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(15.56,-4.90)" id="36" title="VL19">
-            <circle r="0.60" id="37" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="37" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(16.06,1.02)" id="38" title="VL20">
-            <circle r="0.60" id="39" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="39" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(16.87,6.09)" id="40" title="VL21">
-            <circle r="0.60" id="41" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="41" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(17.74,11.14)" id="42" title="VL22">
-            <circle r="0.60" id="43" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="43" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(14.92,9.59)" id="44" title="VL23">
-            <circle r="0.60" id="45" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="45" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(0.46,11.01)" id="46" title="VL24">
-            <circle r="0.60" id="47" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="47" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(20.88,6.94)" id="48" title="VL25">
-            <circle r="0.60" id="49" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="49" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(19.91,0.19)" id="50" title="VL26">
-            <circle r="0.60" id="51" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="51" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(27.21,9.44)" id="52" title="VL27">
-            <circle r="0.60" id="53" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="53" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(31.96,8.36)" id="54" title="VL28">
-            <circle r="0.60" id="55" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="55" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(32.52,4.31)" id="56" title="VL29">
-            <circle r="0.60" id="57" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="57" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(16.70,-7.44)" id="58" title="VL30">
-            <circle r="0.60" id="59" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="59" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(28.43,1.78)" id="60" title="VL31">
-            <circle r="0.60" id="61" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="61" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(24.39,6.90)" id="62" title="VL32">
-            <circle r="0.60" id="63" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="63" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(14.39,-11.12)" id="64" title="VL33">
-            <circle r="0.60" id="65" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="65" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.02,-9.18)" id="66" title="VL34">
-            <circle r="0.60" id="67" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="67" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.50,-13.66)" id="68" title="VL35">
-            <circle r="0.60" id="69" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="69" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(4.14,-13.73)" id="70" title="VL36">
-            <circle r="0.60" id="71" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="71" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(9.77,-8.03)" id="72" title="VL37">
-            <circle r="0.60" id="73" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="73" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.30,-2.88)" id="74" title="VL38">
-            <circle r="0.60" id="75" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="75" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(10.83,-5.08)" id="76" title="VL39">
-            <circle r="0.60" id="77" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="77" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(10.33,-1.31)" id="78" title="VL40">
-            <circle r="0.60" id="79" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="79" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(10.51,2.26)" id="80" title="VL41">
-            <circle r="0.60" id="81" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="81" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(8.77,5.25)" id="82" title="VL42">
-            <circle r="0.60" id="83" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="83" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3.31,-6.08)" id="84" title="VL43">
-            <circle r="0.60" id="85" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="85" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3.19,-0.33)" id="86" title="VL44">
-            <circle r="0.60" id="87" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="87" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(4.65,5.85)" id="88" title="VL45">
-            <circle r="0.60" id="89" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="89" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(6.54,9.30)" id="90" title="VL46">
-            <circle r="0.60" id="91" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="91" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2.47,8.59)" id="92" title="VL47">
-            <circle r="0.60" id="93" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="93" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(8.31,12.74)" id="94" title="VL48">
-            <circle r="0.60" id="95" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="95" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(4.24,12.94)" id="96" title="VL49">
-            <circle r="0.60" id="97" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="97" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(5.84,17.57)" id="98" title="VL50">
-            <circle r="0.60" id="99" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="99" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(10.49,20.14)" id="100" title="VL51">
-            <circle r="0.60" id="101" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="101" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(14.49,22.79)" id="102" title="VL52">
-            <circle r="0.60" id="103" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="103" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(11.22,24.49)" id="104" title="VL53">
-            <circle r="0.60" id="105" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="105" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(4.08,23.24)" id="106" title="VL54">
-            <circle r="0.60" id="107" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="107" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2.57,28.41)" id="108" title="VL55">
-            <circle r="0.60" id="109" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="109" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(5.08,26.41)" id="110" title="VL56">
-            <circle r="0.60" id="111" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="111" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(6.85,21.89)" id="112" title="VL57">
-            <circle r="0.60" id="113" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="113" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(9.15,26.93)" id="114" title="VL58">
-            <circle r="0.60" id="115" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="115" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-0.04,25.77)" id="116" title="VL59">
-            <circle r="0.60" id="117" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="117" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.20,24.98)" id="118" title="VL60">
-            <circle r="0.60" id="119" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="119" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-3.56,22.64)" id="120" title="VL61">
-            <circle r="0.60" id="121" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="121" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.32,20.44)" id="122" title="VL62">
-            <circle r="0.60" id="123" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="123" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2.97,26.03)" id="124" title="VL63">
-            <circle r="0.60" id="125" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="125" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-1.84,18.66)" id="126" title="VL64">
-            <circle r="0.60" id="127" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="127" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-0.56,7.14)" id="128" title="VL65">
-            <circle r="0.60" id="129" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="129" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-2.38,14.67)" id="130" title="VL66">
-            <circle r="0.60" id="131" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="131" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.99,17.22)" id="132" title="VL67">
-            <circle r="0.60" id="133" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="133" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-3.38,0.47)" id="134" title="VL68">
-            <circle r="0.60" id="135" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="135" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-3.75,4.72)" id="136" title="VL69">
-            <circle r="0.60" id="137" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="137" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.59,7.86)" id="138" title="VL70">
-            <circle r="0.60" id="139" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="139" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-10.12,12.08)" id="140" title="VL71">
-            <circle r="0.60" id="141" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="141" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-5.61,12.08)" id="142" title="VL72">
-            <circle r="0.60" id="143" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="143" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-14.00,14.67)" id="144" title="VL73">
-            <circle r="0.60" id="145" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="145" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-10.36,6.82)" id="146" title="VL74">
-            <circle r="0.60" id="147" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="147" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-8.86,3.26)" id="148" title="VL75">
-            <circle r="0.60" id="149" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="149" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-13.19,-0.40)" id="150" title="VL76">
-            <circle r="0.60" id="151" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="151" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-10.64,-3.30)" id="152" title="VL77">
-            <circle r="0.60" id="153" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="153" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-7.68,-9.00)" id="154" title="VL78">
-            <circle r="0.60" id="155" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="155" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-8.12,-12.54)" id="156" title="VL79">
-            <circle r="0.60" id="157" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="157" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-12.17,-8.75)" id="158" title="VL80">
-            <circle r="0.60" id="159" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="159" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.82,-4.94)" id="160" title="VL81">
-            <circle r="0.60" id="161" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="161" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-19.02,-8.74)" id="162" title="VL82">
-            <circle r="0.60" id="163" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="163" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-28.61,-8.70)" id="164" title="VL83">
-            <circle r="0.60" id="165" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="165" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-32.33,-7.14)" id="166" title="VL84">
-            <circle r="0.60" id="167" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="167" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-33.58,-10.57)" id="168" title="VL85">
-            <circle r="0.60" id="169" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="169" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-37.95,-7.11)" id="170" title="VL86">
-            <circle r="0.60" id="171" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="171" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-40.29,-3.65)" id="172" title="VL87">
-            <circle r="0.60" id="173" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="173" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-34.90,-14.36)" id="174" title="VL88">
-            <circle r="0.60" id="175" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="175" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-30.91,-15.03)" id="176" title="VL89">
-            <circle r="0.60" id="177" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="177" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-30.38,-19.64)" id="178" title="VL90">
-            <circle r="0.60" id="179" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="179" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-26.67,-19.06)" id="180" title="VL91">
-            <circle r="0.60" id="181" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="181" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-24.82,-13.73)" id="182" title="VL92">
-            <circle r="0.60" id="183" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="183" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-22.10,-17.11)" id="184" title="VL93">
-            <circle r="0.60" id="185" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="185" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-20.29,-13.32)" id="186" title="VL94">
-            <circle r="0.60" id="187" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="187" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-17.02,-17.06)" id="188" title="VL95">
-            <circle r="0.60" id="189" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="189" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-15.89,-12.93)" id="190" title="VL96">
-            <circle r="0.60" id="191" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="191" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-12.26,-14.13)" id="192" title="VL97">
-            <circle r="0.60" id="193" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="193" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-17.31,-4.36)" id="194" title="VL98">
-            <circle r="0.60" id="195" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="195" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-15.99,-7.20)" id="196" title="VL99">
-            <circle r="0.60" id="197" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="197" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-22.08,-4.48)" id="198" title="VL100">
-            <circle r="0.60" id="199" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="199" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-24.96,-6.26)" id="200" title="VL101">
-            <circle r="0.60" id="201" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="201" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-24.90,-10.21)" id="202" title="VL102">
-            <circle r="0.60" id="203" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="203" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-23.38,4.83)" id="204" title="VL103">
-            <circle r="0.60" id="205" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="205" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-23.30,1.29)" id="206" title="VL104">
-            <circle r="0.60" id="207" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="207" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-27.12,4.45)" id="208" title="VL105">
-            <circle r="0.60" id="209" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="209" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-27.26,0.16)" id="210" title="VL106">
-            <circle r="0.60" id="211" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="211" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-30.52,2.85)" id="212" title="VL107">
-            <circle r="0.60" id="213" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="213" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-29.52,8.98)" id="214" title="VL108">
-            <circle r="0.60" id="215" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="215" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-28.79,12.81)" id="216" title="VL109">
-            <circle r="0.60" id="217" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="217" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-24.64,12.82)" id="218" title="VL110">
-            <circle r="0.60" id="219" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="219" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-22.00,16.41)" id="220" title="VL111">
-            <circle r="0.60" id="221" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="221" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-26.33,17.64)" id="222" title="VL112">
-            <circle r="0.60" id="223" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="223" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(24.96,0.89)" id="224" title="VL113">
-            <circle r="0.60" id="225" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="225" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(25.13,12.81)" id="226" title="VL114">
-            <circle r="0.60" id="227" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="227" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(28.45,14.04)" id="228" title="VL115">
-            <circle r="0.60" id="229" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="229" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2.30,-3.55)" id="230" title="VL116">
-            <circle r="0.60" id="231" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="231" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(32.24,-16.23)" id="232" title="VL117">
-            <circle r="0.60" id="233" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="233" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-13.22,3.08)" id="234" title="VL118">
-            <circle r="0.60" id="235" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="235" class="nad-vl120to180-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="236" class="nad-vl120to180-0" title="L1-2-1">
             <g>
-                <polyline points="19.94,-18.34 21.81,-17.75"/>
-                <g class="nad-edge-infos" transform="translate(20.23,-18.25)">
+                <polyline points="19.66,-18.43 21.81,-17.75"/>
+                <g class="nad-edge-infos" transform="translate(19.94,-18.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(107.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -481,8 +481,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="23.67,-17.15 21.81,-17.75"/>
-                <g class="nad-edge-infos" transform="translate(23.38,-17.24)">
+                <polyline points="23.96,-17.06 21.81,-17.75"/>
+                <g class="nad-edge-infos" transform="translate(23.67,-17.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-72.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -502,8 +502,8 @@
         </g>
         <g id="237" class="nad-vl120to180-0" title="L1-3-1">
             <g>
-                <polyline points="19.93,-18.72 20.80,-19.04"/>
-                <g class="nad-edge-infos" transform="translate(20.21,-18.82)">
+                <polyline points="19.65,-18.61 20.80,-19.04"/>
+                <g class="nad-edge-infos" transform="translate(19.93,-18.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -521,8 +521,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="21.67,-19.37 20.80,-19.04"/>
-                <g class="nad-edge-infos" transform="translate(21.39,-19.26)">
+                <polyline points="21.95,-19.47 20.80,-19.04"/>
+                <g class="nad-edge-infos" transform="translate(21.67,-19.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -542,8 +542,8 @@
         </g>
         <g id="238" class="nad-vl120to180-0" title="L2-12-1">
             <g>
-                <polyline points="24.78,-16.97 25.78,-16.96"/>
-                <g class="nad-edge-infos" transform="translate(25.08,-16.97)">
+                <polyline points="24.48,-16.97 25.78,-16.96"/>
+                <g class="nad-edge-infos" transform="translate(24.78,-16.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -561,8 +561,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="26.78,-16.95 25.78,-16.96"/>
-                <g class="nad-edge-infos" transform="translate(26.49,-16.95)">
+                <polyline points="27.08,-16.95 25.78,-16.96"/>
+                <g class="nad-edge-infos" transform="translate(26.78,-16.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -582,8 +582,8 @@
         </g>
         <g id="239" class="nad-vl120to180-0" title="L3-5-1">
             <g>
-                <polyline points="21.91,-20.06 21.13,-21.35"/>
-                <g class="nad-edge-infos" transform="translate(21.75,-20.31)">
+                <polyline points="22.06,-19.80 21.13,-21.35"/>
+                <g class="nad-edge-infos" transform="translate(21.91,-20.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -601,8 +601,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="20.35,-22.64 21.13,-21.35"/>
-                <g class="nad-edge-infos" transform="translate(20.50,-22.39)">
+                <polyline points="20.19,-22.90 21.13,-21.35"/>
+                <g class="nad-edge-infos" transform="translate(20.35,-22.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -622,8 +622,8 @@
         </g>
         <g id="240" class="nad-vl120to180-0" title="L3-12-1">
             <g>
-                <polyline points="22.71,-19.31 24.78,-18.26"/>
-                <g class="nad-edge-infos" transform="translate(22.97,-19.17)">
+                <polyline points="22.44,-19.45 24.78,-18.26"/>
+                <g class="nad-edge-infos" transform="translate(22.71,-19.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -641,8 +641,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="26.85,-17.20 24.78,-18.26"/>
-                <g class="nad-edge-infos" transform="translate(26.58,-17.34)">
+                <polyline points="27.11,-17.07 24.78,-18.26"/>
+                <g class="nad-edge-infos" transform="translate(26.85,-17.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -662,8 +662,8 @@
         </g>
         <g id="241" class="nad-vl120to180-0" title="L4-5-1">
             <g>
-                <polyline points="20.64,-25.94 20.40,-24.81"/>
-                <g class="nad-edge-infos" transform="translate(20.58,-25.65)">
+                <polyline points="20.70,-26.23 20.40,-24.81"/>
+                <g class="nad-edge-infos" transform="translate(20.64,-25.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -681,8 +681,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="20.17,-23.69 20.40,-24.81"/>
-                <g class="nad-edge-infos" transform="translate(20.23,-23.98)">
+                <polyline points="20.11,-23.39 20.40,-24.81"/>
+                <g class="nad-edge-infos" transform="translate(20.17,-23.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -702,8 +702,8 @@
         </g>
         <g id="242" class="nad-vl120to180-0" title="L4-11-1">
             <g>
-                <polyline points="21.04,-26.00 22.11,-24.14"/>
-                <g class="nad-edge-infos" transform="translate(21.19,-25.74)">
+                <polyline points="20.89,-26.26 22.11,-24.14"/>
+                <g class="nad-edge-infos" transform="translate(21.04,-26.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -721,8 +721,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="23.19,-22.28 22.11,-24.14"/>
-                <g class="nad-edge-infos" transform="translate(23.04,-22.54)">
+                <polyline points="23.34,-22.02 22.11,-24.14"/>
+                <g class="nad-edge-infos" transform="translate(23.19,-22.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -742,8 +742,8 @@
         </g>
         <g id="243" class="nad-vl120to180-0" title="L5-6-1">
             <g>
-                <polyline points="20.58,-23.35 22.87,-24.34"/>
-                <g class="nad-edge-infos" transform="translate(20.85,-23.47)">
+                <polyline points="20.30,-23.24 22.87,-24.34"/>
+                <g class="nad-edge-infos" transform="translate(20.58,-23.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -761,8 +761,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="25.16,-25.32 22.87,-24.34"/>
-                <g class="nad-edge-infos" transform="translate(24.89,-25.20)">
+                <polyline points="25.44,-25.43 22.87,-24.34"/>
+                <g class="nad-edge-infos" transform="translate(25.16,-25.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -782,8 +782,8 @@
         </g>
         <g id="244" title="T8-5-1">
             <g class="nad-vl120to180-1">
-                <polyline points="15.02,-18.65 17.32,-20.70"/>
-                <g class="nad-edge-infos" transform="translate(15.25,-18.85)">
+                <polyline points="14.80,-18.45 17.32,-20.70"/>
+                <g class="nad-edge-infos" transform="translate(15.02,-18.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -802,8 +802,8 @@
                 <circle cx="17.25" cy="-20.63" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="19.63,-22.75 17.32,-20.70"/>
-                <g class="nad-edge-infos" transform="translate(19.40,-22.55)">
+                <polyline points="19.85,-22.95 17.32,-20.70"/>
+                <g class="nad-edge-infos" transform="translate(19.63,-22.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -824,8 +824,8 @@
         </g>
         <g id="245" class="nad-vl120to180-0" title="L5-11-1">
             <g>
-                <polyline points="20.58,-22.92 21.76,-22.46"/>
-                <g class="nad-edge-infos" transform="translate(20.86,-22.81)">
+                <polyline points="20.30,-23.03 21.76,-22.46"/>
+                <g class="nad-edge-infos" transform="translate(20.58,-22.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -843,8 +843,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="22.94,-22.00 21.76,-22.46"/>
-                <g class="nad-edge-infos" transform="translate(22.66,-22.11)">
+                <polyline points="23.22,-21.89 21.76,-22.46"/>
+                <g class="nad-edge-infos" transform="translate(22.94,-22.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -864,8 +864,8 @@
         </g>
         <g id="246" class="nad-vl120to180-0" title="L6-7-1">
             <g>
-                <polyline points="26.09,-25.14 27.35,-23.88"/>
-                <g class="nad-edge-infos" transform="translate(26.30,-24.92)">
+                <polyline points="25.88,-25.35 27.35,-23.88"/>
+                <g class="nad-edge-infos" transform="translate(26.09,-25.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -883,8 +883,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="28.60,-22.62 27.35,-23.88"/>
-                <g class="nad-edge-infos" transform="translate(28.39,-22.83)">
+                <polyline points="28.81,-22.40 27.35,-23.88"/>
+                <g class="nad-edge-infos" transform="translate(28.60,-22.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -904,8 +904,8 @@
         </g>
         <g id="247" class="nad-vl120to180-0" title="L7-12-1">
             <g>
-                <polyline points="28.83,-21.67 28.18,-19.58"/>
-                <g class="nad-edge-infos" transform="translate(28.74,-21.38)">
+                <polyline points="28.92,-21.96 28.18,-19.58"/>
+                <g class="nad-edge-infos" transform="translate(28.83,-21.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -923,8 +923,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="27.53,-17.49 28.18,-19.58"/>
-                <g class="nad-edge-infos" transform="translate(27.61,-17.78)">
+                <polyline points="27.44,-17.20 28.18,-19.58"/>
+                <g class="nad-edge-infos" transform="translate(27.53,-17.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -944,8 +944,8 @@
         </g>
         <g id="248" class="nad-vl120to180-1" title="L8-9-1">
             <g>
-                <polyline points="14.22,-18.70 12.54,-20.63"/>
-                <g class="nad-edge-infos" transform="translate(14.02,-18.93)">
+                <polyline points="14.42,-18.47 12.54,-20.63"/>
+                <g class="nad-edge-infos" transform="translate(14.22,-18.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -963,8 +963,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.86,-22.56 12.54,-20.63"/>
-                <g class="nad-edge-infos" transform="translate(11.06,-22.33)">
+                <polyline points="10.66,-22.78 12.54,-20.63"/>
+                <g class="nad-edge-infos" transform="translate(10.86,-22.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -984,8 +984,8 @@
         </g>
         <g id="249" class="nad-vl120to180-1" title="L8-30-1">
             <g>
-                <polyline points="14.70,-17.71 15.65,-12.86"/>
-                <g class="nad-edge-infos" transform="translate(14.76,-17.42)">
+                <polyline points="14.65,-18.01 15.65,-12.86"/>
+                <g class="nad-edge-infos" transform="translate(14.70,-17.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1003,8 +1003,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.59,-8.00 15.65,-12.86"/>
-                <g class="nad-edge-infos" transform="translate(16.53,-8.29)">
+                <polyline points="16.64,-7.71 15.65,-12.86"/>
+                <g class="nad-edge-infos" transform="translate(16.59,-8.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1024,8 +1024,8 @@
         </g>
         <g id="250" class="nad-vl120to180-1" title="L9-10-1">
             <g>
-                <polyline points="10.11,-23.42 9.05,-24.66"/>
-                <g class="nad-edge-infos" transform="translate(9.92,-23.65)">
+                <polyline points="10.31,-23.19 9.05,-24.66"/>
+                <g class="nad-edge-infos" transform="translate(10.11,-23.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1043,8 +1043,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.98,-25.91 9.05,-24.66"/>
-                <g class="nad-edge-infos" transform="translate(8.17,-25.68)">
+                <polyline points="7.78,-26.13 9.05,-24.66"/>
+                <g class="nad-edge-infos" transform="translate(7.98,-25.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1064,8 +1064,8 @@
         </g>
         <g id="251" class="nad-vl120to180-0" title="L11-12-1">
             <g>
-                <polyline points="23.83,-21.35 25.41,-19.37"/>
-                <g class="nad-edge-infos" transform="translate(24.02,-21.11)">
+                <polyline points="23.64,-21.58 25.41,-19.37"/>
+                <g class="nad-edge-infos" transform="translate(23.83,-21.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1083,8 +1083,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="27.00,-17.39 25.41,-19.37"/>
-                <g class="nad-edge-infos" transform="translate(26.81,-17.62)">
+                <polyline points="27.19,-17.16 25.41,-19.37"/>
+                <g class="nad-edge-infos" transform="translate(27.00,-17.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1104,8 +1104,8 @@
         </g>
         <g id="252" class="nad-vl120to180-0" title="L11-13-1">
             <g>
-                <polyline points="23.27,-21.26 22.15,-18.32"/>
-                <g class="nad-edge-infos" transform="translate(23.16,-20.98)">
+                <polyline points="23.38,-21.54 22.15,-18.32"/>
+                <g class="nad-edge-infos" transform="translate(23.27,-21.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-159.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1123,8 +1123,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="21.02,-15.38 22.15,-18.32"/>
-                <g class="nad-edge-infos" transform="translate(21.13,-15.66)">
+                <polyline points="20.91,-15.10 22.15,-18.32"/>
+                <g class="nad-edge-infos" transform="translate(21.02,-15.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(20.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1144,8 +1144,8 @@
         </g>
         <g id="253" class="nad-vl120to180-0" title="L12-14-1">
             <g>
-                <polyline points="27.10,-16.44 26.19,-14.65"/>
-                <g class="nad-edge-infos" transform="translate(26.96,-16.17)">
+                <polyline points="27.23,-16.71 26.19,-14.65"/>
+                <g class="nad-edge-infos" transform="translate(27.10,-16.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1163,8 +1163,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="25.27,-12.85 26.19,-14.65"/>
-                <g class="nad-edge-infos" transform="translate(25.41,-13.12)">
+                <polyline points="25.14,-12.59 26.19,-14.65"/>
+                <g class="nad-edge-infos" transform="translate(25.27,-12.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1184,8 +1184,8 @@
         </g>
         <g id="254" class="nad-vl120to180-0" title="L12-16-1">
             <g>
-                <polyline points="27.43,-16.38 27.81,-13.37"/>
-                <g class="nad-edge-infos" transform="translate(27.46,-16.08)">
+                <polyline points="27.39,-16.68 27.81,-13.37"/>
+                <g class="nad-edge-infos" transform="translate(27.43,-16.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(172.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1203,8 +1203,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="28.19,-10.36 27.81,-13.37"/>
-                <g class="nad-edge-infos" transform="translate(28.15,-10.66)">
+                <polyline points="28.23,-10.07 27.81,-13.37"/>
+                <g class="nad-edge-infos" transform="translate(28.19,-10.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1224,8 +1224,8 @@
         </g>
         <g id="255" class="nad-vl120to180-0" title="L12-117-1">
             <g>
-                <polyline points="27.92,-16.86 29.80,-16.59"/>
-                <g class="nad-edge-infos" transform="translate(28.22,-16.82)">
+                <polyline points="27.62,-16.91 29.80,-16.59"/>
+                <g class="nad-edge-infos" transform="translate(27.92,-16.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1243,8 +1243,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="31.68,-16.31 29.80,-16.59"/>
-                <g class="nad-edge-infos" transform="translate(31.38,-16.35)">
+                <polyline points="31.98,-16.26 29.80,-16.59"/>
+                <g class="nad-edge-infos" transform="translate(31.68,-16.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1264,8 +1264,8 @@
         </g>
         <g id="256" class="nad-vl120to180-0" title="L13-15-1">
             <g>
-                <polyline points="20.76,-14.28 20.55,-12.30"/>
-                <g class="nad-edge-infos" transform="translate(20.73,-13.98)">
+                <polyline points="20.79,-14.58 20.55,-12.30"/>
+                <g class="nad-edge-infos" transform="translate(20.76,-14.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1283,8 +1283,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="20.34,-10.32 20.55,-12.30"/>
-                <g class="nad-edge-infos" transform="translate(20.37,-10.61)">
+                <polyline points="20.31,-10.02 20.55,-12.30"/>
+                <g class="nad-edge-infos" transform="translate(20.34,-10.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1304,8 +1304,8 @@
         </g>
         <g id="257" class="nad-vl120to180-0" title="L14-15-1">
             <g>
-                <polyline points="24.52,-12.07 22.65,-11.05"/>
-                <g class="nad-edge-infos" transform="translate(24.25,-11.93)">
+                <polyline points="24.78,-12.21 22.65,-11.05"/>
+                <g class="nad-edge-infos" transform="translate(24.52,-12.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1323,8 +1323,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="20.78,-10.02 22.65,-11.05"/>
-                <g class="nad-edge-infos" transform="translate(21.04,-10.17)">
+                <polyline points="20.51,-9.88 22.65,-11.05"/>
+                <g class="nad-edge-infos" transform="translate(20.78,-10.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1344,8 +1344,8 @@
         </g>
         <g id="258" class="nad-vl120to180-0" title="L15-17-1">
             <g>
-                <polyline points="20.63,-9.30 22.21,-7.29"/>
-                <g class="nad-edge-infos" transform="translate(20.81,-9.06)">
+                <polyline points="20.44,-9.54 22.21,-7.29"/>
+                <g class="nad-edge-infos" transform="translate(20.63,-9.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1363,8 +1363,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="23.79,-5.27 22.21,-7.29"/>
-                <g class="nad-edge-infos" transform="translate(23.61,-5.51)">
+                <polyline points="23.98,-5.03 22.21,-7.29"/>
+                <g class="nad-edge-infos" transform="translate(23.79,-5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1384,8 +1384,8 @@
         </g>
         <g id="259" class="nad-vl120to180-0" title="L15-19-1">
             <g>
-                <polyline points="19.88,-9.34 17.92,-7.33"/>
-                <g class="nad-edge-infos" transform="translate(19.67,-9.13)">
+                <polyline points="20.09,-9.56 17.92,-7.33"/>
+                <g class="nad-edge-infos" transform="translate(19.88,-9.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1403,8 +1403,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="15.96,-5.31 17.92,-7.33"/>
-                <g class="nad-edge-infos" transform="translate(16.17,-5.53)">
+                <polyline points="15.75,-5.10 17.92,-7.33"/>
+                <g class="nad-edge-infos" transform="translate(15.96,-5.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1424,8 +1424,8 @@
         </g>
         <g id="260" class="nad-vl120to180-0" title="L15-33-1">
             <g>
-                <polyline points="19.72,-9.88 17.33,-10.43"/>
-                <g class="nad-edge-infos" transform="translate(19.43,-9.95)">
+                <polyline points="20.01,-9.81 17.33,-10.43"/>
+                <g class="nad-edge-infos" transform="translate(19.72,-9.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1443,8 +1443,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="14.95,-10.99 17.33,-10.43"/>
-                <g class="nad-edge-infos" transform="translate(15.24,-10.92)">
+                <polyline points="14.66,-11.06 17.33,-10.43"/>
+                <g class="nad-edge-infos" transform="translate(14.95,-10.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1464,8 +1464,8 @@
         </g>
         <g id="261" class="nad-vl120to180-0" title="L16-17-1">
             <g>
-                <polyline points="27.90,-9.36 26.20,-7.31"/>
-                <g class="nad-edge-infos" transform="translate(27.71,-9.13)">
+                <polyline points="28.09,-9.59 26.20,-7.31"/>
+                <g class="nad-edge-infos" transform="translate(27.90,-9.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-140.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1483,8 +1483,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="24.51,-5.26 26.20,-7.31"/>
-                <g class="nad-edge-infos" transform="translate(24.70,-5.49)">
+                <polyline points="24.32,-5.03 26.20,-7.31"/>
+                <g class="nad-edge-infos" transform="translate(24.51,-5.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(39.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1504,8 +1504,8 @@
         </g>
         <g id="262" class="nad-vl120to180-0" title="L17-18-1">
             <g>
-                <polyline points="23.58,-4.78 22.32,-4.69"/>
-                <g class="nad-edge-infos" transform="translate(23.28,-4.76)">
+                <polyline points="23.88,-4.80 22.32,-4.69"/>
+                <g class="nad-edge-infos" transform="translate(23.58,-4.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1523,8 +1523,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="21.06,-4.61 22.32,-4.69"/>
-                <g class="nad-edge-infos" transform="translate(21.36,-4.63)">
+                <polyline points="20.76,-4.59 22.32,-4.69"/>
+                <g class="nad-edge-infos" transform="translate(21.06,-4.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1544,8 +1544,8 @@
         </g>
         <g id="263" title="T30-17-1">
             <g class="nad-vl120to180-1">
-                <polyline points="17.23,-7.25 20.42,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(17.52,-7.15)">
+                <polyline points="16.95,-7.35 20.42,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(17.23,-7.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1564,8 +1564,8 @@
                 <circle cx="20.33" cy="-6.16" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="23.61,-5.01 20.42,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(23.33,-5.11)">
+                <polyline points="23.89,-4.91 20.42,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(23.61,-5.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1586,8 +1586,8 @@
         </g>
         <g id="264" class="nad-vl120to180-0" title="L17-31-1">
             <g>
-                <polyline points="24.46,-4.34 26.29,-1.52"/>
-                <g class="nad-edge-infos" transform="translate(24.62,-4.09)">
+                <polyline points="24.29,-4.60 26.29,-1.52"/>
+                <g class="nad-edge-infos" transform="translate(24.46,-4.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1605,8 +1605,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="28.12,1.30 26.29,-1.52"/>
-                <g class="nad-edge-infos" transform="translate(27.95,1.05)">
+                <polyline points="28.28,1.55 26.29,-1.52"/>
+                <g class="nad-edge-infos" transform="translate(28.12,1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1626,8 +1626,8 @@
         </g>
         <g id="265" class="nad-vl120to180-0" title="L17-113-1">
             <g>
-                <polyline points="24.23,-4.26 24.55,-1.97"/>
-                <g class="nad-edge-infos" transform="translate(24.27,-3.96)">
+                <polyline points="24.18,-4.55 24.55,-1.97"/>
+                <g class="nad-edge-infos" transform="translate(24.23,-4.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1645,8 +1645,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="24.88,0.32 24.55,-1.97"/>
-                <g class="nad-edge-infos" transform="translate(24.83,0.03)">
+                <polyline points="24.92,0.62 24.55,-1.97"/>
+                <g class="nad-edge-infos" transform="translate(24.88,0.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1666,8 +1666,8 @@
         </g>
         <g id="266" class="nad-vl120to180-0" title="L18-19-1">
             <g>
-                <polyline points="19.92,-4.61 18.03,-4.74"/>
-                <g class="nad-edge-infos" transform="translate(19.62,-4.63)">
+                <polyline points="20.22,-4.58 18.03,-4.74"/>
+                <g class="nad-edge-infos" transform="translate(19.92,-4.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1685,8 +1685,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.13,-4.87 18.03,-4.74"/>
-                <g class="nad-edge-infos" transform="translate(16.43,-4.84)">
+                <polyline points="15.83,-4.89 18.03,-4.74"/>
+                <g class="nad-edge-infos" transform="translate(16.13,-4.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.92)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1706,8 +1706,8 @@
         </g>
         <g id="267" class="nad-vl120to180-0" title="L19-20-1">
             <g>
-                <polyline points="15.61,-4.34 15.81,-1.94"/>
-                <g class="nad-edge-infos" transform="translate(15.63,-4.04)">
+                <polyline points="15.58,-4.64 15.81,-1.94"/>
+                <g class="nad-edge-infos" transform="translate(15.61,-4.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1725,8 +1725,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.01,0.45 15.81,-1.94"/>
-                <g class="nad-edge-infos" transform="translate(15.99,0.16)">
+                <polyline points="16.04,0.75 15.81,-1.94"/>
+                <g class="nad-edge-infos" transform="translate(16.01,0.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1746,8 +1746,8 @@
         </g>
         <g id="268" class="nad-vl120to180-0" title="L19-34-1">
             <g>
-                <polyline points="15.05,-5.16 11.29,-7.04"/>
-                <g class="nad-edge-infos" transform="translate(14.78,-5.29)">
+                <polyline points="15.32,-5.02 11.29,-7.04"/>
+                <g class="nad-edge-infos" transform="translate(15.05,-5.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1765,8 +1765,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.53,-8.93 11.29,-7.04"/>
-                <g class="nad-edge-infos" transform="translate(7.79,-8.79)">
+                <polyline points="7.26,-9.06 11.29,-7.04"/>
+                <g class="nad-edge-infos" transform="translate(7.53,-8.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1786,8 +1786,8 @@
         </g>
         <g id="269" class="nad-vl120to180-0" title="L20-21-1">
             <g>
-                <polyline points="16.15,1.59 16.46,3.56"/>
-                <g class="nad-edge-infos" transform="translate(16.20,1.88)">
+                <polyline points="16.10,1.29 16.46,3.56"/>
+                <g class="nad-edge-infos" transform="translate(16.15,1.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1805,8 +1805,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.78,5.53 16.46,3.56"/>
-                <g class="nad-edge-infos" transform="translate(16.73,5.23)">
+                <polyline points="16.82,5.83 16.46,3.56"/>
+                <g class="nad-edge-infos" transform="translate(16.78,5.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1826,8 +1826,8 @@
         </g>
         <g id="270" class="nad-vl120to180-0" title="L21-22-1">
             <g>
-                <polyline points="16.96,6.65 17.30,8.62"/>
-                <g class="nad-edge-infos" transform="translate(17.01,6.95)">
+                <polyline points="16.91,6.36 17.30,8.62"/>
+                <g class="nad-edge-infos" transform="translate(16.96,6.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1845,8 +1845,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="17.64,10.58 17.30,8.62"/>
-                <g class="nad-edge-infos" transform="translate(17.59,10.29)">
+                <polyline points="17.69,10.88 17.30,8.62"/>
+                <g class="nad-edge-infos" transform="translate(17.64,10.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1866,8 +1866,8 @@
         </g>
         <g id="271" class="nad-vl120to180-0" title="L22-23-1">
             <g>
-                <polyline points="17.24,10.87 16.33,10.37"/>
-                <g class="nad-edge-infos" transform="translate(16.98,10.72)">
+                <polyline points="17.50,11.01 16.33,10.37"/>
+                <g class="nad-edge-infos" transform="translate(17.24,10.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1885,8 +1885,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="15.42,9.87 16.33,10.37"/>
-                <g class="nad-edge-infos" transform="translate(15.68,10.01)">
+                <polyline points="15.15,9.72 16.33,10.37"/>
+                <g class="nad-edge-infos" transform="translate(15.42,9.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(118.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1906,8 +1906,8 @@
         </g>
         <g id="272" class="nad-vl120to180-0" title="L23-24-1">
             <g>
-                <polyline points="14.35,9.65 7.69,10.30"/>
-                <g class="nad-edge-infos" transform="translate(14.05,9.68)">
+                <polyline points="14.65,9.62 7.69,10.30"/>
+                <g class="nad-edge-infos" transform="translate(14.35,9.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1925,8 +1925,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.03,10.95 7.69,10.30"/>
-                <g class="nad-edge-infos" transform="translate(1.33,10.92)">
+                <polyline points="0.73,10.98 7.69,10.30"/>
+                <g class="nad-edge-infos" transform="translate(1.03,10.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1946,8 +1946,8 @@
         </g>
         <g id="273" class="nad-vl120to180-0" title="L23-25-1">
             <g>
-                <polyline points="15.44,9.36 17.90,8.27"/>
-                <g class="nad-edge-infos" transform="translate(15.71,9.24)">
+                <polyline points="15.16,9.48 17.90,8.27"/>
+                <g class="nad-edge-infos" transform="translate(15.44,9.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1965,8 +1965,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="20.36,7.17 17.90,8.27"/>
-                <g class="nad-edge-infos" transform="translate(20.09,7.30)">
+                <polyline points="20.64,7.05 17.90,8.27"/>
+                <g class="nad-edge-infos" transform="translate(20.36,7.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1986,8 +1986,8 @@
         </g>
         <g id="274" class="nad-vl120to180-0" title="L23-32-1">
             <g>
-                <polyline points="15.46,9.44 19.65,8.24"/>
-                <g class="nad-edge-infos" transform="translate(15.75,9.35)">
+                <polyline points="15.18,9.52 19.65,8.24"/>
+                <g class="nad-edge-infos" transform="translate(15.46,9.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2005,8 +2005,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="23.84,7.05 19.65,8.24"/>
-                <g class="nad-edge-infos" transform="translate(23.55,7.14)">
+                <polyline points="24.13,6.97 19.65,8.24"/>
+                <g class="nad-edge-infos" transform="translate(23.84,7.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2026,8 +2026,8 @@
         </g>
         <g id="275" class="nad-vl120to180-0" title="L24-70-1">
             <g>
-                <polyline points="-0.06,10.77 -3.06,9.43"/>
-                <g class="nad-edge-infos" transform="translate(-0.33,10.65)">
+                <polyline points="0.22,10.90 -3.06,9.43"/>
+                <g class="nad-edge-infos" transform="translate(-0.06,10.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2045,8 +2045,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.07,8.09 -3.06,9.43"/>
-                <g class="nad-edge-infos" transform="translate(-5.80,8.22)">
+                <polyline points="-6.34,7.97 -3.06,9.43"/>
+                <g class="nad-edge-infos" transform="translate(-6.07,8.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2066,8 +2066,8 @@
         </g>
         <g id="276" class="nad-vl120to180-0" title="L24-72-1">
             <g>
-                <polyline points="-0.10,11.11 -2.58,11.54"/>
-                <g class="nad-edge-infos" transform="translate(-0.39,11.16)">
+                <polyline points="0.20,11.05 -2.58,11.54"/>
+                <g class="nad-edge-infos" transform="translate(-0.10,11.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2085,8 +2085,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.05,11.98 -2.58,11.54"/>
-                <g class="nad-edge-infos" transform="translate(-4.76,11.93)">
+                <polyline points="-5.35,12.03 -2.58,11.54"/>
+                <g class="nad-edge-infos" transform="translate(-5.05,11.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2106,8 +2106,8 @@
         </g>
         <g id="277" title="T26-25-1">
             <g class="nad-vl120to180-1">
-                <polyline points="19.99,0.75 20.40,3.57"/>
-                <g class="nad-edge-infos" transform="translate(20.03,1.05)">
+                <polyline points="19.95,0.45 20.40,3.57"/>
+                <g class="nad-edge-infos" transform="translate(19.99,0.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2126,8 +2126,8 @@
                 <circle cx="20.38" cy="3.47" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="20.80,6.38 20.40,3.57"/>
-                <g class="nad-edge-infos" transform="translate(20.76,6.08)">
+                <polyline points="20.85,6.68 20.40,3.57"/>
+                <g class="nad-edge-infos" transform="translate(20.80,6.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2148,8 +2148,8 @@
         </g>
         <g id="278" class="nad-vl120to180-0" title="L25-27-1">
             <g>
-                <polyline points="21.41,7.15 24.04,8.19"/>
-                <g class="nad-edge-infos" transform="translate(21.69,7.26)">
+                <polyline points="21.14,7.04 24.04,8.19"/>
+                <g class="nad-edge-infos" transform="translate(21.41,7.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2167,8 +2167,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="26.68,9.23 24.04,8.19"/>
-                <g class="nad-edge-infos" transform="translate(26.40,9.12)">
+                <polyline points="26.95,9.34 24.04,8.19"/>
+                <g class="nad-edge-infos" transform="translate(26.68,9.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2188,8 +2188,8 @@
         </g>
         <g id="279" class="nad-vl120to180-1" title="L26-30-1">
             <g>
-                <polyline points="19.69,-0.34 18.30,-3.63"/>
-                <g class="nad-edge-infos" transform="translate(19.57,-0.62)">
+                <polyline points="19.80,-0.06 18.30,-3.63"/>
+                <g class="nad-edge-infos" transform="translate(19.69,-0.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2207,8 +2207,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.92,-6.92 18.30,-3.63"/>
-                <g class="nad-edge-infos" transform="translate(17.03,-6.64)">
+                <polyline points="16.80,-7.19 18.30,-3.63"/>
+                <g class="nad-edge-infos" transform="translate(16.92,-6.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2228,8 +2228,8 @@
         </g>
         <g id="280" class="nad-vl120to180-0" title="L27-28-1">
             <g>
-                <polyline points="27.76,9.31 29.58,8.90"/>
-                <g class="nad-edge-infos" transform="translate(28.05,9.24)">
+                <polyline points="27.47,9.38 29.58,8.90"/>
+                <g class="nad-edge-infos" transform="translate(27.76,9.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2247,8 +2247,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="31.40,8.48 29.58,8.90"/>
-                <g class="nad-edge-infos" transform="translate(31.11,8.55)">
+                <polyline points="31.69,8.42 29.58,8.90"/>
+                <g class="nad-edge-infos" transform="translate(31.40,8.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2268,8 +2268,8 @@
         </g>
         <g id="281" class="nad-vl120to180-0" title="L27-32-1">
             <g>
-                <polyline points="26.78,9.05 25.80,8.17"/>
-                <g class="nad-edge-infos" transform="translate(26.56,8.85)">
+                <polyline points="27.01,9.25 25.80,8.17"/>
+                <g class="nad-edge-infos" transform="translate(26.78,9.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2287,8 +2287,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="24.81,7.28 25.80,8.17"/>
-                <g class="nad-edge-infos" transform="translate(25.04,7.48)">
+                <polyline points="24.59,7.08 25.80,8.17"/>
+                <g class="nad-edge-infos" transform="translate(24.81,7.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2308,8 +2308,8 @@
         </g>
         <g id="282" class="nad-vl120to180-0" title="L27-115-1">
             <g>
-                <polyline points="27.35,9.99 27.83,11.74"/>
-                <g class="nad-edge-infos" transform="translate(27.43,10.28)">
+                <polyline points="27.28,9.70 27.83,11.74"/>
+                <g class="nad-edge-infos" transform="translate(27.35,9.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2327,8 +2327,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="28.30,13.49 27.83,11.74"/>
-                <g class="nad-edge-infos" transform="translate(28.22,13.20)">
+                <polyline points="28.38,13.78 27.83,11.74"/>
+                <g class="nad-edge-infos" transform="translate(28.30,13.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2348,8 +2348,8 @@
         </g>
         <g id="283" class="nad-vl120to180-0" title="L28-29-1">
             <g>
-                <polyline points="32.03,7.79 32.24,6.33"/>
-                <g class="nad-edge-infos" transform="translate(32.08,7.50)">
+                <polyline points="31.99,8.09 32.24,6.33"/>
+                <g class="nad-edge-infos" transform="translate(32.03,7.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2367,8 +2367,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="32.44,4.87 32.24,6.33"/>
-                <g class="nad-edge-infos" transform="translate(32.40,5.17)">
+                <polyline points="32.49,4.58 32.24,6.33"/>
+                <g class="nad-edge-infos" transform="translate(32.44,4.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2388,8 +2388,8 @@
         </g>
         <g id="284" class="nad-vl120to180-0" title="L29-31-1">
             <g>
-                <polyline points="32.04,4.01 30.47,3.04"/>
-                <g class="nad-edge-infos" transform="translate(31.78,3.85)">
+                <polyline points="32.29,4.17 30.47,3.04"/>
+                <g class="nad-edge-infos" transform="translate(32.04,4.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2407,8 +2407,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="28.91,2.08 30.47,3.04"/>
-                <g class="nad-edge-infos" transform="translate(29.17,2.23)">
+                <polyline points="28.66,1.92 30.47,3.04"/>
+                <g class="nad-edge-infos" transform="translate(28.91,2.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2428,8 +2428,8 @@
         </g>
         <g id="285" class="nad-vl120to180-1" title="L30-38-1">
             <g>
-                <polyline points="16.18,-7.19 12.00,-5.16"/>
-                <g class="nad-edge-infos" transform="translate(15.91,-7.06)">
+                <polyline points="16.45,-7.32 12.00,-5.16"/>
+                <g class="nad-edge-infos" transform="translate(16.18,-7.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-115.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2447,8 +2447,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.81,-3.13 12.00,-5.16"/>
-                <g class="nad-edge-infos" transform="translate(8.08,-3.26)">
+                <polyline points="7.54,-3.00 12.00,-5.16"/>
+                <g class="nad-edge-infos" transform="translate(7.81,-3.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2468,8 +2468,8 @@
         </g>
         <g id="286" class="nad-vl120to180-0" title="L31-32-1">
             <g>
-                <polyline points="28.07,2.22 26.41,4.34"/>
-                <g class="nad-edge-infos" transform="translate(27.89,2.46)">
+                <polyline points="28.26,1.99 26.41,4.34"/>
+                <g class="nad-edge-infos" transform="translate(28.07,2.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2487,8 +2487,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="24.74,6.45 26.41,4.34"/>
-                <g class="nad-edge-infos" transform="translate(24.93,6.21)">
+                <polyline points="24.56,6.69 26.41,4.34"/>
+                <g class="nad-edge-infos" transform="translate(24.74,6.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2508,8 +2508,8 @@
         </g>
         <g id="287" class="nad-vl120to180-0" title="L32-113-1">
             <g>
-                <polyline points="24.44,6.33 24.67,3.89"/>
-                <g class="nad-edge-infos" transform="translate(24.47,6.03)">
+                <polyline points="24.42,6.63 24.67,3.89"/>
+                <g class="nad-edge-infos" transform="translate(24.44,6.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2527,8 +2527,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="24.90,1.45 24.67,3.89"/>
-                <g class="nad-edge-infos" transform="translate(24.87,1.75)">
+                <polyline points="24.93,1.16 24.67,3.89"/>
+                <g class="nad-edge-infos" transform="translate(24.90,1.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2548,8 +2548,8 @@
         </g>
         <g id="288" class="nad-vl120to180-0" title="L32-114-1">
             <g>
-                <polyline points="24.46,7.46 24.76,9.85"/>
-                <g class="nad-edge-infos" transform="translate(24.50,7.76)">
+                <polyline points="24.42,7.17 24.76,9.85"/>
+                <g class="nad-edge-infos" transform="translate(24.46,7.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(172.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2567,8 +2567,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="25.06,12.25 24.76,9.85"/>
-                <g class="nad-edge-infos" transform="translate(25.02,11.95)">
+                <polyline points="25.10,12.54 24.76,9.85"/>
+                <g class="nad-edge-infos" transform="translate(25.06,12.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2588,8 +2588,8 @@
         </g>
         <g id="289" class="nad-vl120to180-0" title="L33-37-1">
             <g>
-                <polyline points="13.92,-10.80 12.08,-9.57"/>
-                <g class="nad-edge-infos" transform="translate(13.67,-10.64)">
+                <polyline points="14.17,-10.97 12.08,-9.57"/>
+                <g class="nad-edge-infos" transform="translate(13.92,-10.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2607,8 +2607,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.24,-8.34 12.08,-9.57"/>
-                <g class="nad-edge-infos" transform="translate(10.49,-8.51)">
+                <polyline points="9.99,-8.18 12.08,-9.57"/>
+                <g class="nad-edge-infos" transform="translate(10.24,-8.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2628,8 +2628,8 @@
         </g>
         <g id="290" class="nad-vl120to180-0" title="L34-36-1">
             <g>
-                <polyline points="6.71,-9.66 5.58,-11.46"/>
-                <g class="nad-edge-infos" transform="translate(6.55,-9.92)">
+                <polyline points="6.87,-9.41 5.58,-11.46"/>
+                <g class="nad-edge-infos" transform="translate(6.71,-9.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2647,8 +2647,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.45,-13.25 5.58,-11.46"/>
-                <g class="nad-edge-infos" transform="translate(4.61,-12.99)">
+                <polyline points="4.29,-13.50 5.58,-11.46"/>
+                <g class="nad-edge-infos" transform="translate(4.45,-13.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2668,8 +2668,8 @@
         </g>
         <g id="291" class="nad-vl120to180-0" title="L34-37-1">
             <g>
-                <polyline points="7.54,-8.96 8.39,-8.60"/>
-                <g class="nad-edge-infos" transform="translate(7.82,-8.84)">
+                <polyline points="7.27,-9.08 8.39,-8.60"/>
+                <g class="nad-edge-infos" transform="translate(7.54,-8.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2687,8 +2687,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.24,-8.25 8.39,-8.60"/>
-                <g class="nad-edge-infos" transform="translate(8.97,-8.36)">
+                <polyline points="9.52,-8.13 8.39,-8.60"/>
+                <g class="nad-edge-infos" transform="translate(9.24,-8.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2708,8 +2708,8 @@
         </g>
         <g id="292" class="nad-vl120to180-0" title="L34-43-1">
             <g>
-                <polyline points="6.58,-8.82 5.16,-7.63"/>
-                <g class="nad-edge-infos" transform="translate(6.35,-8.62)">
+                <polyline points="6.81,-9.01 5.16,-7.63"/>
+                <g class="nad-edge-infos" transform="translate(6.58,-8.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2727,8 +2727,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.75,-6.45 5.16,-7.63"/>
-                <g class="nad-edge-infos" transform="translate(3.98,-6.64)">
+                <polyline points="3.52,-6.26 5.16,-7.63"/>
+                <g class="nad-edge-infos" transform="translate(3.75,-6.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2748,8 +2748,8 @@
         </g>
         <g id="293" class="nad-vl120to180-0" title="L35-36-1">
             <g>
-                <polyline points="6.93,-13.68 5.82,-13.70"/>
-                <g class="nad-edge-infos" transform="translate(6.63,-13.68)">
+                <polyline points="7.23,-13.67 5.82,-13.70"/>
+                <g class="nad-edge-infos" transform="translate(6.93,-13.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2767,8 +2767,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.71,-13.72 5.82,-13.70"/>
-                <g class="nad-edge-infos" transform="translate(5.01,-13.71)">
+                <polyline points="4.41,-13.72 5.82,-13.70"/>
+                <g class="nad-edge-infos" transform="translate(4.71,-13.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2788,8 +2788,8 @@
         </g>
         <g id="294" class="nad-vl120to180-0" title="L35-37-1">
             <g>
-                <polyline points="7.72,-13.14 8.64,-10.85"/>
-                <g class="nad-edge-infos" transform="translate(7.83,-12.86)">
+                <polyline points="7.60,-13.41 8.64,-10.85"/>
+                <g class="nad-edge-infos" transform="translate(7.72,-13.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(158.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2807,8 +2807,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.56,-8.56 8.64,-10.85"/>
-                <g class="nad-edge-infos" transform="translate(9.44,-8.83)">
+                <polyline points="9.67,-8.28 8.64,-10.85"/>
+                <g class="nad-edge-infos" transform="translate(9.56,-8.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-21.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2828,8 +2828,8 @@
         </g>
         <g id="295" title="T38-37-1">
             <g class="nad-vl120to180-1">
-                <polyline points="7.55,-3.40 8.53,-5.45"/>
-                <g class="nad-edge-infos" transform="translate(7.68,-3.67)">
+                <polyline points="7.42,-3.12 8.53,-5.45"/>
+                <g class="nad-edge-infos" transform="translate(7.55,-3.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2848,8 +2848,8 @@
                 <circle cx="8.49" cy="-5.36" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="9.52,-7.51 8.53,-5.45"/>
-                <g class="nad-edge-infos" transform="translate(9.39,-7.24)">
+                <polyline points="9.65,-7.78 8.53,-5.45"/>
+                <g class="nad-edge-infos" transform="translate(9.52,-7.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2870,8 +2870,8 @@
         </g>
         <g id="296" class="nad-vl120to180-0" title="L37-39-1">
             <g>
-                <polyline points="9.96,-7.49 10.30,-6.56"/>
-                <g class="nad-edge-infos" transform="translate(10.06,-7.21)">
+                <polyline points="9.86,-7.77 10.30,-6.56"/>
+                <g class="nad-edge-infos" transform="translate(9.96,-7.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2889,8 +2889,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.64,-5.62 10.30,-6.56"/>
-                <g class="nad-edge-infos" transform="translate(10.54,-5.90)">
+                <polyline points="10.74,-5.34 10.30,-6.56"/>
+                <g class="nad-edge-infos" transform="translate(10.64,-5.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2910,8 +2910,8 @@
         </g>
         <g id="297" class="nad-vl120to180-0" title="L37-40-1">
             <g>
-                <polyline points="9.82,-7.46 10.05,-4.67"/>
-                <g class="nad-edge-infos" transform="translate(9.84,-7.16)">
+                <polyline points="9.79,-7.76 10.05,-4.67"/>
+                <g class="nad-edge-infos" transform="translate(9.82,-7.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2929,8 +2929,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.29,-1.88 10.05,-4.67"/>
-                <g class="nad-edge-infos" transform="translate(10.26,-2.18)">
+                <polyline points="10.31,-1.58 10.05,-4.67"/>
+                <g class="nad-edge-infos" transform="translate(10.29,-1.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2950,8 +2950,8 @@
         </g>
         <g id="298" class="nad-vl120to180-1" title="L38-65-1">
             <g>
-                <polyline points="6.95,-2.43 3.37,2.13"/>
-                <g class="nad-edge-infos" transform="translate(6.76,-2.20)">
+                <polyline points="7.13,-2.67 3.37,2.13"/>
+                <g class="nad-edge-infos" transform="translate(6.95,-2.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2969,8 +2969,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.21,6.70 3.37,2.13"/>
-                <g class="nad-edge-infos" transform="translate(-0.02,6.46)">
+                <polyline points="-0.39,6.93 3.37,2.13"/>
+                <g class="nad-edge-infos" transform="translate(-0.21,6.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2990,8 +2990,8 @@
         </g>
         <g id="299" class="nad-vl120to180-0" title="L39-40-1">
             <g>
-                <polyline points="10.76,-4.52 10.58,-3.20"/>
-                <g class="nad-edge-infos" transform="translate(10.72,-4.22)">
+                <polyline points="10.80,-4.82 10.58,-3.20"/>
+                <g class="nad-edge-infos" transform="translate(10.76,-4.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3009,8 +3009,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.41,-1.88 10.58,-3.20"/>
-                <g class="nad-edge-infos" transform="translate(10.45,-2.18)">
+                <polyline points="10.37,-1.58 10.58,-3.20"/>
+                <g class="nad-edge-infos" transform="translate(10.41,-1.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3030,8 +3030,8 @@
         </g>
         <g id="300" class="nad-vl120to180-0" title="L40-41-1">
             <g>
-                <polyline points="10.36,-0.74 10.42,0.47"/>
-                <g class="nad-edge-infos" transform="translate(10.38,-0.44)">
+                <polyline points="10.35,-1.04 10.42,0.47"/>
+                <g class="nad-edge-infos" transform="translate(10.36,-0.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3049,8 +3049,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.48,1.69 10.42,0.47"/>
-                <g class="nad-edge-infos" transform="translate(10.47,1.39)">
+                <polyline points="10.50,1.99 10.42,0.47"/>
+                <g class="nad-edge-infos" transform="translate(10.48,1.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-2.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3070,8 +3070,8 @@
         </g>
         <g id="301" class="nad-vl120to180-0" title="L40-42-1">
             <g>
-                <polyline points="10.20,-0.76 9.55,1.97"/>
-                <g class="nad-edge-infos" transform="translate(10.13,-0.47)">
+                <polyline points="10.27,-1.05 9.55,1.97"/>
+                <g class="nad-edge-infos" transform="translate(10.20,-0.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3089,8 +3089,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.90,4.69 9.55,1.97"/>
-                <g class="nad-edge-infos" transform="translate(8.97,4.40)">
+                <polyline points="8.83,4.99 9.55,1.97"/>
+                <g class="nad-edge-infos" transform="translate(8.90,4.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3110,8 +3110,8 @@
         </g>
         <g id="302" class="nad-vl120to180-0" title="L41-42-1">
             <g>
-                <polyline points="10.22,2.75 9.64,3.75"/>
-                <g class="nad-edge-infos" transform="translate(10.07,3.01)">
+                <polyline points="10.37,2.49 9.64,3.75"/>
+                <g class="nad-edge-infos" transform="translate(10.22,2.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3129,8 +3129,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.06,4.76 9.64,3.75"/>
-                <g class="nad-edge-infos" transform="translate(9.21,4.50)">
+                <polyline points="8.91,5.02 9.64,3.75"/>
+                <g class="nad-edge-infos" transform="translate(9.06,4.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3150,7 +3150,7 @@
         </g>
         <g id="303" class="nad-vl120to180-0" title="L42-49-1">
             <g>
-                <polyline points="8.27,5.53 8.07,5.64 6.16,8.89"/>
+                <polyline points="8.54,5.38 8.07,5.64 6.16,8.89"/>
                 <g class="nad-edge-infos" transform="translate(7.92,5.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.53)">
@@ -3169,7 +3169,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.25,12.37 4.25,12.14 6.16,8.89"/>
+                <polyline points="4.25,12.67 4.25,12.14 6.16,8.89"/>
                 <g class="nad-edge-infos" transform="translate(4.40,11.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.47)">
@@ -3190,7 +3190,7 @@
         </g>
         <g id="304" class="nad-vl120to180-0" title="L42-49-2">
             <g>
-                <polyline points="8.77,5.82 8.76,6.05 6.85,9.30"/>
+                <polyline points="8.77,5.52 8.76,6.05 6.85,9.30"/>
                 <g class="nad-edge-infos" transform="translate(8.61,6.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.53)">
@@ -3209,7 +3209,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.74,12.66 4.94,12.55 6.85,9.30"/>
+                <polyline points="4.48,12.81 4.94,12.55 6.85,9.30"/>
                 <g class="nad-edge-infos" transform="translate(5.09,12.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.47)">
@@ -3230,8 +3230,8 @@
         </g>
         <g id="305" class="nad-vl120to180-0" title="L43-44-1">
             <g>
-                <polyline points="3.30,-5.51 3.25,-3.21"/>
-                <g class="nad-edge-infos" transform="translate(3.29,-5.21)">
+                <polyline points="3.30,-5.81 3.25,-3.21"/>
+                <g class="nad-edge-infos" transform="translate(3.30,-5.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3249,8 +3249,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.20,-0.90 3.25,-3.21"/>
-                <g class="nad-edge-infos" transform="translate(3.21,-1.20)">
+                <polyline points="3.20,-0.60 3.25,-3.21"/>
+                <g class="nad-edge-infos" transform="translate(3.20,-0.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3270,8 +3270,8 @@
         </g>
         <g id="306" class="nad-vl120to180-0" title="L44-45-1">
             <g>
-                <polyline points="3.32,0.23 3.92,2.76"/>
-                <g class="nad-edge-infos" transform="translate(3.39,0.52)">
+                <polyline points="3.25,-0.07 3.92,2.76"/>
+                <g class="nad-edge-infos" transform="translate(3.32,0.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(166.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3289,8 +3289,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.52,5.29 3.92,2.76"/>
-                <g class="nad-edge-infos" transform="translate(4.45,5.00)">
+                <polyline points="4.59,5.58 3.92,2.76"/>
+                <g class="nad-edge-infos" transform="translate(4.52,5.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-13.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3310,8 +3310,8 @@
         </g>
         <g id="307" class="nad-vl120to180-0" title="L45-46-1">
             <g>
-                <polyline points="4.93,6.35 5.60,7.57"/>
-                <g class="nad-edge-infos" transform="translate(5.07,6.61)">
+                <polyline points="4.78,6.08 5.60,7.57"/>
+                <g class="nad-edge-infos" transform="translate(4.93,6.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(151.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3329,8 +3329,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.27,8.80 5.60,7.57"/>
-                <g class="nad-edge-infos" transform="translate(6.12,8.53)">
+                <polyline points="6.41,9.06 5.60,7.57"/>
+                <g class="nad-edge-infos" transform="translate(6.27,8.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-28.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3350,8 +3350,8 @@
         </g>
         <g id="308" class="nad-vl120to180-0" title="L45-49-1">
             <g>
-                <polyline points="4.62,6.42 4.45,9.39"/>
-                <g class="nad-edge-infos" transform="translate(4.60,6.72)">
+                <polyline points="4.64,6.12 4.45,9.39"/>
+                <g class="nad-edge-infos" transform="translate(4.62,6.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3369,8 +3369,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.28,12.37 4.45,9.39"/>
-                <g class="nad-edge-infos" transform="translate(4.30,12.07)">
+                <polyline points="4.26,12.67 4.45,9.39"/>
+                <g class="nad-edge-infos" transform="translate(4.28,12.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3390,8 +3390,8 @@
         </g>
         <g id="309" class="nad-vl120to180-0" title="L46-47-1">
             <g>
-                <polyline points="5.98,9.20 4.51,8.94"/>
-                <g class="nad-edge-infos" transform="translate(5.68,9.15)">
+                <polyline points="6.27,9.25 4.51,8.94"/>
+                <g class="nad-edge-infos" transform="translate(5.98,9.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3409,8 +3409,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.03,8.69 4.51,8.94"/>
-                <g class="nad-edge-infos" transform="translate(3.33,8.74)">
+                <polyline points="2.74,8.64 4.51,8.94"/>
+                <g class="nad-edge-infos" transform="translate(3.03,8.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3430,8 +3430,8 @@
         </g>
         <g id="310" class="nad-vl120to180-0" title="L46-48-1">
             <g>
-                <polyline points="6.80,9.80 7.43,11.02"/>
-                <g class="nad-edge-infos" transform="translate(6.94,10.07)">
+                <polyline points="6.66,9.54 7.43,11.02"/>
+                <g class="nad-edge-infos" transform="translate(6.80,9.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3449,8 +3449,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.05,12.23 7.43,11.02"/>
-                <g class="nad-edge-infos" transform="translate(7.91,11.96)">
+                <polyline points="8.19,12.50 7.43,11.02"/>
+                <g class="nad-edge-infos" transform="translate(8.05,12.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3470,8 +3470,8 @@
         </g>
         <g id="311" class="nad-vl120to180-0" title="L47-49-1">
             <g>
-                <polyline points="2.69,9.12 3.36,10.77"/>
-                <g class="nad-edge-infos" transform="translate(2.80,9.40)">
+                <polyline points="2.57,8.84 3.36,10.77"/>
+                <g class="nad-edge-infos" transform="translate(2.69,9.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3489,8 +3489,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.03,12.41 3.36,10.77"/>
-                <g class="nad-edge-infos" transform="translate(3.92,12.14)">
+                <polyline points="4.14,12.69 3.36,10.77"/>
+                <g class="nad-edge-infos" transform="translate(4.03,12.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3510,8 +3510,8 @@
         </g>
         <g id="312" class="nad-vl120to180-0" title="L47-69-1">
             <g>
-                <polyline points="1.99,8.29 -0.64,6.66"/>
-                <g class="nad-edge-infos" transform="translate(1.73,8.13)">
+                <polyline points="2.24,8.45 -0.64,6.66"/>
+                <g class="nad-edge-infos" transform="translate(1.99,8.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3529,8 +3529,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.26,5.02 -0.64,6.66"/>
-                <g class="nad-edge-infos" transform="translate(-3.01,5.18)">
+                <polyline points="-3.52,4.87 -0.64,6.66"/>
+                <g class="nad-edge-infos" transform="translate(-3.26,5.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3550,8 +3550,8 @@
         </g>
         <g id="313" class="nad-vl120to180-0" title="L48-49-1">
             <g>
-                <polyline points="7.74,12.76 6.28,12.84"/>
-                <g class="nad-edge-infos" transform="translate(7.44,12.78)">
+                <polyline points="8.04,12.75 6.28,12.84"/>
+                <g class="nad-edge-infos" transform="translate(7.74,12.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3569,8 +3569,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.81,12.91 6.28,12.84"/>
-                <g class="nad-edge-infos" transform="translate(5.11,12.90)">
+                <polyline points="4.51,12.93 6.28,12.84"/>
+                <g class="nad-edge-infos" transform="translate(4.81,12.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3590,8 +3590,8 @@
         </g>
         <g id="314" class="nad-vl120to180-0" title="L49-50-1">
             <g>
-                <polyline points="4.43,13.48 5.04,15.26"/>
-                <g class="nad-edge-infos" transform="translate(4.53,13.76)">
+                <polyline points="4.33,13.20 5.04,15.26"/>
+                <g class="nad-edge-infos" transform="translate(4.43,13.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3609,8 +3609,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.66,17.03 5.04,15.26"/>
-                <g class="nad-edge-infos" transform="translate(5.56,16.75)">
+                <polyline points="5.76,17.32 5.04,15.26"/>
+                <g class="nad-edge-infos" transform="translate(5.66,17.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3630,8 +3630,8 @@
         </g>
         <g id="315" class="nad-vl120to180-0" title="L49-51-1">
             <g>
-                <polyline points="4.62,13.37 7.37,16.54"/>
-                <g class="nad-edge-infos" transform="translate(4.82,13.60)">
+                <polyline points="4.42,13.15 7.37,16.54"/>
+                <g class="nad-edge-infos" transform="translate(4.62,13.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3649,8 +3649,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.12,19.71 7.37,16.54"/>
-                <g class="nad-edge-infos" transform="translate(9.92,19.48)">
+                <polyline points="10.32,19.93 7.37,16.54"/>
+                <g class="nad-edge-infos" transform="translate(10.12,19.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3670,7 +3670,7 @@
         </g>
         <g id="316" class="nad-vl120to180-0" title="L49-54-1">
             <g>
-                <polyline points="3.95,13.43 3.83,13.63 3.76,18.08"/>
+                <polyline points="4.11,13.17 3.83,13.63 3.76,18.08"/>
                 <g class="nad-edge-infos" transform="translate(3.83,13.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.07)">
@@ -3689,7 +3689,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.80,22.74 3.69,22.54 3.76,18.08"/>
+                <polyline points="3.95,23.00 3.69,22.54 3.76,18.08"/>
                 <g class="nad-edge-infos" transform="translate(3.69,22.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.93)">
@@ -3710,7 +3710,7 @@
         </g>
         <g id="317" class="nad-vl120to180-0" title="L49-54-2">
             <g>
-                <polyline points="4.52,13.44 4.63,13.64 4.56,18.10"/>
+                <polyline points="4.38,13.18 4.63,13.64 4.56,18.10"/>
                 <g class="nad-edge-infos" transform="translate(4.63,13.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.07)">
@@ -3729,7 +3729,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.37,22.75 4.49,22.55 4.56,18.10"/>
+                <polyline points="4.22,23.01 4.49,22.55 4.56,18.10"/>
                 <g class="nad-edge-infos" transform="translate(4.49,22.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.93)">
@@ -3750,7 +3750,7 @@
         </g>
         <g id="318" class="nad-vl120to180-0" title="L49-66-1">
             <g>
-                <polyline points="3.70,12.79 3.47,12.73 0.83,13.42"/>
+                <polyline points="3.98,12.87 3.47,12.73 0.83,13.42"/>
                 <g class="nad-edge-infos" transform="translate(3.18,12.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.63)">
@@ -3769,7 +3769,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.97,14.27 -1.81,14.11 0.83,13.42"/>
+                <polyline points="-2.19,14.48 -1.81,14.11 0.83,13.42"/>
                 <g class="nad-edge-infos" transform="translate(-1.52,14.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.37)">
@@ -3790,7 +3790,7 @@
         </g>
         <g id="319" class="nad-vl120to180-0" title="L49-66-2">
             <g>
-                <polyline points="3.84,13.34 3.68,13.50 1.03,14.19"/>
+                <polyline points="4.05,13.13 3.68,13.50 1.03,14.19"/>
                 <g class="nad-edge-infos" transform="translate(3.39,13.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.63)">
@@ -3809,7 +3809,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.83,14.82 -1.61,14.88 1.03,14.19"/>
+                <polyline points="-2.12,14.74 -1.61,14.88 1.03,14.19"/>
                 <g class="nad-edge-infos" transform="translate(-1.32,14.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.37)">
@@ -3830,8 +3830,8 @@
         </g>
         <g id="320" class="nad-vl120to180-0" title="L49-69-1">
             <g>
-                <polyline points="3.85,12.53 0.25,8.83"/>
-                <g class="nad-edge-infos" transform="translate(3.64,12.32)">
+                <polyline points="4.06,12.75 0.25,8.83"/>
+                <g class="nad-edge-infos" transform="translate(3.85,12.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3849,8 +3849,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.35,5.13 0.25,8.83"/>
-                <g class="nad-edge-infos" transform="translate(-3.14,5.35)">
+                <polyline points="-3.56,4.92 0.25,8.83"/>
+                <g class="nad-edge-infos" transform="translate(-3.35,5.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3870,8 +3870,8 @@
         </g>
         <g id="321" class="nad-vl120to180-0" title="L50-57-1">
             <g>
-                <polyline points="5.97,18.13 6.35,19.73"/>
-                <g class="nad-edge-infos" transform="translate(6.04,18.42)">
+                <polyline points="5.90,17.83 6.35,19.73"/>
+                <g class="nad-edge-infos" transform="translate(5.97,18.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(166.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3889,8 +3889,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.72,21.34 6.35,19.73"/>
-                <g class="nad-edge-infos" transform="translate(6.65,21.05)">
+                <polyline points="6.79,21.63 6.35,19.73"/>
+                <g class="nad-edge-infos" transform="translate(6.72,21.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-13.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3910,8 +3910,8 @@
         </g>
         <g id="322" class="nad-vl120to180-0" title="L51-52-1">
             <g>
-                <polyline points="10.97,20.45 12.49,21.46"/>
-                <g class="nad-edge-infos" transform="translate(11.22,20.62)">
+                <polyline points="10.72,20.29 12.49,21.46"/>
+                <g class="nad-edge-infos" transform="translate(10.97,20.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3929,8 +3929,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="14.02,22.48 12.49,21.46"/>
-                <g class="nad-edge-infos" transform="translate(13.77,22.31)">
+                <polyline points="14.27,22.64 12.49,21.46"/>
+                <g class="nad-edge-infos" transform="translate(14.02,22.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3950,8 +3950,8 @@
         </g>
         <g id="323" class="nad-vl120to180-0" title="L51-58-1">
             <g>
-                <polyline points="10.38,20.70 9.82,23.53"/>
-                <g class="nad-edge-infos" transform="translate(10.32,20.99)">
+                <polyline points="10.44,20.40 9.82,23.53"/>
+                <g class="nad-edge-infos" transform="translate(10.38,20.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3969,8 +3969,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.26,26.37 9.82,23.53"/>
-                <g class="nad-edge-infos" transform="translate(9.32,26.07)">
+                <polyline points="9.20,26.66 9.82,23.53"/>
+                <g class="nad-edge-infos" transform="translate(9.26,26.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3990,8 +3990,8 @@
         </g>
         <g id="324" class="nad-vl120to180-0" title="L52-53-1">
             <g>
-                <polyline points="13.99,23.05 12.86,23.64"/>
-                <g class="nad-edge-infos" transform="translate(13.72,23.19)">
+                <polyline points="14.25,22.91 12.86,23.64"/>
+                <g class="nad-edge-infos" transform="translate(13.99,23.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4009,8 +4009,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.73,24.23 12.86,23.64"/>
-                <g class="nad-edge-infos" transform="translate(12.00,24.09)">
+                <polyline points="11.46,24.37 12.86,23.64"/>
+                <g class="nad-edge-infos" transform="translate(11.73,24.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4030,8 +4030,8 @@
         </g>
         <g id="325" class="nad-vl120to180-0" title="L53-54-1">
             <g>
-                <polyline points="10.66,24.39 7.65,23.87"/>
-                <g class="nad-edge-infos" transform="translate(10.37,24.34)">
+                <polyline points="10.96,24.45 7.65,23.87"/>
+                <g class="nad-edge-infos" transform="translate(10.66,24.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4049,8 +4049,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.64,23.34 7.65,23.87"/>
-                <g class="nad-edge-infos" transform="translate(4.94,23.39)">
+                <polyline points="4.34,23.29 7.65,23.87"/>
+                <g class="nad-edge-infos" transform="translate(4.64,23.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4070,8 +4070,8 @@
         </g>
         <g id="326" class="nad-vl120to180-0" title="L54-55-1">
             <g>
-                <polyline points="3.92,23.79 3.32,25.82"/>
-                <g class="nad-edge-infos" transform="translate(3.83,24.08)">
+                <polyline points="4.00,23.50 3.32,25.82"/>
+                <g class="nad-edge-infos" transform="translate(3.92,23.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-163.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4089,8 +4089,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.73,27.86 3.32,25.82"/>
-                <g class="nad-edge-infos" transform="translate(2.81,27.57)">
+                <polyline points="2.64,28.15 3.32,25.82"/>
+                <g class="nad-edge-infos" transform="translate(2.73,27.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(16.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4110,8 +4110,8 @@
         </g>
         <g id="327" class="nad-vl120to180-0" title="L54-56-1">
             <g>
-                <polyline points="4.25,23.78 4.58,24.82"/>
-                <g class="nad-edge-infos" transform="translate(4.34,24.07)">
+                <polyline points="4.16,23.50 4.58,24.82"/>
+                <g class="nad-edge-infos" transform="translate(4.25,23.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(162.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4129,8 +4129,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.91,25.87 4.58,24.82"/>
-                <g class="nad-edge-infos" transform="translate(4.82,25.58)">
+                <polyline points="5.00,26.15 4.58,24.82"/>
+                <g class="nad-edge-infos" transform="translate(4.91,25.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4150,8 +4150,8 @@
         </g>
         <g id="328" class="nad-vl120to180-0" title="L54-59-1">
             <g>
-                <polyline points="3.59,23.54 2.02,24.50"/>
-                <g class="nad-edge-infos" transform="translate(3.34,23.70)">
+                <polyline points="3.85,23.38 2.02,24.50"/>
+                <g class="nad-edge-infos" transform="translate(3.59,23.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4169,8 +4169,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.45,25.47 2.02,24.50"/>
-                <g class="nad-edge-infos" transform="translate(0.70,25.31)">
+                <polyline points="0.19,25.63 2.02,24.50"/>
+                <g class="nad-edge-infos" transform="translate(0.45,25.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4190,8 +4190,8 @@
         </g>
         <g id="329" class="nad-vl120to180-0" title="L55-56-1">
             <g>
-                <polyline points="3.02,28.05 3.83,27.41"/>
-                <g class="nad-edge-infos" transform="translate(3.25,27.87)">
+                <polyline points="2.78,28.24 3.83,27.41"/>
+                <g class="nad-edge-infos" transform="translate(3.02,28.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4209,8 +4209,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.64,26.76 3.83,27.41"/>
-                <g class="nad-edge-infos" transform="translate(4.40,26.95)">
+                <polyline points="4.87,26.58 3.83,27.41"/>
+                <g class="nad-edge-infos" transform="translate(4.64,26.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4230,8 +4230,8 @@
         </g>
         <g id="330" class="nad-vl120to180-0" title="L55-59-1">
             <g>
-                <polyline points="2.17,28.00 1.27,27.09"/>
-                <g class="nad-edge-infos" transform="translate(1.96,27.79)">
+                <polyline points="2.38,28.21 1.27,27.09"/>
+                <g class="nad-edge-infos" transform="translate(2.17,28.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4249,8 +4249,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.36,26.17 1.27,27.09"/>
-                <g class="nad-edge-infos" transform="translate(0.57,26.39)">
+                <polyline points="0.15,25.96 1.27,27.09"/>
+                <g class="nad-edge-infos" transform="translate(0.36,26.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4270,8 +4270,8 @@
         </g>
         <g id="331" class="nad-vl120to180-0" title="L56-57-1">
             <g>
-                <polyline points="5.29,25.88 5.97,24.15"/>
-                <g class="nad-edge-infos" transform="translate(5.40,25.60)">
+                <polyline points="5.18,26.16 5.97,24.15"/>
+                <g class="nad-edge-infos" transform="translate(5.29,25.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4289,8 +4289,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.64,22.43 5.97,24.15"/>
-                <g class="nad-edge-infos" transform="translate(6.53,22.70)">
+                <polyline points="6.75,22.15 5.97,24.15"/>
+                <g class="nad-edge-infos" transform="translate(6.64,22.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4310,8 +4310,8 @@
         </g>
         <g id="332" class="nad-vl120to180-0" title="L56-58-1">
             <g>
-                <polyline points="5.65,26.48 7.12,26.67"/>
-                <g class="nad-edge-infos" transform="translate(5.95,26.52)">
+                <polyline points="5.35,26.44 7.12,26.67"/>
+                <g class="nad-edge-infos" transform="translate(5.65,26.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4329,8 +4329,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.59,26.85 7.12,26.67"/>
-                <g class="nad-edge-infos" transform="translate(8.29,26.82)">
+                <polyline points="8.88,26.89 7.12,26.67"/>
+                <g class="nad-edge-infos" transform="translate(8.59,26.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4350,7 +4350,7 @@
         </g>
         <g id="333" class="nad-vl120to180-0" title="L56-59-1">
             <g>
-                <polyline points="4.63,26.07 4.44,25.93 2.57,25.69"/>
+                <polyline points="4.87,26.25 4.44,25.93 2.57,25.69"/>
                 <g class="nad-edge-infos" transform="translate(4.15,25.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.87)">
@@ -4369,7 +4369,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.49,25.55 0.70,25.46 2.57,25.69"/>
+                <polyline points="0.21,25.66 0.70,25.46 2.57,25.69"/>
                 <g class="nad-edge-infos" transform="translate(1.00,25.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.13)">
@@ -4390,7 +4390,7 @@
         </g>
         <g id="334" class="nad-vl120to180-0" title="L56-59-2">
             <g>
-                <polyline points="4.56,26.63 4.35,26.72 2.47,26.49"/>
+                <polyline points="4.83,26.51 4.35,26.72 2.47,26.49"/>
                 <g class="nad-edge-infos" transform="translate(4.05,26.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.87)">
@@ -4409,7 +4409,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.42,26.11 0.60,26.25 2.47,26.49"/>
+                <polyline points="0.18,25.93 0.60,26.25 2.47,26.49"/>
                 <g class="nad-edge-infos" transform="translate(0.90,26.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.13)">
@@ -4430,8 +4430,8 @@
         </g>
         <g id="335" class="nad-vl120to180-0" title="L59-60-1">
             <g>
-                <polyline points="-0.60,25.70 -3.12,25.37"/>
-                <g class="nad-edge-infos" transform="translate(-0.90,25.66)">
+                <polyline points="-0.30,25.73 -3.12,25.37"/>
+                <g class="nad-edge-infos" transform="translate(-0.60,25.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4449,8 +4449,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.64,25.05 -3.12,25.37"/>
-                <g class="nad-edge-infos" transform="translate(-5.34,25.09)">
+                <polyline points="-5.93,25.01 -3.12,25.37"/>
+                <g class="nad-edge-infos" transform="translate(-5.64,25.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4470,8 +4470,8 @@
         </g>
         <g id="336" class="nad-vl120to180-0" title="L59-61-1">
             <g>
-                <polyline points="-0.46,25.39 -1.80,24.20"/>
-                <g class="nad-edge-infos" transform="translate(-0.69,25.19)">
+                <polyline points="-0.24,25.59 -1.80,24.20"/>
+                <g class="nad-edge-infos" transform="translate(-0.46,25.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4489,8 +4489,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.13,23.01 -1.80,24.20"/>
-                <g class="nad-edge-infos" transform="translate(-2.91,23.21)">
+                <polyline points="-3.36,22.81 -1.80,24.20"/>
+                <g class="nad-edge-infos" transform="translate(-3.13,23.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4510,8 +4510,8 @@
         </g>
         <g id="337" title="T63-59-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-2.40,25.98 -1.50,25.90"/>
-                <g class="nad-edge-infos" transform="translate(-2.10,25.95)">
+                <polyline points="-2.70,26.01 -1.50,25.90"/>
+                <g class="nad-edge-infos" transform="translate(-2.40,25.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4530,8 +4530,8 @@
                 <circle cx="-1.60" cy="25.91" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.60,25.82 -1.50,25.90"/>
-                <g class="nad-edge-infos" transform="translate(-0.90,25.85)">
+                <polyline points="-0.31,25.79 -1.50,25.90"/>
+                <g class="nad-edge-infos" transform="translate(-0.60,25.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4552,8 +4552,8 @@
         </g>
         <g id="338" class="nad-vl120to180-0" title="L60-61-1">
             <g>
-                <polyline points="-5.78,24.60 -4.88,23.81"/>
-                <g class="nad-edge-infos" transform="translate(-5.55,24.40)">
+                <polyline points="-6.00,24.80 -4.88,23.81"/>
+                <g class="nad-edge-infos" transform="translate(-5.78,24.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4571,8 +4571,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.99,23.01 -4.88,23.81"/>
-                <g class="nad-edge-infos" transform="translate(-4.21,23.21)">
+                <polyline points="-3.76,22.81 -4.88,23.81"/>
+                <g class="nad-edge-infos" transform="translate(-3.99,23.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4592,8 +4592,8 @@
         </g>
         <g id="339" class="nad-vl120to180-0" title="L60-62-1">
             <g>
-                <polyline points="-6.22,24.41 -6.26,22.71"/>
-                <g class="nad-edge-infos" transform="translate(-6.22,24.11)">
+                <polyline points="-6.21,24.71 -6.26,22.71"/>
+                <g class="nad-edge-infos" transform="translate(-6.22,24.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4611,8 +4611,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.30,21.01 -6.26,22.71"/>
-                <g class="nad-edge-infos" transform="translate(-6.30,21.31)">
+                <polyline points="-6.31,20.71 -6.26,22.71"/>
+                <g class="nad-edge-infos" transform="translate(-6.30,21.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4632,8 +4632,8 @@
         </g>
         <g id="340" class="nad-vl120to180-0" title="L61-62-1">
             <g>
-                <polyline points="-4.01,22.28 -4.94,21.54"/>
-                <g class="nad-edge-infos" transform="translate(-4.24,22.09)">
+                <polyline points="-3.77,22.47 -4.94,21.54"/>
+                <g class="nad-edge-infos" transform="translate(-4.01,22.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-51.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4651,8 +4651,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.87,20.80 -4.94,21.54"/>
-                <g class="nad-edge-infos" transform="translate(-5.64,20.98)">
+                <polyline points="-6.11,20.61 -4.94,21.54"/>
+                <g class="nad-edge-infos" transform="translate(-5.87,20.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(128.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4672,8 +4672,8 @@
         </g>
         <g id="341" title="T64-61-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-2.07,19.19 -2.70,20.65"/>
-                <g class="nad-edge-infos" transform="translate(-2.19,19.46)">
+                <polyline points="-1.95,18.91 -2.70,20.65"/>
+                <g class="nad-edge-infos" transform="translate(-2.07,19.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4692,8 +4692,8 @@
                 <circle cx="-2.66" cy="20.56" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-3.33,22.11 -2.70,20.65"/>
-                <g class="nad-edge-infos" transform="translate(-3.21,21.84)">
+                <polyline points="-3.45,22.39 -2.70,20.65"/>
+                <g class="nad-edge-infos" transform="translate(-3.33,22.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4714,8 +4714,8 @@
         </g>
         <g id="342" class="nad-vl120to180-0" title="L62-66-1">
             <g>
-                <polyline points="-6.00,19.97 -4.35,17.56"/>
-                <g class="nad-edge-infos" transform="translate(-5.83,19.72)">
+                <polyline points="-6.17,20.22 -4.35,17.56"/>
+                <g class="nad-edge-infos" transform="translate(-6.00,19.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4733,8 +4733,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.70,15.14 -4.35,17.56"/>
-                <g class="nad-edge-infos" transform="translate(-2.87,15.39)">
+                <polyline points="-2.53,14.89 -4.35,17.56"/>
+                <g class="nad-edge-infos" transform="translate(-2.70,15.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4754,8 +4754,8 @@
         </g>
         <g id="343" class="nad-vl120to180-0" title="L62-67-1">
             <g>
-                <polyline points="-6.44,19.88 -6.66,18.83"/>
-                <g class="nad-edge-infos" transform="translate(-6.50,19.59)">
+                <polyline points="-6.37,20.18 -6.66,18.83"/>
+                <g class="nad-edge-infos" transform="translate(-6.44,19.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4773,8 +4773,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.88,17.78 -6.66,18.83"/>
-                <g class="nad-edge-infos" transform="translate(-6.81,18.07)">
+                <polyline points="-6.94,17.48 -6.66,18.83"/>
+                <g class="nad-edge-infos" transform="translate(-6.88,17.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4794,8 +4794,8 @@
         </g>
         <g id="344" class="nad-vl120to180-1" title="L63-64-1">
             <g>
-                <polyline points="-2.88,25.47 -2.41,22.35"/>
-                <g class="nad-edge-infos" transform="translate(-2.84,25.17)">
+                <polyline points="-2.93,25.76 -2.41,22.35"/>
+                <g class="nad-edge-infos" transform="translate(-2.88,25.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4813,8 +4813,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.93,19.23 -2.41,22.35"/>
-                <g class="nad-edge-infos" transform="translate(-1.97,19.52)">
+                <polyline points="-1.88,18.93 -2.41,22.35"/>
+                <g class="nad-edge-infos" transform="translate(-1.93,19.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4834,8 +4834,8 @@
         </g>
         <g id="345" class="nad-vl120to180-1" title="L64-65-1">
             <g>
-                <polyline points="-1.78,18.10 -1.20,12.90"/>
-                <g class="nad-edge-infos" transform="translate(-1.75,17.80)">
+                <polyline points="-1.81,18.40 -1.20,12.90"/>
+                <g class="nad-edge-infos" transform="translate(-1.78,18.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4853,8 +4853,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.62,7.71 -1.20,12.90"/>
-                <g class="nad-edge-infos" transform="translate(-0.65,8.01)">
+                <polyline points="-0.59,7.41 -1.20,12.90"/>
+                <g class="nad-edge-infos" transform="translate(-0.62,7.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4874,8 +4874,8 @@
         </g>
         <g id="346" title="T65-66-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-0.69,7.70 -1.47,10.91"/>
-                <g class="nad-edge-infos" transform="translate(-0.76,7.99)">
+                <polyline points="-0.62,7.41 -1.47,10.91"/>
+                <g class="nad-edge-infos" transform="translate(-0.69,7.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4894,8 +4894,8 @@
                 <circle cx="-1.44" cy="10.81" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2.24,14.12 -1.47,10.91"/>
-                <g class="nad-edge-infos" transform="translate(-2.17,13.83)">
+                <polyline points="-2.31,14.41 -1.47,10.91"/>
+                <g class="nad-edge-infos" transform="translate(-2.24,14.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4916,8 +4916,8 @@
         </g>
         <g id="347" class="nad-vl120to180-1" title="L65-68-1">
             <g>
-                <polyline points="-0.78,6.62 -1.97,3.81"/>
-                <g class="nad-edge-infos" transform="translate(-0.90,6.34)">
+                <polyline points="-0.66,6.90 -1.97,3.81"/>
+                <g class="nad-edge-infos" transform="translate(-0.78,6.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4935,8 +4935,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.16,1.00 -1.97,3.81"/>
-                <g class="nad-edge-infos" transform="translate(-3.04,1.27)">
+                <polyline points="-3.28,0.72 -1.97,3.81"/>
+                <g class="nad-edge-infos" transform="translate(-3.16,1.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4956,8 +4956,8 @@
         </g>
         <g id="348" class="nad-vl120to180-0" title="L66-67-1">
             <g>
-                <polyline points="-2.88,14.95 -4.68,15.94"/>
-                <g class="nad-edge-infos" transform="translate(-3.14,15.09)">
+                <polyline points="-2.61,14.80 -4.68,15.94"/>
+                <g class="nad-edge-infos" transform="translate(-2.88,14.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4975,8 +4975,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.49,16.94 -4.68,15.94"/>
-                <g class="nad-edge-infos" transform="translate(-6.23,16.80)">
+                <polyline points="-6.76,17.09 -4.68,15.94"/>
+                <g class="nad-edge-infos" transform="translate(-6.49,16.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -4996,8 +4996,8 @@
         </g>
         <g id="349" title="T68-69-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-3.43,1.04 -3.56,2.60"/>
-                <g class="nad-edge-infos" transform="translate(-3.46,1.34)">
+                <polyline points="-3.40,0.74 -3.56,2.60"/>
+                <g class="nad-edge-infos" transform="translate(-3.43,1.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5016,8 +5016,8 @@
                 <circle cx="-3.56" cy="2.50" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-3.70,4.16 -3.56,2.60"/>
-                <g class="nad-edge-infos" transform="translate(-3.67,3.86)">
+                <polyline points="-3.73,4.46 -3.56,2.60"/>
+                <g class="nad-edge-infos" transform="translate(-3.70,4.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5038,8 +5038,8 @@
         </g>
         <g id="350" class="nad-vl120to180-1" title="L68-81-1">
             <g>
-                <polyline points="-3.69,-0.01 -5.10,-2.23"/>
-                <g class="nad-edge-infos" transform="translate(-3.85,-0.26)">
+                <polyline points="-3.53,0.24 -5.10,-2.23"/>
+                <g class="nad-edge-infos" transform="translate(-3.69,-0.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5057,8 +5057,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.52,-4.46 -5.10,-2.23"/>
-                <g class="nad-edge-infos" transform="translate(-6.36,-4.20)">
+                <polyline points="-6.68,-4.71 -5.10,-2.23"/>
+                <g class="nad-edge-infos" transform="translate(-6.52,-4.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5078,8 +5078,8 @@
         </g>
         <g id="351" class="nad-vl120to180-1" title="L68-116-1">
             <g>
-                <polyline points="-3.23,-0.08 -2.84,-1.54"/>
-                <g class="nad-edge-infos" transform="translate(-3.15,-0.37)">
+                <polyline points="-3.31,0.21 -2.84,-1.54"/>
+                <g class="nad-edge-infos" transform="translate(-3.23,-0.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5097,8 +5097,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.44,-3.00 -2.84,-1.54"/>
-                <g class="nad-edge-infos" transform="translate(-2.52,-2.71)">
+                <polyline points="-2.37,-3.29 -2.84,-1.54"/>
+                <g class="nad-edge-infos" transform="translate(-2.44,-3.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5118,8 +5118,8 @@
         </g>
         <g id="352" class="nad-vl120to180-0" title="L69-70-1">
             <g>
-                <polyline points="-4.13,5.15 -5.17,6.29"/>
-                <g class="nad-edge-infos" transform="translate(-4.33,5.37)">
+                <polyline points="-3.93,4.92 -5.17,6.29"/>
+                <g class="nad-edge-infos" transform="translate(-4.13,5.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5137,8 +5137,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.21,7.44 -5.17,6.29"/>
-                <g class="nad-edge-infos" transform="translate(-6.01,7.22)">
+                <polyline points="-6.41,7.66 -5.17,6.29"/>
+                <g class="nad-edge-infos" transform="translate(-6.21,7.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5158,8 +5158,8 @@
         </g>
         <g id="353" class="nad-vl120to180-0" title="L69-75-1">
             <g>
-                <polyline points="-4.30,4.57 -6.30,3.99"/>
-                <g class="nad-edge-infos" transform="translate(-4.59,4.48)">
+                <polyline points="-4.01,4.65 -6.30,3.99"/>
+                <g class="nad-edge-infos" transform="translate(-4.30,4.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5177,8 +5177,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.31,3.42 -6.30,3.99"/>
-                <g class="nad-edge-infos" transform="translate(-8.02,3.50)">
+                <polyline points="-8.60,3.34 -6.30,3.99"/>
+                <g class="nad-edge-infos" transform="translate(-8.31,3.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5198,8 +5198,8 @@
         </g>
         <g id="354" class="nad-vl120to180-0" title="L69-77-1">
             <g>
-                <polyline points="-4.12,4.29 -7.20,0.71"/>
-                <g class="nad-edge-infos" transform="translate(-4.32,4.06)">
+                <polyline points="-3.92,4.52 -7.20,0.71"/>
+                <g class="nad-edge-infos" transform="translate(-4.12,4.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5217,8 +5217,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.27,-2.87 -7.20,0.71"/>
-                <g class="nad-edge-infos" transform="translate(-10.08,-2.64)">
+                <polyline points="-10.47,-3.09 -7.20,0.71"/>
+                <g class="nad-edge-infos" transform="translate(-10.27,-2.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5238,8 +5238,8 @@
         </g>
         <g id="355" class="nad-vl120to180-0" title="L70-71-1">
             <g>
-                <polyline points="-6.96,8.30 -8.36,9.97"/>
-                <g class="nad-edge-infos" transform="translate(-7.15,8.53)">
+                <polyline points="-6.76,8.07 -8.36,9.97"/>
+                <g class="nad-edge-infos" transform="translate(-6.96,8.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-140.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5257,8 +5257,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.76,11.64 -8.36,9.97"/>
-                <g class="nad-edge-infos" transform="translate(-9.56,11.41)">
+                <polyline points="-9.95,11.87 -8.36,9.97"/>
+                <g class="nad-edge-infos" transform="translate(-9.76,11.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(39.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5278,8 +5278,8 @@
         </g>
         <g id="356" class="nad-vl120to180-0" title="L70-74-1">
             <g>
-                <polyline points="-7.14,7.71 -8.47,7.34"/>
-                <g class="nad-edge-infos" transform="translate(-7.43,7.63)">
+                <polyline points="-6.85,7.79 -8.47,7.34"/>
+                <g class="nad-edge-infos" transform="translate(-7.14,7.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5297,8 +5297,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.81,6.97 -8.47,7.34"/>
-                <g class="nad-edge-infos" transform="translate(-9.52,7.05)">
+                <polyline points="-10.10,6.89 -8.47,7.34"/>
+                <g class="nad-edge-infos" transform="translate(-9.81,6.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5318,8 +5318,8 @@
         </g>
         <g id="357" class="nad-vl120to180-0" title="L70-75-1">
             <g>
-                <polyline points="-6.84,7.35 -7.73,5.56"/>
-                <g class="nad-edge-infos" transform="translate(-6.98,7.08)">
+                <polyline points="-6.71,7.62 -7.73,5.56"/>
+                <g class="nad-edge-infos" transform="translate(-6.84,7.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5337,8 +5337,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.61,3.77 -7.73,5.56"/>
-                <g class="nad-edge-infos" transform="translate(-8.48,4.04)">
+                <polyline points="-8.74,3.51 -7.73,5.56"/>
+                <g class="nad-edge-infos" transform="translate(-8.61,3.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5358,8 +5358,8 @@
         </g>
         <g id="358" class="nad-vl120to180-0" title="L71-72-1">
             <g>
-                <polyline points="-9.55,12.08 -7.87,12.08"/>
-                <g class="nad-edge-infos" transform="translate(-9.25,12.08)">
+                <polyline points="-9.85,12.08 -7.87,12.08"/>
+                <g class="nad-edge-infos" transform="translate(-9.55,12.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5377,8 +5377,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.18,12.08 -7.87,12.08"/>
-                <g class="nad-edge-infos" transform="translate(-6.48,12.08)">
+                <polyline points="-5.88,12.08 -7.87,12.08"/>
+                <g class="nad-edge-infos" transform="translate(-6.18,12.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5398,8 +5398,8 @@
         </g>
         <g id="359" class="nad-vl120to180-0" title="L71-73-1">
             <g>
-                <polyline points="-10.60,12.39 -12.06,13.37"/>
-                <g class="nad-edge-infos" transform="translate(-10.85,12.56)">
+                <polyline points="-10.35,12.23 -12.06,13.37"/>
+                <g class="nad-edge-infos" transform="translate(-10.60,12.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5417,8 +5417,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-13.52,14.35 -12.06,13.37"/>
-                <g class="nad-edge-infos" transform="translate(-13.27,14.18)">
+                <polyline points="-13.77,14.52 -12.06,13.37"/>
+                <g class="nad-edge-infos" transform="translate(-13.52,14.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5438,8 +5438,8 @@
         </g>
         <g id="360" class="nad-vl120to180-0" title="L74-75-1">
             <g>
-                <polyline points="-10.13,6.29 -9.61,5.04"/>
-                <g class="nad-edge-infos" transform="translate(-10.02,6.02)">
+                <polyline points="-10.25,6.57 -9.61,5.04"/>
+                <g class="nad-edge-infos" transform="translate(-10.13,6.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5457,8 +5457,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.08,3.79 -9.61,5.04"/>
-                <g class="nad-edge-infos" transform="translate(-9.20,4.07)">
+                <polyline points="-8.97,3.51 -9.61,5.04"/>
+                <g class="nad-edge-infos" transform="translate(-9.08,3.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5478,8 +5478,8 @@
         </g>
         <g id="361" class="nad-vl120to180-0" title="L75-77-1">
             <g>
-                <polyline points="-9.01,2.71 -9.75,-0.02"/>
-                <g class="nad-edge-infos" transform="translate(-9.09,2.42)">
+                <polyline points="-8.93,3.00 -9.75,-0.02"/>
+                <g class="nad-edge-infos" transform="translate(-9.01,2.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5497,8 +5497,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.49,-2.75 -9.75,-0.02"/>
-                <g class="nad-edge-infos" transform="translate(-10.42,-2.46)">
+                <polyline points="-10.57,-3.04 -9.75,-0.02"/>
+                <g class="nad-edge-infos" transform="translate(-10.49,-2.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5518,8 +5518,8 @@
         </g>
         <g id="362" class="nad-vl120to180-0" title="L75-118-1">
             <g>
-                <polyline points="-9.43,3.24 -11.04,3.17"/>
-                <g class="nad-edge-infos" transform="translate(-9.73,3.23)">
+                <polyline points="-9.13,3.25 -11.04,3.17"/>
+                <g class="nad-edge-infos" transform="translate(-9.43,3.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5537,8 +5537,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.65,3.11 -11.04,3.17"/>
-                <g class="nad-edge-infos" transform="translate(-12.35,3.12)">
+                <polyline points="-12.95,3.09 -11.04,3.17"/>
+                <g class="nad-edge-infos" transform="translate(-12.65,3.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5558,8 +5558,8 @@
         </g>
         <g id="363" class="nad-vl120to180-0" title="L76-77-1">
             <g>
-                <polyline points="-12.81,-0.83 -11.91,-1.85"/>
-                <g class="nad-edge-infos" transform="translate(-12.61,-1.05)">
+                <polyline points="-13.01,-0.60 -11.91,-1.85"/>
+                <g class="nad-edge-infos" transform="translate(-12.81,-0.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5577,8 +5577,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.02,-2.87 -11.91,-1.85"/>
-                <g class="nad-edge-infos" transform="translate(-11.22,-2.65)">
+                <polyline points="-10.82,-3.10 -11.91,-1.85"/>
+                <g class="nad-edge-infos" transform="translate(-11.02,-2.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5598,8 +5598,8 @@
         </g>
         <g id="364" class="nad-vl120to180-0" title="L76-118-1">
             <g>
-                <polyline points="-13.19,0.17 -13.20,1.34"/>
-                <g class="nad-edge-infos" transform="translate(-13.20,0.47)">
+                <polyline points="-13.19,-0.13 -13.20,1.34"/>
+                <g class="nad-edge-infos" transform="translate(-13.19,0.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5617,8 +5617,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-13.22,2.51 -13.20,1.34"/>
-                <g class="nad-edge-infos" transform="translate(-13.21,2.21)">
+                <polyline points="-13.22,2.81 -13.20,1.34"/>
+                <g class="nad-edge-infos" transform="translate(-13.22,2.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5638,8 +5638,8 @@
         </g>
         <g id="365" class="nad-vl120to180-0" title="L77-78-1">
             <g>
-                <polyline points="-10.38,-3.81 -9.16,-6.15"/>
-                <g class="nad-edge-infos" transform="translate(-10.24,-4.07)">
+                <polyline points="-10.52,-3.54 -9.16,-6.15"/>
+                <g class="nad-edge-infos" transform="translate(-10.38,-3.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5657,8 +5657,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-7.94,-8.49 -9.16,-6.15"/>
-                <g class="nad-edge-infos" transform="translate(-8.08,-8.22)">
+                <polyline points="-7.80,-8.76 -9.16,-6.15"/>
+                <g class="nad-edge-infos" transform="translate(-7.94,-8.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5678,7 +5678,7 @@
         </g>
         <g id="366" class="nad-vl120to180-0" title="L77-80-1">
             <g>
-                <polyline points="-10.50,-3.85 -10.44,-4.07 -11.02,-6.13"/>
+                <polyline points="-10.58,-3.56 -10.44,-4.07 -11.02,-6.13"/>
                 <g class="nad-edge-infos" transform="translate(-10.53,-4.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.62)">
@@ -5697,7 +5697,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.76,-8.35 -11.59,-8.19 -11.02,-6.13"/>
+                <polyline points="-11.97,-8.56 -11.59,-8.19 -11.02,-6.13"/>
                 <g class="nad-edge-infos" transform="translate(-11.51,-7.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.38)">
@@ -5718,7 +5718,7 @@
         </g>
         <g id="367" class="nad-vl120to180-0" title="L77-80-2">
             <g>
-                <polyline points="-11.05,-3.70 -11.21,-3.86 -11.79,-5.92"/>
+                <polyline points="-10.84,-3.49 -11.21,-3.86 -11.79,-5.92"/>
                 <g class="nad-edge-infos" transform="translate(-11.30,-4.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.62)">
@@ -5737,7 +5737,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.31,-8.20 -12.37,-7.97 -11.79,-5.92"/>
+                <polyline points="-12.23,-8.49 -12.37,-7.97 -11.79,-5.92"/>
                 <g class="nad-edge-infos" transform="translate(-12.28,-7.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.38)">
@@ -5758,8 +5758,8 @@
         </g>
         <g id="368" class="nad-vl120to180-0" title="L77-82-1">
             <g>
-                <polyline points="-11.12,-3.61 -14.83,-6.02"/>
-                <g class="nad-edge-infos" transform="translate(-11.37,-3.77)">
+                <polyline points="-10.87,-3.45 -14.83,-6.02"/>
+                <g class="nad-edge-infos" transform="translate(-11.12,-3.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5777,8 +5777,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-18.54,-8.43 -14.83,-6.02"/>
-                <g class="nad-edge-infos" transform="translate(-18.29,-8.27)">
+                <polyline points="-18.80,-8.59 -14.83,-6.02"/>
+                <g class="nad-edge-infos" transform="translate(-18.54,-8.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5798,8 +5798,8 @@
         </g>
         <g id="369" class="nad-vl120to180-0" title="L78-79-1">
             <g>
-                <polyline points="-7.75,-9.56 -7.90,-10.77"/>
-                <g class="nad-edge-infos" transform="translate(-7.79,-9.86)">
+                <polyline points="-7.71,-9.26 -7.90,-10.77"/>
+                <g class="nad-edge-infos" transform="translate(-7.75,-9.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5817,8 +5817,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.05,-11.98 -7.90,-10.77"/>
-                <g class="nad-edge-infos" transform="translate(-8.01,-11.68)">
+                <polyline points="-8.09,-12.28 -7.90,-10.77"/>
+                <g class="nad-edge-infos" transform="translate(-8.05,-11.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(172.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5838,8 +5838,8 @@
         </g>
         <g id="370" class="nad-vl120to180-0" title="L79-80-1">
             <g>
-                <polyline points="-8.54,-12.15 -10.14,-10.65"/>
-                <g class="nad-edge-infos" transform="translate(-8.75,-11.95)">
+                <polyline points="-8.32,-12.36 -10.14,-10.65"/>
+                <g class="nad-edge-infos" transform="translate(-8.54,-12.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5857,8 +5857,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.75,-9.14 -10.14,-10.65"/>
-                <g class="nad-edge-infos" transform="translate(-11.53,-9.34)">
+                <polyline points="-11.97,-8.93 -10.14,-10.65"/>
+                <g class="nad-edge-infos" transform="translate(-11.75,-9.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5878,8 +5878,8 @@
         </g>
         <g id="371" title="T81-80-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-7.29,-5.27 -9.49,-6.84"/>
-                <g class="nad-edge-infos" transform="translate(-7.53,-5.44)">
+                <polyline points="-7.04,-5.09 -9.49,-6.84"/>
+                <g class="nad-edge-infos" transform="translate(-7.29,-5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5898,8 +5898,8 @@
                 <circle cx="-9.41" cy="-6.78" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-11.70,-8.42 -9.49,-6.84"/>
-                <g class="nad-edge-infos" transform="translate(-11.46,-8.24)">
+                <polyline points="-11.95,-8.59 -9.49,-6.84"/>
+                <g class="nad-edge-infos" transform="translate(-11.70,-8.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5920,8 +5920,8 @@
         </g>
         <g id="372" class="nad-vl120to180-0" title="L80-96-1">
             <g>
-                <polyline points="-12.55,-9.18 -14.03,-10.84"/>
-                <g class="nad-edge-infos" transform="translate(-12.75,-9.40)">
+                <polyline points="-12.35,-8.95 -14.03,-10.84"/>
+                <g class="nad-edge-infos" transform="translate(-12.55,-9.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5939,8 +5939,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-15.52,-12.50 -14.03,-10.84"/>
-                <g class="nad-edge-infos" transform="translate(-15.32,-12.28)">
+                <polyline points="-15.71,-12.73 -14.03,-10.84"/>
+                <g class="nad-edge-infos" transform="translate(-15.52,-12.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5960,8 +5960,8 @@
         </g>
         <g id="373" class="nad-vl120to180-0" title="L80-97-1">
             <g>
-                <polyline points="-12.18,-9.32 -12.21,-11.44"/>
-                <g class="nad-edge-infos" transform="translate(-12.18,-9.62)">
+                <polyline points="-12.17,-9.02 -12.21,-11.44"/>
+                <g class="nad-edge-infos" transform="translate(-12.18,-9.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -5979,8 +5979,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.25,-13.56 -12.21,-11.44"/>
-                <g class="nad-edge-infos" transform="translate(-12.25,-13.26)">
+                <polyline points="-12.26,-13.86 -12.21,-11.44"/>
+                <g class="nad-edge-infos" transform="translate(-12.25,-13.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6000,8 +6000,8 @@
         </g>
         <g id="374" class="nad-vl120to180-0" title="L80-98-1">
             <g>
-                <polyline points="-12.60,-8.38 -14.74,-6.55"/>
-                <g class="nad-edge-infos" transform="translate(-12.83,-8.19)">
+                <polyline points="-12.37,-8.57 -14.74,-6.55"/>
+                <g class="nad-edge-infos" transform="translate(-12.60,-8.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6019,8 +6019,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-16.88,-4.73 -14.74,-6.55"/>
-                <g class="nad-edge-infos" transform="translate(-16.65,-4.92)">
+                <polyline points="-17.11,-4.53 -14.74,-6.55"/>
+                <g class="nad-edge-infos" transform="translate(-16.88,-4.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6040,8 +6040,8 @@
         </g>
         <g id="375" class="nad-vl120to180-0" title="L80-99-1">
             <g>
-                <polyline points="-12.70,-8.54 -14.08,-7.98"/>
-                <g class="nad-edge-infos" transform="translate(-12.97,-8.42)">
+                <polyline points="-12.42,-8.65 -14.08,-7.98"/>
+                <g class="nad-edge-infos" transform="translate(-12.70,-8.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-112.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6059,8 +6059,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-15.46,-7.42 -14.08,-7.98"/>
-                <g class="nad-edge-infos" transform="translate(-15.18,-7.53)">
+                <polyline points="-15.74,-7.31 -14.08,-7.98"/>
+                <g class="nad-edge-infos" transform="translate(-15.46,-7.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(67.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6080,8 +6080,8 @@
         </g>
         <g id="376" class="nad-vl120to180-0" title="L82-83-1">
             <g>
-                <polyline points="-19.59,-8.74 -23.81,-8.72"/>
-                <g class="nad-edge-infos" transform="translate(-19.89,-8.74)">
+                <polyline points="-19.29,-8.74 -23.81,-8.72"/>
+                <g class="nad-edge-infos" transform="translate(-19.59,-8.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6099,8 +6099,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-28.04,-8.71 -23.81,-8.72"/>
-                <g class="nad-edge-infos" transform="translate(-27.74,-8.71)">
+                <polyline points="-28.34,-8.70 -23.81,-8.72"/>
+                <g class="nad-edge-infos" transform="translate(-28.04,-8.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6120,8 +6120,8 @@
         </g>
         <g id="377" class="nad-vl120to180-0" title="L82-96-1">
             <g>
-                <polyline points="-18.68,-9.20 -17.46,-10.83"/>
-                <g class="nad-edge-infos" transform="translate(-18.50,-9.44)">
+                <polyline points="-18.86,-8.96 -17.46,-10.83"/>
+                <g class="nad-edge-infos" transform="translate(-18.68,-9.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6139,8 +6139,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-16.24,-12.47 -17.46,-10.83"/>
-                <g class="nad-edge-infos" transform="translate(-16.42,-12.23)">
+                <polyline points="-16.06,-12.71 -17.46,-10.83"/>
+                <g class="nad-edge-infos" transform="translate(-16.24,-12.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-143.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6160,8 +6160,8 @@
         </g>
         <g id="378" class="nad-vl120to180-0" title="L83-84-1">
             <g>
-                <polyline points="-29.13,-8.48 -30.47,-7.92"/>
-                <g class="nad-edge-infos" transform="translate(-29.41,-8.37)">
+                <polyline points="-28.86,-8.60 -30.47,-7.92"/>
+                <g class="nad-edge-infos" transform="translate(-29.13,-8.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-112.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6179,8 +6179,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-31.80,-7.36 -30.47,-7.92"/>
-                <g class="nad-edge-infos" transform="translate(-31.52,-7.47)">
+                <polyline points="-32.08,-7.24 -30.47,-7.92"/>
+                <g class="nad-edge-infos" transform="translate(-31.80,-7.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(67.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6200,8 +6200,8 @@
         </g>
         <g id="379" class="nad-vl120to180-0" title="L83-85-1">
             <g>
-                <polyline points="-29.14,-8.90 -31.09,-9.63"/>
-                <g class="nad-edge-infos" transform="translate(-29.42,-9.01)">
+                <polyline points="-28.86,-8.80 -31.09,-9.63"/>
+                <g class="nad-edge-infos" transform="translate(-29.14,-8.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6219,8 +6219,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-33.04,-10.37 -31.09,-9.63"/>
-                <g class="nad-edge-infos" transform="translate(-32.76,-10.26)">
+                <polyline points="-33.32,-10.47 -31.09,-9.63"/>
+                <g class="nad-edge-infos" transform="translate(-33.04,-10.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6240,8 +6240,8 @@
         </g>
         <g id="380" class="nad-vl120to180-0" title="L84-85-1">
             <g>
-                <polyline points="-32.52,-7.67 -32.95,-8.85"/>
-                <g class="nad-edge-infos" transform="translate(-32.62,-7.95)">
+                <polyline points="-32.42,-7.39 -32.95,-8.85"/>
+                <g class="nad-edge-infos" transform="translate(-32.52,-7.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6259,8 +6259,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-33.38,-10.03 -32.95,-8.85"/>
-                <g class="nad-edge-infos" transform="translate(-33.28,-9.75)">
+                <polyline points="-33.48,-10.31 -32.95,-8.85"/>
+                <g class="nad-edge-infos" transform="translate(-33.38,-10.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6280,8 +6280,8 @@
         </g>
         <g id="381" class="nad-vl120to180-0" title="L85-86-1">
             <g>
-                <polyline points="-34.02,-10.21 -35.76,-8.84"/>
-                <g class="nad-edge-infos" transform="translate(-34.26,-10.03)">
+                <polyline points="-33.79,-10.40 -35.76,-8.84"/>
+                <g class="nad-edge-infos" transform="translate(-34.02,-10.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6299,8 +6299,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-37.51,-7.46 -35.76,-8.84"/>
-                <g class="nad-edge-infos" transform="translate(-37.27,-7.65)">
+                <polyline points="-37.74,-7.28 -35.76,-8.84"/>
+                <g class="nad-edge-infos" transform="translate(-37.51,-7.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6320,8 +6320,8 @@
         </g>
         <g id="382" class="nad-vl120to180-0" title="L85-88-1">
             <g>
-                <polyline points="-33.76,-11.10 -34.24,-12.46"/>
-                <g class="nad-edge-infos" transform="translate(-33.86,-11.39)">
+                <polyline points="-33.66,-10.82 -34.24,-12.46"/>
+                <g class="nad-edge-infos" transform="translate(-33.76,-11.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6339,8 +6339,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-34.72,-13.82 -34.24,-12.46"/>
-                <g class="nad-edge-infos" transform="translate(-34.62,-13.54)">
+                <polyline points="-34.81,-14.11 -34.24,-12.46"/>
+                <g class="nad-edge-infos" transform="translate(-34.72,-13.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6360,8 +6360,8 @@
         </g>
         <g id="383" class="nad-vl120to180-0" title="L85-89-1">
             <g>
-                <polyline points="-33.28,-11.06 -32.24,-12.80"/>
-                <g class="nad-edge-infos" transform="translate(-33.13,-11.31)">
+                <polyline points="-33.44,-10.80 -32.24,-12.80"/>
+                <g class="nad-edge-infos" transform="translate(-33.28,-11.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6379,8 +6379,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-31.20,-14.55 -32.24,-12.80"/>
-                <g class="nad-edge-infos" transform="translate(-31.36,-14.29)">
+                <polyline points="-31.05,-14.80 -32.24,-12.80"/>
+                <g class="nad-edge-infos" transform="translate(-31.20,-14.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6400,8 +6400,8 @@
         </g>
         <g id="384" class="nad-vl120to180-0" title="L86-87-1">
             <g>
-                <polyline points="-38.27,-6.64 -39.12,-5.38"/>
-                <g class="nad-edge-infos" transform="translate(-38.44,-6.39)">
+                <polyline points="-38.10,-6.89 -39.12,-5.38"/>
+                <g class="nad-edge-infos" transform="translate(-38.27,-6.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-146.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6419,8 +6419,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-39.97,-4.12 -39.12,-5.38"/>
-                <g class="nad-edge-infos" transform="translate(-39.80,-4.37)">
+                <polyline points="-40.14,-3.87 -39.12,-5.38"/>
+                <g class="nad-edge-infos" transform="translate(-39.97,-4.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6440,8 +6440,8 @@
         </g>
         <g id="385" class="nad-vl120to180-0" title="L88-89-1">
             <g>
-                <polyline points="-34.34,-14.46 -32.91,-14.70"/>
-                <g class="nad-edge-infos" transform="translate(-34.05,-14.51)">
+                <polyline points="-34.64,-14.41 -32.91,-14.70"/>
+                <g class="nad-edge-infos" transform="translate(-34.34,-14.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6459,8 +6459,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-31.47,-14.94 -32.91,-14.70"/>
-                <g class="nad-edge-infos" transform="translate(-31.77,-14.89)">
+                <polyline points="-31.18,-14.99 -32.91,-14.70"/>
+                <g class="nad-edge-infos" transform="translate(-31.47,-14.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6480,7 +6480,7 @@
         </g>
         <g id="386" class="nad-vl120to180-0" title="L89-90-1">
             <g>
-                <polyline points="-30.57,-15.49 -30.43,-15.68 -30.25,-17.29"/>
+                <polyline points="-30.75,-15.25 -30.43,-15.68 -30.25,-17.29"/>
                 <g class="nad-edge-infos" transform="translate(-30.40,-15.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.61)">
@@ -6499,7 +6499,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-30.15,-19.12 -30.06,-18.91 -30.25,-17.29"/>
+                <polyline points="-30.27,-19.39 -30.06,-18.91 -30.25,-17.29"/>
                 <g class="nad-edge-infos" transform="translate(-30.09,-18.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.39)">
@@ -6520,7 +6520,7 @@
         </g>
         <g id="387" class="nad-vl120to180-0" title="L89-90-2">
             <g>
-                <polyline points="-31.14,-15.56 -31.23,-15.77 -31.04,-17.38"/>
+                <polyline points="-31.02,-15.28 -31.23,-15.77 -31.04,-17.38"/>
                 <g class="nad-edge-infos" transform="translate(-31.19,-16.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.61)">
@@ -6539,7 +6539,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-30.72,-19.18 -30.85,-19.00 -31.04,-17.38"/>
+                <polyline points="-30.54,-19.43 -30.85,-19.00 -31.04,-17.38"/>
                 <g class="nad-edge-infos" transform="translate(-30.89,-18.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.39)">
@@ -6560,7 +6560,7 @@
         </g>
         <g id="388" class="nad-vl120to180-0" title="L89-92-1">
             <g>
-                <polyline points="-30.49,-14.65 -30.32,-14.50 -27.95,-13.99"/>
+                <polyline points="-30.71,-14.85 -30.32,-14.50 -27.95,-13.99"/>
                 <g class="nad-edge-infos" transform="translate(-30.02,-14.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.12)">
@@ -6579,7 +6579,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-25.37,-13.55 -25.59,-13.48 -27.95,-13.99"/>
+                <polyline points="-25.08,-13.64 -25.59,-13.48 -27.95,-13.99"/>
                 <g class="nad-edge-infos" transform="translate(-25.88,-13.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.88)">
@@ -6600,7 +6600,7 @@
         </g>
         <g id="389" class="nad-vl120to180-0" title="L89-92-2">
             <g>
-                <polyline points="-30.37,-15.21 -30.15,-15.28 -27.78,-14.77"/>
+                <polyline points="-30.65,-15.12 -30.15,-15.28 -27.78,-14.77"/>
                 <g class="nad-edge-infos" transform="translate(-29.86,-15.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.12)">
@@ -6619,7 +6619,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-25.25,-14.11 -25.42,-14.26 -27.78,-14.77"/>
+                <polyline points="-25.02,-13.91 -25.42,-14.26 -27.78,-14.77"/>
                 <g class="nad-edge-infos" transform="translate(-25.71,-14.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.88)">
@@ -6640,8 +6640,8 @@
         </g>
         <g id="390" class="nad-vl120to180-0" title="L90-91-1">
             <g>
-                <polyline points="-29.81,-19.55 -28.52,-19.35"/>
-                <g class="nad-edge-infos" transform="translate(-29.52,-19.51)">
+                <polyline points="-30.11,-19.60 -28.52,-19.35"/>
+                <g class="nad-edge-infos" transform="translate(-29.81,-19.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6659,8 +6659,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-27.24,-19.15 -28.52,-19.35"/>
-                <g class="nad-edge-infos" transform="translate(-27.53,-19.20)">
+                <polyline points="-26.94,-19.11 -28.52,-19.35"/>
+                <g class="nad-edge-infos" transform="translate(-27.24,-19.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6680,8 +6680,8 @@
         </g>
         <g id="391" class="nad-vl120to180-0" title="L91-92-1">
             <g>
-                <polyline points="-26.49,-18.53 -25.75,-16.40"/>
-                <g class="nad-edge-infos" transform="translate(-26.39,-18.24)">
+                <polyline points="-26.58,-18.81 -25.75,-16.40"/>
+                <g class="nad-edge-infos" transform="translate(-26.49,-18.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6699,8 +6699,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-25.01,-14.27 -25.75,-16.40"/>
-                <g class="nad-edge-infos" transform="translate(-25.11,-14.55)">
+                <polyline points="-24.91,-13.98 -25.75,-16.40"/>
+                <g class="nad-edge-infos" transform="translate(-25.01,-14.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6720,8 +6720,8 @@
         </g>
         <g id="392" class="nad-vl120to180-0" title="L92-93-1">
             <g>
-                <polyline points="-24.47,-14.17 -23.46,-15.42"/>
-                <g class="nad-edge-infos" transform="translate(-24.28,-14.41)">
+                <polyline points="-24.65,-13.94 -23.46,-15.42"/>
+                <g class="nad-edge-infos" transform="translate(-24.47,-14.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6739,8 +6739,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-22.46,-16.67 -23.46,-15.42"/>
-                <g class="nad-edge-infos" transform="translate(-22.65,-16.43)">
+                <polyline points="-22.27,-16.90 -23.46,-15.42"/>
+                <g class="nad-edge-infos" transform="translate(-22.46,-16.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6760,8 +6760,8 @@
         </g>
         <g id="393" class="nad-vl120to180-0" title="L92-94-1">
             <g>
-                <polyline points="-24.26,-13.68 -22.56,-13.53"/>
-                <g class="nad-edge-infos" transform="translate(-23.96,-13.65)">
+                <polyline points="-24.55,-13.70 -22.56,-13.53"/>
+                <g class="nad-edge-infos" transform="translate(-24.26,-13.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6779,8 +6779,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-20.86,-13.37 -22.56,-13.53"/>
-                <g class="nad-edge-infos" transform="translate(-21.16,-13.40)">
+                <polyline points="-20.56,-13.35 -22.56,-13.53"/>
+                <g class="nad-edge-infos" transform="translate(-20.86,-13.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6800,8 +6800,8 @@
         </g>
         <g id="394" class="nad-vl120to180-0" title="L92-100-1">
             <g>
-                <polyline points="-24.66,-13.18 -23.45,-9.10"/>
-                <g class="nad-edge-infos" transform="translate(-24.58,-12.89)">
+                <polyline points="-24.75,-13.47 -23.45,-9.10"/>
+                <g class="nad-edge-infos" transform="translate(-24.66,-13.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6819,8 +6819,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-22.24,-5.02 -23.45,-9.10"/>
-                <g class="nad-edge-infos" transform="translate(-22.32,-5.31)">
+                <polyline points="-22.15,-4.74 -23.45,-9.10"/>
+                <g class="nad-edge-infos" transform="translate(-22.24,-5.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6840,8 +6840,8 @@
         </g>
         <g id="395" class="nad-vl120to180-0" title="L92-102-1">
             <g>
-                <polyline points="-24.84,-13.16 -24.86,-11.97"/>
-                <g class="nad-edge-infos" transform="translate(-24.84,-12.86)">
+                <polyline points="-24.83,-13.46 -24.86,-11.97"/>
+                <g class="nad-edge-infos" transform="translate(-24.84,-13.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6859,8 +6859,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-24.89,-10.78 -24.86,-11.97"/>
-                <g class="nad-edge-infos" transform="translate(-24.88,-11.08)">
+                <polyline points="-24.89,-10.48 -24.86,-11.97"/>
+                <g class="nad-edge-infos" transform="translate(-24.89,-10.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6880,8 +6880,8 @@
         </g>
         <g id="396" class="nad-vl120to180-0" title="L93-94-1">
             <g>
-                <polyline points="-21.86,-16.60 -21.20,-15.22"/>
-                <g class="nad-edge-infos" transform="translate(-21.73,-16.33)">
+                <polyline points="-21.99,-16.87 -21.20,-15.22"/>
+                <g class="nad-edge-infos" transform="translate(-21.86,-16.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6899,8 +6899,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-20.54,-13.84 -21.20,-15.22"/>
-                <g class="nad-edge-infos" transform="translate(-20.67,-14.11)">
+                <polyline points="-20.41,-13.57 -21.20,-15.22"/>
+                <g class="nad-edge-infos" transform="translate(-20.54,-13.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6920,8 +6920,8 @@
         </g>
         <g id="397" class="nad-vl120to180-0" title="L94-95-1">
             <g>
-                <polyline points="-19.92,-13.75 -18.65,-15.19"/>
-                <g class="nad-edge-infos" transform="translate(-19.72,-13.98)">
+                <polyline points="-20.11,-13.53 -18.65,-15.19"/>
+                <g class="nad-edge-infos" transform="translate(-19.92,-13.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6939,8 +6939,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-17.39,-16.64 -18.65,-15.19"/>
-                <g class="nad-edge-infos" transform="translate(-17.59,-16.41)">
+                <polyline points="-17.20,-16.86 -18.65,-15.19"/>
+                <g class="nad-edge-infos" transform="translate(-17.39,-16.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6960,8 +6960,8 @@
         </g>
         <g id="398" class="nad-vl120to180-0" title="L94-96-1">
             <g>
-                <polyline points="-19.72,-13.27 -18.09,-13.13"/>
-                <g class="nad-edge-infos" transform="translate(-19.42,-13.25)">
+                <polyline points="-20.02,-13.30 -18.09,-13.13"/>
+                <g class="nad-edge-infos" transform="translate(-19.72,-13.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -6979,8 +6979,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-16.46,-12.98 -18.09,-13.13"/>
-                <g class="nad-edge-infos" transform="translate(-16.76,-13.00)">
+                <polyline points="-16.16,-12.95 -18.09,-13.13"/>
+                <g class="nad-edge-infos" transform="translate(-16.46,-12.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7000,8 +7000,8 @@
         </g>
         <g id="399" class="nad-vl120to180-0" title="L94-100-1">
             <g>
-                <polyline points="-20.40,-12.76 -21.18,-8.90"/>
-                <g class="nad-edge-infos" transform="translate(-20.46,-12.47)">
+                <polyline points="-20.34,-13.06 -21.18,-8.90"/>
+                <g class="nad-edge-infos" transform="translate(-20.40,-12.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7019,8 +7019,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-21.96,-5.04 -21.18,-8.90"/>
-                <g class="nad-edge-infos" transform="translate(-21.90,-5.33)">
+                <polyline points="-22.02,-4.74 -21.18,-8.90"/>
+                <g class="nad-edge-infos" transform="translate(-21.96,-5.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7040,8 +7040,8 @@
         </g>
         <g id="400" class="nad-vl120to180-0" title="L95-96-1">
             <g>
-                <polyline points="-16.87,-16.51 -16.46,-15.00"/>
-                <g class="nad-edge-infos" transform="translate(-16.79,-16.23)">
+                <polyline points="-16.95,-16.80 -16.46,-15.00"/>
+                <g class="nad-edge-infos" transform="translate(-16.87,-16.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7059,8 +7059,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-16.04,-13.48 -16.46,-15.00"/>
-                <g class="nad-edge-infos" transform="translate(-16.12,-13.77)">
+                <polyline points="-15.97,-13.19 -16.46,-15.00"/>
+                <g class="nad-edge-infos" transform="translate(-16.04,-13.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7080,8 +7080,8 @@
         </g>
         <g id="401" class="nad-vl120to180-0" title="L96-97-1">
             <g>
-                <polyline points="-15.35,-13.11 -14.08,-13.53"/>
-                <g class="nad-edge-infos" transform="translate(-15.07,-13.20)">
+                <polyline points="-15.64,-13.01 -14.08,-13.53"/>
+                <g class="nad-edge-infos" transform="translate(-15.35,-13.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7099,8 +7099,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.80,-13.95 -14.08,-13.53"/>
-                <g class="nad-edge-infos" transform="translate(-13.09,-13.86)">
+                <polyline points="-12.52,-14.04 -14.08,-13.53"/>
+                <g class="nad-edge-infos" transform="translate(-12.80,-13.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7120,8 +7120,8 @@
         </g>
         <g id="402" class="nad-vl120to180-0" title="L98-100-1">
             <g>
-                <polyline points="-17.88,-4.37 -19.69,-4.42"/>
-                <g class="nad-edge-infos" transform="translate(-18.18,-4.38)">
+                <polyline points="-17.58,-4.37 -19.69,-4.42"/>
+                <g class="nad-edge-infos" transform="translate(-17.88,-4.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7139,8 +7139,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-21.51,-4.46 -19.69,-4.42"/>
-                <g class="nad-edge-infos" transform="translate(-21.21,-4.46)">
+                <polyline points="-21.81,-4.47 -19.69,-4.42"/>
+                <g class="nad-edge-infos" transform="translate(-21.51,-4.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7160,8 +7160,8 @@
         </g>
         <g id="403" class="nad-vl120to180-0" title="L99-100-1">
             <g>
-                <polyline points="-16.51,-6.97 -19.03,-5.84"/>
-                <g class="nad-edge-infos" transform="translate(-16.78,-6.85)">
+                <polyline points="-16.23,-7.09 -19.03,-5.84"/>
+                <g class="nad-edge-infos" transform="translate(-16.51,-6.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7179,8 +7179,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-21.56,-4.71 -19.03,-5.84"/>
-                <g class="nad-edge-infos" transform="translate(-21.28,-4.83)">
+                <polyline points="-21.83,-4.59 -19.03,-5.84"/>
+                <g class="nad-edge-infos" transform="translate(-21.56,-4.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7200,8 +7200,8 @@
         </g>
         <g id="404" class="nad-vl120to180-0" title="L100-101-1">
             <g>
-                <polyline points="-22.56,-4.78 -23.52,-5.37"/>
-                <g class="nad-edge-infos" transform="translate(-22.82,-4.94)">
+                <polyline points="-22.31,-4.62 -23.52,-5.37"/>
+                <g class="nad-edge-infos" transform="translate(-22.56,-4.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7219,8 +7219,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-24.47,-5.96 -23.52,-5.37"/>
-                <g class="nad-edge-infos" transform="translate(-24.22,-5.80)">
+                <polyline points="-24.73,-6.12 -23.52,-5.37"/>
+                <g class="nad-edge-infos" transform="translate(-24.47,-5.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7240,8 +7240,8 @@
         </g>
         <g id="405" class="nad-vl120to180-0" title="L100-103-1">
             <g>
-                <polyline points="-22.16,-3.91 -22.73,0.18"/>
-                <g class="nad-edge-infos" transform="translate(-22.20,-3.62)">
+                <polyline points="-22.11,-4.21 -22.73,0.18"/>
+                <g class="nad-edge-infos" transform="translate(-22.16,-3.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7259,8 +7259,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-23.30,4.27 -22.73,0.18"/>
-                <g class="nad-edge-infos" transform="translate(-23.26,3.97)">
+                <polyline points="-23.34,4.56 -22.73,0.18"/>
+                <g class="nad-edge-infos" transform="translate(-23.30,4.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7280,8 +7280,8 @@
         </g>
         <g id="406" class="nad-vl120to180-0" title="L100-104-1">
             <g>
-                <polyline points="-22.20,-3.92 -22.69,-1.60"/>
-                <g class="nad-edge-infos" transform="translate(-22.26,-3.63)">
+                <polyline points="-22.13,-4.21 -22.69,-1.60"/>
+                <g class="nad-edge-infos" transform="translate(-22.20,-3.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7299,8 +7299,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-23.18,0.73 -22.69,-1.60"/>
-                <g class="nad-edge-infos" transform="translate(-23.12,0.44)">
+                <polyline points="-23.24,1.02 -22.69,-1.60"/>
+                <g class="nad-edge-infos" transform="translate(-23.18,0.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7320,8 +7320,8 @@
         </g>
         <g id="407" class="nad-vl120to180-0" title="L100-106-1">
             <g>
-                <polyline points="-22.50,-4.10 -24.67,-2.16"/>
-                <g class="nad-edge-infos" transform="translate(-22.73,-3.90)">
+                <polyline points="-22.28,-4.30 -24.67,-2.16"/>
+                <g class="nad-edge-infos" transform="translate(-22.50,-4.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7339,8 +7339,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-26.83,-0.22 -24.67,-2.16"/>
-                <g class="nad-edge-infos" transform="translate(-26.61,-0.42)">
+                <polyline points="-27.06,-0.02 -24.67,-2.16"/>
+                <g class="nad-edge-infos" transform="translate(-26.83,-0.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7360,8 +7360,8 @@
         </g>
         <g id="408" class="nad-vl120to180-0" title="L101-102-1">
             <g>
-                <polyline points="-24.95,-6.83 -24.93,-8.23"/>
-                <g class="nad-edge-infos" transform="translate(-24.94,-7.13)">
+                <polyline points="-24.95,-6.53 -24.93,-8.23"/>
+                <g class="nad-edge-infos" transform="translate(-24.95,-6.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7379,8 +7379,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-24.91,-9.64 -24.93,-8.23"/>
-                <g class="nad-edge-infos" transform="translate(-24.91,-9.34)">
+                <polyline points="-24.90,-9.94 -24.93,-8.23"/>
+                <g class="nad-edge-infos" transform="translate(-24.91,-9.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7400,8 +7400,8 @@
         </g>
         <g id="409" class="nad-vl120to180-0" title="L103-104-1">
             <g>
-                <polyline points="-23.37,4.26 -23.34,3.06"/>
-                <g class="nad-edge-infos" transform="translate(-23.36,3.96)">
+                <polyline points="-23.38,4.56 -23.34,3.06"/>
+                <g class="nad-edge-infos" transform="translate(-23.37,4.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7419,8 +7419,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-23.31,1.86 -23.34,3.06"/>
-                <g class="nad-edge-infos" transform="translate(-23.32,2.16)">
+                <polyline points="-23.30,1.56 -23.34,3.06"/>
+                <g class="nad-edge-infos" transform="translate(-23.31,1.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7440,8 +7440,8 @@
         </g>
         <g id="410" class="nad-vl120to180-0" title="L103-105-1">
             <g>
-                <polyline points="-23.95,4.77 -25.25,4.64"/>
-                <g class="nad-edge-infos" transform="translate(-24.25,4.74)">
+                <polyline points="-23.65,4.80 -25.25,4.64"/>
+                <g class="nad-edge-infos" transform="translate(-23.95,4.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7459,8 +7459,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-26.56,4.51 -25.25,4.64"/>
-                <g class="nad-edge-infos" transform="translate(-26.26,4.54)">
+                <polyline points="-26.85,4.48 -25.25,4.64"/>
+                <g class="nad-edge-infos" transform="translate(-26.56,4.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7480,8 +7480,8 @@
         </g>
         <g id="411" class="nad-vl120to180-0" title="L103-110-1">
             <g>
-                <polyline points="-23.47,5.39 -24.01,8.83"/>
-                <g class="nad-edge-infos" transform="translate(-23.52,5.69)">
+                <polyline points="-23.42,5.10 -24.01,8.83"/>
+                <g class="nad-edge-infos" transform="translate(-23.47,5.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7499,8 +7499,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-24.55,12.26 -24.01,8.83"/>
-                <g class="nad-edge-infos" transform="translate(-24.50,11.96)">
+                <polyline points="-24.60,12.55 -24.01,8.83"/>
+                <g class="nad-edge-infos" transform="translate(-24.55,12.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7520,8 +7520,8 @@
         </g>
         <g id="412" class="nad-vl120to180-0" title="L104-105-1">
             <g>
-                <polyline points="-23.74,1.65 -25.21,2.87"/>
-                <g class="nad-edge-infos" transform="translate(-23.97,1.84)">
+                <polyline points="-23.51,1.46 -25.21,2.87"/>
+                <g class="nad-edge-infos" transform="translate(-23.74,1.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7539,8 +7539,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-26.68,4.09 -25.21,2.87"/>
-                <g class="nad-edge-infos" transform="translate(-26.45,3.89)">
+                <polyline points="-26.91,4.28 -25.21,2.87"/>
+                <g class="nad-edge-infos" transform="translate(-26.68,4.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7560,8 +7560,8 @@
         </g>
         <g id="413" class="nad-vl120to180-0" title="L105-106-1">
             <g>
-                <polyline points="-27.14,3.88 -27.19,2.30"/>
-                <g class="nad-edge-infos" transform="translate(-27.15,3.58)">
+                <polyline points="-27.13,4.18 -27.19,2.30"/>
+                <g class="nad-edge-infos" transform="translate(-27.14,3.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7579,8 +7579,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-27.24,0.73 -27.19,2.30"/>
-                <g class="nad-edge-infos" transform="translate(-27.23,1.02)">
+                <polyline points="-27.25,0.43 -27.19,2.30"/>
+                <g class="nad-edge-infos" transform="translate(-27.24,0.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7600,8 +7600,8 @@
         </g>
         <g id="414" class="nad-vl120to180-0" title="L105-107-1">
             <g>
-                <polyline points="-27.64,4.21 -28.82,3.65"/>
-                <g class="nad-edge-infos" transform="translate(-27.91,4.08)">
+                <polyline points="-27.37,4.33 -28.82,3.65"/>
+                <g class="nad-edge-infos" transform="translate(-27.64,4.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7619,8 +7619,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-30.01,3.09 -28.82,3.65"/>
-                <g class="nad-edge-infos" transform="translate(-29.74,3.22)">
+                <polyline points="-30.28,2.96 -28.82,3.65"/>
+                <g class="nad-edge-infos" transform="translate(-30.01,3.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(115.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7640,8 +7640,8 @@
         </g>
         <g id="415" class="nad-vl120to180-0" title="L105-108-1">
             <g>
-                <polyline points="-27.39,4.95 -28.32,6.72"/>
-                <g class="nad-edge-infos" transform="translate(-27.53,5.22)">
+                <polyline points="-27.25,4.69 -28.32,6.72"/>
+                <g class="nad-edge-infos" transform="translate(-27.39,4.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7659,8 +7659,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-29.26,8.48 -28.32,6.72"/>
-                <g class="nad-edge-infos" transform="translate(-29.12,8.21)">
+                <polyline points="-29.40,8.74 -28.32,6.72"/>
+                <g class="nad-edge-infos" transform="translate(-29.26,8.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7680,8 +7680,8 @@
         </g>
         <g id="416" class="nad-vl120to180-0" title="L106-107-1">
             <g>
-                <polyline points="-27.70,0.52 -28.89,1.50"/>
-                <g class="nad-edge-infos" transform="translate(-27.93,0.71)">
+                <polyline points="-27.47,0.33 -28.89,1.50"/>
+                <g class="nad-edge-infos" transform="translate(-27.70,0.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7699,8 +7699,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-30.08,2.49 -28.89,1.50"/>
-                <g class="nad-edge-infos" transform="translate(-29.85,2.30)">
+                <polyline points="-30.31,2.68 -28.89,1.50"/>
+                <g class="nad-edge-infos" transform="translate(-30.08,2.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7720,8 +7720,8 @@
         </g>
         <g id="417" class="nad-vl120to180-0" title="L108-109-1">
             <g>
-                <polyline points="-29.41,9.54 -29.15,10.89"/>
-                <g class="nad-edge-infos" transform="translate(-29.36,9.84)">
+                <polyline points="-29.47,9.25 -29.15,10.89"/>
+                <g class="nad-edge-infos" transform="translate(-29.41,9.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7739,8 +7739,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-28.89,12.25 -29.15,10.89"/>
-                <g class="nad-edge-infos" transform="translate(-28.95,11.95)">
+                <polyline points="-28.84,12.54 -29.15,10.89"/>
+                <g class="nad-edge-infos" transform="translate(-28.89,12.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7760,8 +7760,8 @@
         </g>
         <g id="418" class="nad-vl120to180-0" title="L109-110-1">
             <g>
-                <polyline points="-28.22,12.81 -26.71,12.81"/>
-                <g class="nad-edge-infos" transform="translate(-27.92,12.81)">
+                <polyline points="-28.52,12.81 -26.71,12.81"/>
+                <g class="nad-edge-infos" transform="translate(-28.22,12.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7779,8 +7779,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-25.21,12.82 -26.71,12.81"/>
-                <g class="nad-edge-infos" transform="translate(-25.51,12.82)">
+                <polyline points="-24.91,12.82 -26.71,12.81"/>
+                <g class="nad-edge-infos" transform="translate(-25.21,12.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7800,8 +7800,8 @@
         </g>
         <g id="419" class="nad-vl120to180-0" title="L110-111-1">
             <g>
-                <polyline points="-24.30,13.28 -23.32,14.61"/>
-                <g class="nad-edge-infos" transform="translate(-24.12,13.52)">
+                <polyline points="-24.48,13.04 -23.32,14.61"/>
+                <g class="nad-edge-infos" transform="translate(-24.30,13.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7819,8 +7819,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-22.34,15.95 -23.32,14.61"/>
-                <g class="nad-edge-infos" transform="translate(-22.52,15.71)">
+                <polyline points="-22.16,16.19 -23.32,14.61"/>
+                <g class="nad-edge-infos" transform="translate(-22.34,15.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7840,8 +7840,8 @@
         </g>
         <g id="420" class="nad-vl120to180-0" title="L110-112-1">
             <g>
-                <polyline points="-24.83,13.36 -25.48,15.23"/>
-                <g class="nad-edge-infos" transform="translate(-24.93,13.64)">
+                <polyline points="-24.73,13.08 -25.48,15.23"/>
+                <g class="nad-edge-infos" transform="translate(-24.83,13.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-160.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7859,8 +7859,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-26.14,17.10 -25.48,15.23"/>
-                <g class="nad-edge-infos" transform="translate(-26.04,16.82)">
+                <polyline points="-26.24,17.38 -25.48,15.23"/>
+                <g class="nad-edge-infos" transform="translate(-26.14,17.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(19.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7880,8 +7880,8 @@
         </g>
         <g id="421" class="nad-vl120to180-0" title="L114-115-1">
             <g>
-                <polyline points="25.66,13.01 26.79,13.43"/>
-                <g class="nad-edge-infos" transform="translate(25.95,13.11)">
+                <polyline points="25.38,12.91 26.79,13.43"/>
+                <g class="nad-edge-infos" transform="translate(25.66,13.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7899,8 +7899,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="27.91,13.84 26.79,13.43"/>
-                <g class="nad-edge-infos" transform="translate(27.63,13.74)">
+                <polyline points="28.19,13.95 26.79,13.43"/>
+                <g class="nad-edge-infos" transform="translate(27.91,13.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -7920,124 +7920,124 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="20.00,-18.52 20.40,-18.52"/>
-        <polyline id="2_text_edge" points="24.81,-16.98 25.21,-16.98"/>
-        <polyline id="4_text_edge" points="22.80,-19.57 23.20,-19.57"/>
-        <polyline id="6_text_edge" points="21.35,-26.50 21.75,-26.50"/>
-        <polyline id="8_text_edge" points="20.65,-23.13 21.05,-23.13"/>
-        <polyline id="10_text_edge" points="26.29,-25.54 26.69,-25.54"/>
-        <polyline id="12_text_edge" points="29.60,-22.21 30.00,-22.21"/>
-        <polyline id="14_text_edge" points="15.20,-18.27 15.60,-18.27"/>
-        <polyline id="16_text_edge" points="11.09,-22.99 11.49,-22.99"/>
-        <polyline id="18_text_edge" points="8.20,-26.34 8.60,-26.34"/>
-        <polyline id="20_text_edge" points="24.07,-21.79 24.47,-21.79"/>
-        <polyline id="22_text_edge" points="27.95,-16.95 28.35,-16.95"/>
-        <polyline id="24_text_edge" points="21.42,-14.84 21.82,-14.84"/>
-        <polyline id="26_text_edge" points="25.62,-12.34 26.02,-12.34"/>
-        <polyline id="28_text_edge" points="20.88,-9.75 21.28,-9.75"/>
-        <polyline id="30_text_edge" points="28.86,-9.80 29.26,-9.80"/>
-        <polyline id="32_text_edge" points="24.75,-4.82 25.15,-4.82"/>
-        <polyline id="34_text_edge" points="21.09,-4.57 21.49,-4.57"/>
-        <polyline id="36_text_edge" points="16.16,-4.90 16.56,-4.90"/>
-        <polyline id="38_text_edge" points="16.66,1.02 17.06,1.02"/>
-        <polyline id="40_text_edge" points="17.47,6.09 17.87,6.09"/>
-        <polyline id="42_text_edge" points="18.34,11.14 18.74,11.14"/>
-        <polyline id="44_text_edge" points="15.52,9.59 15.92,9.59"/>
-        <polyline id="46_text_edge" points="1.06,11.01 1.46,11.01"/>
-        <polyline id="48_text_edge" points="21.48,6.94 21.88,6.94"/>
-        <polyline id="50_text_edge" points="20.51,0.19 20.91,0.19"/>
-        <polyline id="52_text_edge" points="27.81,9.44 28.21,9.44"/>
-        <polyline id="54_text_edge" points="32.56,8.36 32.96,8.36"/>
-        <polyline id="56_text_edge" points="33.12,4.31 33.52,4.31"/>
-        <polyline id="58_text_edge" points="17.30,-7.44 17.70,-7.44"/>
-        <polyline id="60_text_edge" points="29.03,1.78 29.43,1.78"/>
-        <polyline id="62_text_edge" points="24.99,6.90 25.39,6.90"/>
-        <polyline id="64_text_edge" points="14.99,-11.12 15.39,-11.12"/>
-        <polyline id="66_text_edge" points="7.62,-9.18 8.02,-9.18"/>
-        <polyline id="68_text_edge" points="8.10,-13.66 8.50,-13.66"/>
-        <polyline id="70_text_edge" points="4.74,-13.73 5.14,-13.73"/>
-        <polyline id="72_text_edge" points="10.37,-8.03 10.77,-8.03"/>
-        <polyline id="74_text_edge" points="7.90,-2.88 8.30,-2.88"/>
-        <polyline id="76_text_edge" points="11.43,-5.08 11.83,-5.08"/>
-        <polyline id="78_text_edge" points="10.93,-1.31 11.33,-1.31"/>
-        <polyline id="80_text_edge" points="11.11,2.26 11.51,2.26"/>
-        <polyline id="82_text_edge" points="9.37,5.25 9.77,5.25"/>
-        <polyline id="84_text_edge" points="3.91,-6.08 4.31,-6.08"/>
-        <polyline id="86_text_edge" points="3.79,-0.33 4.19,-0.33"/>
-        <polyline id="88_text_edge" points="5.25,5.85 5.65,5.85"/>
-        <polyline id="90_text_edge" points="7.14,9.30 7.54,9.30"/>
-        <polyline id="92_text_edge" points="3.07,8.59 3.47,8.59"/>
-        <polyline id="94_text_edge" points="8.91,12.74 9.31,12.74"/>
-        <polyline id="96_text_edge" points="4.84,12.94 5.24,12.94"/>
-        <polyline id="98_text_edge" points="6.44,17.57 6.84,17.57"/>
-        <polyline id="100_text_edge" points="11.09,20.14 11.49,20.14"/>
-        <polyline id="102_text_edge" points="15.09,22.79 15.49,22.79"/>
-        <polyline id="104_text_edge" points="11.82,24.49 12.22,24.49"/>
-        <polyline id="106_text_edge" points="4.68,23.24 5.08,23.24"/>
-        <polyline id="108_text_edge" points="3.17,28.41 3.57,28.41"/>
-        <polyline id="110_text_edge" points="5.68,26.41 6.08,26.41"/>
-        <polyline id="112_text_edge" points="7.45,21.89 7.85,21.89"/>
-        <polyline id="114_text_edge" points="9.75,26.93 10.15,26.93"/>
-        <polyline id="116_text_edge" points="0.56,25.77 0.96,25.77"/>
-        <polyline id="118_text_edge" points="-5.60,24.98 -5.20,24.98"/>
-        <polyline id="120_text_edge" points="-2.96,22.64 -2.56,22.64"/>
-        <polyline id="122_text_edge" points="-5.72,20.44 -5.32,20.44"/>
-        <polyline id="124_text_edge" points="-2.37,26.03 -1.97,26.03"/>
-        <polyline id="126_text_edge" points="-1.24,18.66 -0.84,18.66"/>
-        <polyline id="128_text_edge" points="0.04,7.14 0.44,7.14"/>
-        <polyline id="130_text_edge" points="-1.78,14.67 -1.38,14.67"/>
-        <polyline id="132_text_edge" points="-6.39,17.22 -5.99,17.22"/>
-        <polyline id="134_text_edge" points="-2.78,0.47 -2.38,0.47"/>
-        <polyline id="136_text_edge" points="-3.15,4.72 -2.75,4.72"/>
-        <polyline id="138_text_edge" points="-5.99,7.86 -5.59,7.86"/>
-        <polyline id="140_text_edge" points="-9.52,12.08 -9.12,12.08"/>
-        <polyline id="142_text_edge" points="-5.01,12.08 -4.61,12.08"/>
-        <polyline id="144_text_edge" points="-13.40,14.67 -13.00,14.67"/>
-        <polyline id="146_text_edge" points="-9.76,6.82 -9.36,6.82"/>
-        <polyline id="148_text_edge" points="-8.26,3.26 -7.86,3.26"/>
-        <polyline id="150_text_edge" points="-12.59,-0.40 -12.19,-0.40"/>
-        <polyline id="152_text_edge" points="-10.04,-3.30 -9.64,-3.30"/>
-        <polyline id="154_text_edge" points="-7.08,-9.00 -6.68,-9.00"/>
-        <polyline id="156_text_edge" points="-7.52,-12.54 -7.12,-12.54"/>
-        <polyline id="158_text_edge" points="-11.57,-8.75 -11.17,-8.75"/>
-        <polyline id="160_text_edge" points="-6.22,-4.94 -5.82,-4.94"/>
-        <polyline id="162_text_edge" points="-18.42,-8.74 -18.02,-8.74"/>
-        <polyline id="164_text_edge" points="-28.01,-8.70 -27.61,-8.70"/>
-        <polyline id="166_text_edge" points="-31.73,-7.14 -31.33,-7.14"/>
-        <polyline id="168_text_edge" points="-32.98,-10.57 -32.58,-10.57"/>
-        <polyline id="170_text_edge" points="-37.35,-7.11 -36.95,-7.11"/>
-        <polyline id="172_text_edge" points="-39.69,-3.65 -39.29,-3.65"/>
-        <polyline id="174_text_edge" points="-34.30,-14.36 -33.90,-14.36"/>
-        <polyline id="176_text_edge" points="-30.31,-15.03 -29.91,-15.03"/>
-        <polyline id="178_text_edge" points="-29.78,-19.64 -29.38,-19.64"/>
-        <polyline id="180_text_edge" points="-26.07,-19.06 -25.67,-19.06"/>
-        <polyline id="182_text_edge" points="-24.22,-13.73 -23.82,-13.73"/>
-        <polyline id="184_text_edge" points="-21.50,-17.11 -21.10,-17.11"/>
-        <polyline id="186_text_edge" points="-19.69,-13.32 -19.29,-13.32"/>
-        <polyline id="188_text_edge" points="-16.42,-17.06 -16.02,-17.06"/>
-        <polyline id="190_text_edge" points="-15.29,-12.93 -14.89,-12.93"/>
-        <polyline id="192_text_edge" points="-11.66,-14.13 -11.26,-14.13"/>
-        <polyline id="194_text_edge" points="-16.71,-4.36 -16.31,-4.36"/>
-        <polyline id="196_text_edge" points="-15.39,-7.20 -14.99,-7.20"/>
-        <polyline id="198_text_edge" points="-21.48,-4.48 -21.08,-4.48"/>
-        <polyline id="200_text_edge" points="-24.36,-6.26 -23.96,-6.26"/>
-        <polyline id="202_text_edge" points="-24.30,-10.21 -23.90,-10.21"/>
-        <polyline id="204_text_edge" points="-22.78,4.83 -22.38,4.83"/>
-        <polyline id="206_text_edge" points="-22.70,1.29 -22.30,1.29"/>
-        <polyline id="208_text_edge" points="-26.52,4.45 -26.12,4.45"/>
-        <polyline id="210_text_edge" points="-26.66,0.16 -26.26,0.16"/>
-        <polyline id="212_text_edge" points="-29.92,2.85 -29.52,2.85"/>
-        <polyline id="214_text_edge" points="-28.92,8.98 -28.52,8.98"/>
-        <polyline id="216_text_edge" points="-28.19,12.81 -27.79,12.81"/>
-        <polyline id="218_text_edge" points="-24.04,12.82 -23.64,12.82"/>
-        <polyline id="220_text_edge" points="-21.40,16.41 -21.00,16.41"/>
-        <polyline id="222_text_edge" points="-25.73,17.64 -25.33,17.64"/>
-        <polyline id="224_text_edge" points="25.56,0.89 25.96,0.89"/>
-        <polyline id="226_text_edge" points="25.73,12.81 26.13,12.81"/>
-        <polyline id="228_text_edge" points="29.05,14.04 29.45,14.04"/>
-        <polyline id="230_text_edge" points="-1.70,-3.55 -1.30,-3.55"/>
-        <polyline id="232_text_edge" points="32.84,-16.23 33.24,-16.23"/>
-        <polyline id="234_text_edge" points="-12.62,3.08 -12.22,3.08"/>
+        <polyline id="0_text_edge" points="19.70,-18.52 20.40,-18.52"/>
+        <polyline id="2_text_edge" points="24.51,-16.98 25.21,-16.98"/>
+        <polyline id="4_text_edge" points="22.50,-19.57 23.20,-19.57"/>
+        <polyline id="6_text_edge" points="21.05,-26.50 21.75,-26.50"/>
+        <polyline id="8_text_edge" points="20.35,-23.13 21.05,-23.13"/>
+        <polyline id="10_text_edge" points="25.99,-25.54 26.69,-25.54"/>
+        <polyline id="12_text_edge" points="29.30,-22.21 30.00,-22.21"/>
+        <polyline id="14_text_edge" points="14.90,-18.27 15.60,-18.27"/>
+        <polyline id="16_text_edge" points="10.79,-22.99 11.49,-22.99"/>
+        <polyline id="18_text_edge" points="7.90,-26.34 8.60,-26.34"/>
+        <polyline id="20_text_edge" points="23.77,-21.79 24.47,-21.79"/>
+        <polyline id="22_text_edge" points="27.65,-16.95 28.35,-16.95"/>
+        <polyline id="24_text_edge" points="21.12,-14.84 21.82,-14.84"/>
+        <polyline id="26_text_edge" points="25.32,-12.34 26.02,-12.34"/>
+        <polyline id="28_text_edge" points="20.58,-9.75 21.28,-9.75"/>
+        <polyline id="30_text_edge" points="28.56,-9.80 29.26,-9.80"/>
+        <polyline id="32_text_edge" points="24.45,-4.82 25.15,-4.82"/>
+        <polyline id="34_text_edge" points="20.79,-4.57 21.49,-4.57"/>
+        <polyline id="36_text_edge" points="15.86,-4.90 16.56,-4.90"/>
+        <polyline id="38_text_edge" points="16.36,1.02 17.06,1.02"/>
+        <polyline id="40_text_edge" points="17.17,6.09 17.87,6.09"/>
+        <polyline id="42_text_edge" points="18.04,11.14 18.74,11.14"/>
+        <polyline id="44_text_edge" points="15.22,9.59 15.92,9.59"/>
+        <polyline id="46_text_edge" points="0.76,11.01 1.46,11.01"/>
+        <polyline id="48_text_edge" points="21.18,6.94 21.88,6.94"/>
+        <polyline id="50_text_edge" points="20.21,0.19 20.91,0.19"/>
+        <polyline id="52_text_edge" points="27.51,9.44 28.21,9.44"/>
+        <polyline id="54_text_edge" points="32.26,8.36 32.96,8.36"/>
+        <polyline id="56_text_edge" points="32.82,4.31 33.52,4.31"/>
+        <polyline id="58_text_edge" points="17.00,-7.44 17.70,-7.44"/>
+        <polyline id="60_text_edge" points="28.73,1.78 29.43,1.78"/>
+        <polyline id="62_text_edge" points="24.69,6.90 25.39,6.90"/>
+        <polyline id="64_text_edge" points="14.69,-11.12 15.39,-11.12"/>
+        <polyline id="66_text_edge" points="7.32,-9.18 8.02,-9.18"/>
+        <polyline id="68_text_edge" points="7.80,-13.66 8.50,-13.66"/>
+        <polyline id="70_text_edge" points="4.44,-13.73 5.14,-13.73"/>
+        <polyline id="72_text_edge" points="10.07,-8.03 10.77,-8.03"/>
+        <polyline id="74_text_edge" points="7.60,-2.88 8.30,-2.88"/>
+        <polyline id="76_text_edge" points="11.13,-5.08 11.83,-5.08"/>
+        <polyline id="78_text_edge" points="10.63,-1.31 11.33,-1.31"/>
+        <polyline id="80_text_edge" points="10.81,2.26 11.51,2.26"/>
+        <polyline id="82_text_edge" points="9.07,5.25 9.77,5.25"/>
+        <polyline id="84_text_edge" points="3.61,-6.08 4.31,-6.08"/>
+        <polyline id="86_text_edge" points="3.49,-0.33 4.19,-0.33"/>
+        <polyline id="88_text_edge" points="4.95,5.85 5.65,5.85"/>
+        <polyline id="90_text_edge" points="6.84,9.30 7.54,9.30"/>
+        <polyline id="92_text_edge" points="2.77,8.59 3.47,8.59"/>
+        <polyline id="94_text_edge" points="8.61,12.74 9.31,12.74"/>
+        <polyline id="96_text_edge" points="4.54,12.94 5.24,12.94"/>
+        <polyline id="98_text_edge" points="6.14,17.57 6.84,17.57"/>
+        <polyline id="100_text_edge" points="10.79,20.14 11.49,20.14"/>
+        <polyline id="102_text_edge" points="14.79,22.79 15.49,22.79"/>
+        <polyline id="104_text_edge" points="11.52,24.49 12.22,24.49"/>
+        <polyline id="106_text_edge" points="4.38,23.24 5.08,23.24"/>
+        <polyline id="108_text_edge" points="2.87,28.41 3.57,28.41"/>
+        <polyline id="110_text_edge" points="5.38,26.41 6.08,26.41"/>
+        <polyline id="112_text_edge" points="7.15,21.89 7.85,21.89"/>
+        <polyline id="114_text_edge" points="9.45,26.93 10.15,26.93"/>
+        <polyline id="116_text_edge" points="0.26,25.77 0.96,25.77"/>
+        <polyline id="118_text_edge" points="-5.90,24.98 -5.20,24.98"/>
+        <polyline id="120_text_edge" points="-3.26,22.64 -2.56,22.64"/>
+        <polyline id="122_text_edge" points="-6.02,20.44 -5.32,20.44"/>
+        <polyline id="124_text_edge" points="-2.67,26.03 -1.97,26.03"/>
+        <polyline id="126_text_edge" points="-1.54,18.66 -0.84,18.66"/>
+        <polyline id="128_text_edge" points="-0.26,7.14 0.44,7.14"/>
+        <polyline id="130_text_edge" points="-2.08,14.67 -1.38,14.67"/>
+        <polyline id="132_text_edge" points="-6.69,17.22 -5.99,17.22"/>
+        <polyline id="134_text_edge" points="-3.08,0.47 -2.38,0.47"/>
+        <polyline id="136_text_edge" points="-3.45,4.72 -2.75,4.72"/>
+        <polyline id="138_text_edge" points="-6.29,7.86 -5.59,7.86"/>
+        <polyline id="140_text_edge" points="-9.82,12.08 -9.12,12.08"/>
+        <polyline id="142_text_edge" points="-5.31,12.08 -4.61,12.08"/>
+        <polyline id="144_text_edge" points="-13.70,14.67 -13.00,14.67"/>
+        <polyline id="146_text_edge" points="-10.06,6.82 -9.36,6.82"/>
+        <polyline id="148_text_edge" points="-8.56,3.26 -7.86,3.26"/>
+        <polyline id="150_text_edge" points="-12.89,-0.40 -12.19,-0.40"/>
+        <polyline id="152_text_edge" points="-10.34,-3.30 -9.64,-3.30"/>
+        <polyline id="154_text_edge" points="-7.38,-9.00 -6.68,-9.00"/>
+        <polyline id="156_text_edge" points="-7.82,-12.54 -7.12,-12.54"/>
+        <polyline id="158_text_edge" points="-11.87,-8.75 -11.17,-8.75"/>
+        <polyline id="160_text_edge" points="-6.52,-4.94 -5.82,-4.94"/>
+        <polyline id="162_text_edge" points="-18.72,-8.74 -18.02,-8.74"/>
+        <polyline id="164_text_edge" points="-28.31,-8.70 -27.61,-8.70"/>
+        <polyline id="166_text_edge" points="-32.03,-7.14 -31.33,-7.14"/>
+        <polyline id="168_text_edge" points="-33.28,-10.57 -32.58,-10.57"/>
+        <polyline id="170_text_edge" points="-37.65,-7.11 -36.95,-7.11"/>
+        <polyline id="172_text_edge" points="-39.99,-3.65 -39.29,-3.65"/>
+        <polyline id="174_text_edge" points="-34.60,-14.36 -33.90,-14.36"/>
+        <polyline id="176_text_edge" points="-30.61,-15.03 -29.91,-15.03"/>
+        <polyline id="178_text_edge" points="-30.08,-19.64 -29.38,-19.64"/>
+        <polyline id="180_text_edge" points="-26.37,-19.06 -25.67,-19.06"/>
+        <polyline id="182_text_edge" points="-24.52,-13.73 -23.82,-13.73"/>
+        <polyline id="184_text_edge" points="-21.80,-17.11 -21.10,-17.11"/>
+        <polyline id="186_text_edge" points="-19.99,-13.32 -19.29,-13.32"/>
+        <polyline id="188_text_edge" points="-16.72,-17.06 -16.02,-17.06"/>
+        <polyline id="190_text_edge" points="-15.59,-12.93 -14.89,-12.93"/>
+        <polyline id="192_text_edge" points="-11.96,-14.13 -11.26,-14.13"/>
+        <polyline id="194_text_edge" points="-17.01,-4.36 -16.31,-4.36"/>
+        <polyline id="196_text_edge" points="-15.69,-7.20 -14.99,-7.20"/>
+        <polyline id="198_text_edge" points="-21.78,-4.48 -21.08,-4.48"/>
+        <polyline id="200_text_edge" points="-24.66,-6.26 -23.96,-6.26"/>
+        <polyline id="202_text_edge" points="-24.60,-10.21 -23.90,-10.21"/>
+        <polyline id="204_text_edge" points="-23.08,4.83 -22.38,4.83"/>
+        <polyline id="206_text_edge" points="-23.00,1.29 -22.30,1.29"/>
+        <polyline id="208_text_edge" points="-26.82,4.45 -26.12,4.45"/>
+        <polyline id="210_text_edge" points="-26.96,0.16 -26.26,0.16"/>
+        <polyline id="212_text_edge" points="-30.22,2.85 -29.52,2.85"/>
+        <polyline id="214_text_edge" points="-29.22,8.98 -28.52,8.98"/>
+        <polyline id="216_text_edge" points="-28.49,12.81 -27.79,12.81"/>
+        <polyline id="218_text_edge" points="-24.34,12.82 -23.64,12.82"/>
+        <polyline id="220_text_edge" points="-21.70,16.41 -21.00,16.41"/>
+        <polyline id="222_text_edge" points="-26.03,17.64 -25.33,17.64"/>
+        <polyline id="224_text_edge" points="25.26,0.89 25.96,0.89"/>
+        <polyline id="226_text_edge" points="25.43,12.81 26.13,12.81"/>
+        <polyline id="228_text_edge" points="28.75,14.04 29.45,14.04"/>
+        <polyline id="230_text_edge" points="-2.00,-3.55 -1.30,-3.55"/>
+        <polyline id="232_text_edge" points="32.54,-16.23 33.24,-16.23"/>
+        <polyline id="234_text_edge" points="-12.92,3.08 -12.22,3.08"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="20.40" y="-18.52" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -105,71 +105,71 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-3.85,2.05)" id="0" title="VL42">
-            <circle r="0.60" id="1" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(4.13,5.70)" id="2" title="VL45">
-            <circle r="0.60" id="3" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="3" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-0.23,8.91)" id="4" title="VL47">
-            <circle r="0.60" id="5" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="5" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(6.39,8.65)" id="6" title="VL48">
-            <circle r="0.60" id="7" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1.41,4.01)" id="8" title="VL49">
-            <circle r="0.60" id="9" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="9" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(8.91,3.93)" id="10" title="VL50">
-            <circle r="0.60" id="11" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.78,-1.98)" id="12" title="VL51">
-            <circle r="0.60" id="13" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="13" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(11.12,-7.69)" id="14" title="VL52">
-            <circle r="0.60" id="15" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="15" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.78,-9.57)" id="16" title="VL53">
-            <circle r="0.60" id="17" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="17" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2.89,-4.95)" id="18" title="VL54">
-            <circle r="0.60" id="19" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="19" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3.28,-8.53)" id="20" title="VL55">
-            <circle r="0.60" id="21" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="21" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(6.12,-5.44)" id="22" title="VL56">
-            <circle r="0.60" id="23" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="23" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(10.99,0.20)" id="24" title="VL57">
-            <circle r="0.60" id="25" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="25" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(10.79,-4.08)" id="26" title="VL58">
-            <circle r="0.60" id="27" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="27" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-0.36,-8.71)" id="28" title="VL59">
-            <circle r="0.60" id="29" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="29" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-4.78,-7.20)" id="30" title="VL60">
-            <circle r="0.60" id="31" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="31" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-6.10,-9.86)" id="32" title="VL61">
-            <circle r="0.60" id="33" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="33" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2.12,-13.70)" id="34" title="VL63">
-            <circle r="0.60" id="35" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="35" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-8.00,3.10)" id="36" title="VL66">
-            <circle r="0.60" id="37" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="37" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-0.71,13.14)" id="38" title="VL69">
-            <circle r="0.60" id="39" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="39" class="nad-vl120to180-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="42" class="nad-vl120to180-0" title="L40-42-1">
             <g>
-                <polyline points="-3.86,1.48 -3.88,0.40"/>
-                <g class="nad-edge-infos" transform="translate(-3.86,1.18)">
+                <polyline points="-3.85,1.78 -3.88,0.40"/>
+                <g class="nad-edge-infos" transform="translate(-3.86,1.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -189,8 +189,8 @@
         </g>
         <g id="45" class="nad-vl120to180-0" title="L41-42-1">
             <g>
-                <polyline points="-4.37,1.82 -6.44,0.93"/>
-                <g class="nad-edge-infos" transform="translate(-4.65,1.70)">
+                <polyline points="-4.10,1.94 -6.44,0.93"/>
+                <g class="nad-edge-infos" transform="translate(-4.37,1.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -210,7 +210,7 @@
         </g>
         <g id="46" class="nad-vl120to180-0" title="L42-49-1">
             <g>
-                <polyline points="-3.48,2.49 -3.34,2.67 -1.36,3.40"/>
+                <polyline points="-3.68,2.26 -3.34,2.67 -1.36,3.40"/>
                 <g class="nad-edge-infos" transform="translate(-3.06,2.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -229,7 +229,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.85,4.10 0.62,4.14 -1.36,3.40"/>
+                <polyline points="1.15,4.05 0.62,4.14 -1.36,3.40"/>
                 <g class="nad-edge-infos" transform="translate(0.34,4.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -250,7 +250,7 @@
         </g>
         <g id="47" class="nad-vl120to180-0" title="L42-49-2">
             <g>
-                <polyline points="-3.29,1.96 -3.06,1.92 -1.08,2.65"/>
+                <polyline points="-3.58,2.01 -3.06,1.92 -1.08,2.65"/>
                 <g class="nad-edge-infos" transform="translate(-2.78,2.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -269,7 +269,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.05,3.57 0.90,3.39 -1.08,2.65"/>
+                <polyline points="1.24,3.80 0.90,3.39 -1.08,2.65"/>
                 <g class="nad-edge-infos" transform="translate(0.62,3.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -290,8 +290,8 @@
         </g>
         <g id="50" class="nad-vl120to180-0" title="L44-45-1">
             <g>
-                <polyline points="4.31,5.16 4.69,4.00"/>
-                <g class="nad-edge-infos" transform="translate(4.40,4.88)">
+                <polyline points="4.21,5.45 4.69,4.00"/>
+                <g class="nad-edge-infos" transform="translate(4.31,5.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -311,8 +311,8 @@
         </g>
         <g id="53" class="nad-vl120to180-0" title="L45-46-1">
             <g>
-                <polyline points="4.02,6.26 3.76,7.61"/>
-                <g class="nad-edge-infos" transform="translate(3.97,6.56)">
+                <polyline points="4.08,5.97 3.76,7.61"/>
+                <g class="nad-edge-infos" transform="translate(4.02,6.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -332,8 +332,8 @@
         </g>
         <g id="54" class="nad-vl120to180-0" title="L45-49-1">
             <g>
-                <polyline points="3.65,5.40 2.77,4.85"/>
-                <g class="nad-edge-infos" transform="translate(3.39,5.24)">
+                <polyline points="3.90,5.56 2.77,4.85"/>
+                <g class="nad-edge-infos" transform="translate(3.65,5.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -351,8 +351,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.90,4.31 2.77,4.85"/>
-                <g class="nad-edge-infos" transform="translate(2.15,4.47)">
+                <polyline points="1.64,4.15 2.77,4.85"/>
+                <g class="nad-edge-infos" transform="translate(1.90,4.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -372,8 +372,8 @@
         </g>
         <g id="55" class="nad-vl120to180-0" title="L46-47-1">
             <g>
-                <polyline points="0.33,9.01 1.58,9.21"/>
-                <g class="nad-edge-infos" transform="translate(0.63,9.06)">
+                <polyline points="0.04,8.96 1.58,9.21"/>
+                <g class="nad-edge-infos" transform="translate(0.33,9.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -393,8 +393,8 @@
         </g>
         <g id="56" class="nad-vl120to180-0" title="L47-49-1">
             <g>
-                <polyline points="-0.05,8.37 0.59,6.46"/>
-                <g class="nad-edge-infos" transform="translate(0.05,8.09)">
+                <polyline points="-0.14,8.66 0.59,6.46"/>
+                <g class="nad-edge-infos" transform="translate(-0.05,8.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -412,8 +412,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.23,4.55 0.59,6.46"/>
-                <g class="nad-edge-infos" transform="translate(1.14,4.83)">
+                <polyline points="1.33,4.26 0.59,6.46"/>
+                <g class="nad-edge-infos" transform="translate(1.23,4.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -433,8 +433,8 @@
         </g>
         <g id="57" class="nad-vl120to180-0" title="L47-69-1">
             <g>
-                <polyline points="-0.29,9.48 -0.47,11.03"/>
-                <g class="nad-edge-infos" transform="translate(-0.33,9.78)">
+                <polyline points="-0.26,9.18 -0.47,11.03"/>
+                <g class="nad-edge-infos" transform="translate(-0.29,9.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -452,8 +452,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.65,12.57 -0.47,11.03"/>
-                <g class="nad-edge-infos" transform="translate(-0.61,12.27)">
+                <polyline points="-0.68,12.87 -0.47,11.03"/>
+                <g class="nad-edge-infos" transform="translate(-0.65,12.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -473,8 +473,8 @@
         </g>
         <g id="58" class="nad-vl120to180-0" title="L46-48-1">
             <g>
-                <polyline points="5.84,8.81 4.90,9.08"/>
-                <g class="nad-edge-infos" transform="translate(5.56,8.89)">
+                <polyline points="6.13,8.72 4.90,9.08"/>
+                <g class="nad-edge-infos" transform="translate(5.84,8.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -494,8 +494,8 @@
         </g>
         <g id="59" class="nad-vl120to180-0" title="L48-49-1">
             <g>
-                <polyline points="5.98,8.26 3.90,6.33"/>
-                <g class="nad-edge-infos" transform="translate(5.76,8.05)">
+                <polyline points="6.19,8.46 3.90,6.33"/>
+                <g class="nad-edge-infos" transform="translate(5.98,8.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -513,8 +513,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.83,4.40 3.90,6.33"/>
-                <g class="nad-edge-infos" transform="translate(2.05,4.60)">
+                <polyline points="1.61,4.19 3.90,6.33"/>
+                <g class="nad-edge-infos" transform="translate(1.83,4.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -534,8 +534,8 @@
         </g>
         <g id="60" class="nad-vl120to180-0" title="L49-50-1">
             <g>
-                <polyline points="1.98,4.00 5.16,3.97"/>
-                <g class="nad-edge-infos" transform="translate(2.28,4.00)">
+                <polyline points="1.68,4.00 5.16,3.97"/>
+                <g class="nad-edge-infos" transform="translate(1.98,4.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -553,8 +553,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.34,3.94 5.16,3.97"/>
-                <g class="nad-edge-infos" transform="translate(8.04,3.94)">
+                <polyline points="8.64,3.93 5.16,3.97"/>
+                <g class="nad-edge-infos" transform="translate(8.34,3.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -574,8 +574,8 @@
         </g>
         <g id="61" class="nad-vl120to180-0" title="L49-51-1">
             <g>
-                <polyline points="1.83,3.62 4.60,1.01"/>
-                <g class="nad-edge-infos" transform="translate(2.05,3.41)">
+                <polyline points="1.61,3.82 4.60,1.01"/>
+                <g class="nad-edge-infos" transform="translate(1.83,3.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -593,8 +593,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.37,-1.59 4.60,1.01"/>
-                <g class="nad-edge-infos" transform="translate(7.15,-1.39)">
+                <polyline points="7.59,-1.80 4.60,1.01"/>
+                <g class="nad-edge-infos" transform="translate(7.37,-1.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -614,7 +614,7 @@
         </g>
         <g id="62" class="nad-vl120to180-0" title="L49-54-1">
             <g>
-                <polyline points="1.77,3.57 1.92,3.39 2.55,-0.40"/>
+                <polyline points="1.58,3.80 1.92,3.39 2.55,-0.40"/>
                 <g class="nad-edge-infos" transform="translate(1.97,3.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -633,7 +633,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.09,-4.41 3.17,-4.20 2.55,-0.40"/>
+                <polyline points="2.99,-4.69 3.17,-4.20 2.55,-0.40"/>
                 <g class="nad-edge-infos" transform="translate(3.12,-3.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -654,7 +654,7 @@
         </g>
         <g id="63" class="nad-vl120to180-0" title="L49-54-2">
             <g>
-                <polyline points="1.21,3.47 1.13,3.26 1.76,-0.53"/>
+                <polyline points="1.32,3.75 1.13,3.26 1.76,-0.53"/>
                 <g class="nad-edge-infos" transform="translate(1.18,2.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -673,7 +673,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.53,-4.50 2.38,-4.33 1.76,-0.53"/>
+                <polyline points="2.72,-4.74 2.38,-4.33 1.76,-0.53"/>
                 <g class="nad-edge-infos" transform="translate(2.33,-4.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -694,7 +694,7 @@
         </g>
         <g id="64" class="nad-vl120to180-0" title="L49-66-1">
             <g>
-                <polyline points="0.95,3.68 0.76,3.54 -3.26,3.16"/>
+                <polyline points="1.19,3.85 0.76,3.54 -3.26,3.16"/>
                 <g class="nad-edge-infos" transform="translate(0.46,3.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -713,7 +713,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-7.48,2.86 -7.27,2.77 -3.26,3.16"/>
+                <polyline points="-7.76,2.99 -7.27,2.77 -3.26,3.16"/>
                 <g class="nad-edge-infos" transform="translate(-6.98,2.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -734,7 +734,7 @@
         </g>
         <g id="65" class="nad-vl120to180-0" title="L49-66-2">
             <g>
-                <polyline points="0.89,4.24 0.69,4.34 -3.33,3.95"/>
+                <polyline points="1.17,4.12 0.69,4.34 -3.33,3.95"/>
                 <g class="nad-edge-infos" transform="translate(0.39,4.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -753,7 +753,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-7.54,3.43 -7.35,3.56 -3.33,3.95"/>
+                <polyline points="-7.78,3.26 -7.35,3.56 -3.33,3.95"/>
                 <g class="nad-edge-infos" transform="translate(-7.05,3.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -774,8 +774,8 @@
         </g>
         <g id="66" class="nad-vl120to180-0" title="L49-69-1">
             <g>
-                <polyline points="1.28,4.56 0.35,8.57"/>
-                <g class="nad-edge-infos" transform="translate(1.22,4.85)">
+                <polyline points="1.35,4.27 0.35,8.57"/>
+                <g class="nad-edge-infos" transform="translate(1.28,4.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -793,8 +793,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.58,12.58 0.35,8.57"/>
-                <g class="nad-edge-infos" transform="translate(-0.52,12.29)">
+                <polyline points="-0.65,12.88 0.35,8.57"/>
+                <g class="nad-edge-infos" transform="translate(-0.58,12.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -814,8 +814,8 @@
         </g>
         <g id="67" class="nad-vl120to180-0" title="L50-57-1">
             <g>
-                <polyline points="9.18,3.43 9.95,2.07"/>
-                <g class="nad-edge-infos" transform="translate(9.33,3.17)">
+                <polyline points="9.04,3.69 9.95,2.07"/>
+                <g class="nad-edge-infos" transform="translate(9.18,3.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -833,8 +833,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.71,0.70 9.95,2.07"/>
-                <g class="nad-edge-infos" transform="translate(10.56,0.96)">
+                <polyline points="10.86,0.44 9.95,2.07"/>
+                <g class="nad-edge-infos" transform="translate(10.71,0.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -854,8 +854,8 @@
         </g>
         <g id="68" class="nad-vl120to180-0" title="L51-52-1">
             <g>
-                <polyline points="8.07,-2.47 9.45,-4.84"/>
-                <g class="nad-edge-infos" transform="translate(8.22,-2.73)">
+                <polyline points="7.92,-2.22 9.45,-4.84"/>
+                <g class="nad-edge-infos" transform="translate(8.07,-2.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -873,8 +873,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.83,-7.20 9.45,-4.84"/>
-                <g class="nad-edge-infos" transform="translate(10.68,-6.94)">
+                <polyline points="10.99,-7.46 9.45,-4.84"/>
+                <g class="nad-edge-infos" transform="translate(10.83,-7.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -894,8 +894,8 @@
         </g>
         <g id="69" class="nad-vl120to180-0" title="L51-58-1">
             <g>
-                <polyline points="8.25,-2.31 9.29,-3.03"/>
-                <g class="nad-edge-infos" transform="translate(8.50,-2.48)">
+                <polyline points="8.01,-2.14 9.29,-3.03"/>
+                <g class="nad-edge-infos" transform="translate(8.25,-2.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -913,8 +913,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.32,-3.76 9.29,-3.03"/>
-                <g class="nad-edge-infos" transform="translate(10.07,-3.59)">
+                <polyline points="10.57,-3.93 9.29,-3.03"/>
+                <g class="nad-edge-infos" transform="translate(10.32,-3.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -934,8 +934,8 @@
         </g>
         <g id="70" class="nad-vl120to180-0" title="L52-53-1">
             <g>
-                <polyline points="10.62,-7.97 9.45,-8.63"/>
-                <g class="nad-edge-infos" transform="translate(10.36,-8.12)">
+                <polyline points="10.89,-7.83 9.45,-8.63"/>
+                <g class="nad-edge-infos" transform="translate(10.62,-7.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -953,8 +953,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.28,-9.29 9.45,-8.63"/>
-                <g class="nad-edge-infos" transform="translate(8.54,-9.15)">
+                <polyline points="8.01,-9.44 9.45,-8.63"/>
+                <g class="nad-edge-infos" transform="translate(8.28,-9.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -974,8 +974,8 @@
         </g>
         <g id="71" class="nad-vl120to180-0" title="L53-54-1">
             <g>
-                <polyline points="7.37,-9.18 5.33,-7.26"/>
-                <g class="nad-edge-infos" transform="translate(7.15,-8.97)">
+                <polyline points="7.58,-9.39 5.33,-7.26"/>
+                <g class="nad-edge-infos" transform="translate(7.37,-9.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -993,8 +993,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.30,-5.34 5.33,-7.26"/>
-                <g class="nad-edge-infos" transform="translate(3.52,-5.54)">
+                <polyline points="3.09,-5.13 5.33,-7.26"/>
+                <g class="nad-edge-infos" transform="translate(3.30,-5.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1014,8 +1014,8 @@
         </g>
         <g id="72" class="nad-vl120to180-0" title="L54-55-1">
             <g>
-                <polyline points="2.95,-5.51 3.08,-6.74"/>
-                <g class="nad-edge-infos" transform="translate(2.98,-5.81)">
+                <polyline points="2.92,-5.21 3.08,-6.74"/>
+                <g class="nad-edge-infos" transform="translate(2.95,-5.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1033,8 +1033,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.22,-7.97 3.08,-6.74"/>
-                <g class="nad-edge-infos" transform="translate(3.18,-7.67)">
+                <polyline points="3.25,-8.27 3.08,-6.74"/>
+                <g class="nad-edge-infos" transform="translate(3.22,-7.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1054,8 +1054,8 @@
         </g>
         <g id="73" class="nad-vl120to180-0" title="L54-56-1">
             <g>
-                <polyline points="3.45,-5.03 4.51,-5.19"/>
-                <g class="nad-edge-infos" transform="translate(3.75,-5.08)">
+                <polyline points="3.16,-4.99 4.51,-5.19"/>
+                <g class="nad-edge-infos" transform="translate(3.45,-5.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1073,8 +1073,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.56,-5.36 4.51,-5.19"/>
-                <g class="nad-edge-infos" transform="translate(5.26,-5.31)">
+                <polyline points="5.85,-5.40 4.51,-5.19"/>
+                <g class="nad-edge-infos" transform="translate(5.56,-5.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1094,8 +1094,8 @@
         </g>
         <g id="74" class="nad-vl120to180-0" title="L54-59-1">
             <g>
-                <polyline points="2.52,-5.38 1.27,-6.83"/>
-                <g class="nad-edge-infos" transform="translate(2.32,-5.60)">
+                <polyline points="2.71,-5.15 1.27,-6.83"/>
+                <g class="nad-edge-infos" transform="translate(2.52,-5.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1113,8 +1113,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.01,-8.28 1.27,-6.83"/>
-                <g class="nad-edge-infos" transform="translate(0.21,-8.05)">
+                <polyline points="-0.18,-8.50 1.27,-6.83"/>
+                <g class="nad-edge-infos" transform="translate(0.01,-8.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1134,8 +1134,8 @@
         </g>
         <g id="75" class="nad-vl120to180-0" title="L55-56-1">
             <g>
-                <polyline points="3.66,-8.11 4.70,-6.99"/>
-                <g class="nad-edge-infos" transform="translate(3.87,-7.89)">
+                <polyline points="3.46,-8.34 4.70,-6.99"/>
+                <g class="nad-edge-infos" transform="translate(3.66,-8.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1153,8 +1153,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.73,-5.86 4.70,-6.99"/>
-                <g class="nad-edge-infos" transform="translate(5.53,-6.08)">
+                <polyline points="5.94,-5.64 4.70,-6.99"/>
+                <g class="nad-edge-infos" transform="translate(5.73,-5.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1174,8 +1174,8 @@
         </g>
         <g id="76" class="nad-vl120to180-0" title="L55-59-1">
             <g>
-                <polyline points="2.71,-8.56 1.46,-8.62"/>
-                <g class="nad-edge-infos" transform="translate(2.41,-8.58)">
+                <polyline points="3.01,-8.55 1.46,-8.62"/>
+                <g class="nad-edge-infos" transform="translate(2.71,-8.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1193,8 +1193,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.21,-8.68 1.46,-8.62"/>
-                <g class="nad-edge-infos" transform="translate(0.51,-8.67)">
+                <polyline points="-0.09,-8.69 1.46,-8.62"/>
+                <g class="nad-edge-infos" transform="translate(0.21,-8.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1214,8 +1214,8 @@
         </g>
         <g id="77" class="nad-vl120to180-0" title="L56-57-1">
             <g>
-                <polyline points="6.49,-5.01 8.55,-2.62"/>
-                <g class="nad-edge-infos" transform="translate(6.69,-4.78)">
+                <polyline points="6.30,-5.24 8.55,-2.62"/>
+                <g class="nad-edge-infos" transform="translate(6.49,-5.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1233,8 +1233,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.62,-0.23 8.55,-2.62"/>
-                <g class="nad-edge-infos" transform="translate(10.42,-0.46)">
+                <polyline points="10.81,-0.00 8.55,-2.62"/>
+                <g class="nad-edge-infos" transform="translate(10.62,-0.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1254,8 +1254,8 @@
         </g>
         <g id="78" class="nad-vl120to180-0" title="L56-58-1">
             <g>
-                <polyline points="6.67,-5.28 8.45,-4.76"/>
-                <g class="nad-edge-infos" transform="translate(6.96,-5.20)">
+                <polyline points="6.38,-5.37 8.45,-4.76"/>
+                <g class="nad-edge-infos" transform="translate(6.67,-5.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1273,8 +1273,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.24,-4.24 8.45,-4.76"/>
-                <g class="nad-edge-infos" transform="translate(9.95,-4.33)">
+                <polyline points="10.53,-4.16 8.45,-4.76"/>
+                <g class="nad-edge-infos" transform="translate(10.24,-4.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1294,7 +1294,7 @@
         </g>
         <g id="79" class="nad-vl120to180-0" title="L56-59-1">
             <g>
-                <polyline points="5.81,-5.92 5.68,-6.11 3.06,-7.43"/>
+                <polyline points="5.97,-5.67 5.68,-6.11 3.06,-7.43"/>
                 <g class="nad-edge-infos" transform="translate(5.41,-6.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1313,7 +1313,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.21,-8.74 0.44,-8.75 3.06,-7.43"/>
+                <polyline points="-0.09,-8.72 0.44,-8.75 3.06,-7.43"/>
                 <g class="nad-edge-infos" transform="translate(0.71,-8.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1334,7 +1334,7 @@
         </g>
         <g id="80" class="nad-vl120to180-0" title="L56-59-2">
             <g>
-                <polyline points="5.55,-5.41 5.32,-5.40 2.70,-6.72"/>
+                <polyline points="5.85,-5.43 5.32,-5.40 2.70,-6.72"/>
                 <g class="nad-edge-infos" transform="translate(5.05,-5.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1353,7 +1353,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.05,-8.23 0.08,-8.04 2.70,-6.72"/>
+                <polyline points="-0.21,-8.48 0.08,-8.04 2.70,-6.72"/>
                 <g class="nad-edge-infos" transform="translate(0.35,-7.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1374,8 +1374,8 @@
         </g>
         <g id="81" class="nad-vl120to180-0" title="L59-60-1">
             <g>
-                <polyline points="-0.90,-8.52 -2.57,-7.95"/>
-                <g class="nad-edge-infos" transform="translate(-1.18,-8.43)">
+                <polyline points="-0.61,-8.62 -2.57,-7.95"/>
+                <g class="nad-edge-infos" transform="translate(-0.90,-8.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1393,8 +1393,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.24,-7.38 -2.57,-7.95"/>
-                <g class="nad-edge-infos" transform="translate(-3.96,-7.48)">
+                <polyline points="-4.53,-7.29 -2.57,-7.95"/>
+                <g class="nad-edge-infos" transform="translate(-4.24,-7.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1414,8 +1414,8 @@
         </g>
         <g id="82" class="nad-vl120to180-0" title="L59-61-1">
             <g>
-                <polyline points="-0.92,-8.82 -3.23,-9.28"/>
-                <g class="nad-edge-infos" transform="translate(-1.21,-8.88)">
+                <polyline points="-0.62,-8.76 -3.23,-9.28"/>
+                <g class="nad-edge-infos" transform="translate(-0.92,-8.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1433,8 +1433,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.54,-9.75 -3.23,-9.28"/>
-                <g class="nad-edge-infos" transform="translate(-5.24,-9.69)">
+                <polyline points="-5.83,-9.81 -3.23,-9.28"/>
+                <g class="nad-edge-infos" transform="translate(-5.54,-9.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(101.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1454,8 +1454,8 @@
         </g>
         <g id="83" title="T63-59-1">
             <g class="nad-vl120to180-1">
-                <polyline points="-1.93,-13.16 -1.24,-11.20"/>
-                <g class="nad-edge-infos" transform="translate(-1.83,-12.88)">
+                <polyline points="-2.03,-13.44 -1.24,-11.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.93,-13.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1474,8 +1474,8 @@
                 <circle cx="-1.27" cy="-11.30" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.55,-9.24 -1.24,-11.20"/>
-                <g class="nad-edge-infos" transform="translate(-0.65,-9.53)">
+                <polyline points="-0.45,-8.96 -1.24,-11.20"/>
+                <g class="nad-edge-infos" transform="translate(-0.55,-9.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1496,8 +1496,8 @@
         </g>
         <g id="84" class="nad-vl120to180-0" title="L60-61-1">
             <g>
-                <polyline points="-5.04,-7.71 -5.44,-8.53"/>
-                <g class="nad-edge-infos" transform="translate(-5.17,-7.98)">
+                <polyline points="-4.90,-7.44 -5.44,-8.53"/>
+                <g class="nad-edge-infos" transform="translate(-5.04,-7.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1515,8 +1515,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.84,-9.35 -5.44,-8.53"/>
-                <g class="nad-edge-infos" transform="translate(-5.71,-9.08)">
+                <polyline points="-5.98,-9.62 -5.44,-8.53"/>
+                <g class="nad-edge-infos" transform="translate(-5.84,-9.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1536,8 +1536,8 @@
         </g>
         <g id="87" class="nad-vl120to180-0" title="L60-62-1">
             <g>
-                <polyline points="-5.25,-6.87 -6.45,-6.00"/>
-                <g class="nad-edge-infos" transform="translate(-5.49,-6.69)">
+                <polyline points="-5.00,-7.04 -6.45,-6.00"/>
+                <g class="nad-edge-infos" transform="translate(-5.25,-6.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1557,8 +1557,8 @@
         </g>
         <g id="88" class="nad-vl120to180-0" title="L61-62-1">
             <g>
-                <polyline points="-6.31,-9.33 -7.10,-7.33"/>
-                <g class="nad-edge-infos" transform="translate(-6.42,-9.05)">
+                <polyline points="-6.20,-9.61 -7.10,-7.33"/>
+                <g class="nad-edge-infos" transform="translate(-6.31,-9.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1581,8 +1581,8 @@
                 <circle cx="-6.09" cy="-12.14" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-6.10,-10.43 -6.09,-12.04"/>
-                <g class="nad-edge-infos" transform="translate(-6.10,-10.73)">
+                <polyline points="-6.10,-10.13 -6.09,-12.04"/>
+                <g class="nad-edge-infos" transform="translate(-6.10,-10.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1603,8 +1603,8 @@
         </g>
         <g id="92" class="nad-vl120to180-1" title="L63-64-1">
             <g>
-                <polyline points="-2.68,-13.77 -4.10,-13.96"/>
-                <g class="nad-edge-infos" transform="translate(-2.98,-13.81)">
+                <polyline points="-2.39,-13.73 -4.10,-13.96"/>
+                <g class="nad-edge-infos" transform="translate(-2.68,-13.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1624,8 +1624,8 @@
         </g>
         <g id="93" class="nad-vl120to180-0" title="L62-66-1">
             <g>
-                <polyline points="-8.01,2.53 -8.06,-0.85"/>
-                <g class="nad-edge-infos" transform="translate(-8.01,2.23)">
+                <polyline points="-8.01,2.83 -8.06,-0.85"/>
+                <g class="nad-edge-infos" transform="translate(-8.01,2.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1648,8 +1648,8 @@
                 <circle cx="-9.46" cy="5.16" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-8.33,3.57 -9.40,5.08"/>
-                <g class="nad-edge-infos" transform="translate(-8.51,3.81)">
+                <polyline points="-8.16,3.32 -9.40,5.08"/>
+                <g class="nad-edge-infos" transform="translate(-8.33,3.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1670,8 +1670,8 @@
         </g>
         <g id="99" class="nad-vl120to180-0" title="L66-67-1">
             <g>
-                <polyline points="-8.57,3.11 -10.70,3.14"/>
-                <g class="nad-edge-infos" transform="translate(-8.87,3.11)">
+                <polyline points="-8.27,3.10 -10.70,3.14"/>
+                <g class="nad-edge-infos" transform="translate(-8.57,3.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1694,8 +1694,8 @@
                 <circle cx="1.60" cy="14.46" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.22,13.42 1.51,14.41"/>
-                <g class="nad-edge-infos" transform="translate(0.04,13.57)">
+                <polyline points="-0.48,13.27 1.51,14.41"/>
+                <g class="nad-edge-infos" transform="translate(-0.22,13.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1716,8 +1716,8 @@
         </g>
         <g id="105" class="nad-vl120to180-0" title="L69-70-1">
             <g>
-                <polyline points="-1.05,13.60 -2.25,15.26"/>
-                <g class="nad-edge-infos" transform="translate(-1.22,13.84)">
+                <polyline points="-0.87,13.36 -2.25,15.26"/>
+                <g class="nad-edge-infos" transform="translate(-1.05,13.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1737,8 +1737,8 @@
         </g>
         <g id="108" class="nad-vl120to180-0" title="L69-75-1">
             <g>
-                <polyline points="-1.28,13.18 -3.05,13.29"/>
-                <g class="nad-edge-infos" transform="translate(-1.58,13.20)">
+                <polyline points="-0.98,13.16 -3.05,13.29"/>
+                <g class="nad-edge-infos" transform="translate(-1.28,13.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1758,8 +1758,8 @@
         </g>
         <g id="111" class="nad-vl120to180-0" title="L69-77-1">
             <g>
-                <polyline points="-0.59,13.70 -0.16,15.66"/>
-                <g class="nad-edge-infos" transform="translate(-0.53,13.99)">
+                <polyline points="-0.66,13.40 -0.16,15.66"/>
+                <g class="nad-edge-infos" transform="translate(-0.59,13.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1779,26 +1779,26 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-3.25,2.05 -2.85,2.05"/>
-        <polyline id="2_text_edge" points="4.73,5.70 5.13,5.70"/>
-        <polyline id="4_text_edge" points="0.37,8.91 0.77,8.91"/>
-        <polyline id="6_text_edge" points="6.99,8.65 7.39,8.65"/>
-        <polyline id="8_text_edge" points="2.01,4.01 2.41,4.01"/>
-        <polyline id="10_text_edge" points="9.51,3.93 9.91,3.93"/>
-        <polyline id="12_text_edge" points="8.38,-1.98 8.78,-1.98"/>
-        <polyline id="14_text_edge" points="11.72,-7.69 12.12,-7.69"/>
-        <polyline id="16_text_edge" points="8.38,-9.57 8.78,-9.57"/>
-        <polyline id="18_text_edge" points="3.49,-4.95 3.89,-4.95"/>
-        <polyline id="20_text_edge" points="3.88,-8.53 4.28,-8.53"/>
-        <polyline id="22_text_edge" points="6.72,-5.44 7.12,-5.44"/>
-        <polyline id="24_text_edge" points="11.59,0.20 11.99,0.20"/>
-        <polyline id="26_text_edge" points="11.39,-4.08 11.79,-4.08"/>
-        <polyline id="28_text_edge" points="0.24,-8.71 0.64,-8.71"/>
-        <polyline id="30_text_edge" points="-4.18,-7.20 -3.78,-7.20"/>
-        <polyline id="32_text_edge" points="-5.50,-9.86 -5.10,-9.86"/>
-        <polyline id="34_text_edge" points="-1.52,-13.70 -1.12,-13.70"/>
-        <polyline id="36_text_edge" points="-7.40,3.10 -7.00,3.10"/>
-        <polyline id="38_text_edge" points="-0.11,13.14 0.29,13.14"/>
+        <polyline id="0_text_edge" points="-3.55,2.05 -2.85,2.05"/>
+        <polyline id="2_text_edge" points="4.43,5.70 5.13,5.70"/>
+        <polyline id="4_text_edge" points="0.07,8.91 0.77,8.91"/>
+        <polyline id="6_text_edge" points="6.69,8.65 7.39,8.65"/>
+        <polyline id="8_text_edge" points="1.71,4.01 2.41,4.01"/>
+        <polyline id="10_text_edge" points="9.21,3.93 9.91,3.93"/>
+        <polyline id="12_text_edge" points="8.08,-1.98 8.78,-1.98"/>
+        <polyline id="14_text_edge" points="11.42,-7.69 12.12,-7.69"/>
+        <polyline id="16_text_edge" points="8.08,-9.57 8.78,-9.57"/>
+        <polyline id="18_text_edge" points="3.19,-4.95 3.89,-4.95"/>
+        <polyline id="20_text_edge" points="3.58,-8.53 4.28,-8.53"/>
+        <polyline id="22_text_edge" points="6.42,-5.44 7.12,-5.44"/>
+        <polyline id="24_text_edge" points="11.29,0.20 11.99,0.20"/>
+        <polyline id="26_text_edge" points="11.09,-4.08 11.79,-4.08"/>
+        <polyline id="28_text_edge" points="-0.06,-8.71 0.64,-8.71"/>
+        <polyline id="30_text_edge" points="-4.48,-7.20 -3.78,-7.20"/>
+        <polyline id="32_text_edge" points="-5.80,-9.86 -5.10,-9.86"/>
+        <polyline id="34_text_edge" points="-1.82,-13.70 -1.12,-13.70"/>
+        <polyline id="36_text_edge" points="-7.70,3.10 -7.00,3.10"/>
+        <polyline id="38_text_edge" points="-0.41,13.14 0.29,13.14"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-2.85" y="2.05" style="dominant-baseline:middle">VL42</text>

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -105,41 +105,41 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-7.57,5.92)" id="0" title="VL23">
-            <circle r="0.60" id="1" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-14.08,4.33)" id="2" title="VL27">
-            <circle r="0.60" id="3" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="3" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2.43,-6.33)" id="4" title="VL30">
-            <circle r="0.60" id="5" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="5" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-8.38,-5.53)" id="6" title="VL31">
-            <circle r="0.60" id="7" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-10.01,0.31)" id="8" title="VL32">
-            <circle r="0.60" id="9" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="9" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(9.39,5.48)" id="10" title="VL37">
-            <circle r="0.60" id="11" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(7.95,-2.10)" id="12" title="VL38">
-            <circle r="0.60" id="13" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="13" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(12.70,-5.60)" id="14" title="VL65">
-            <circle r="0.60" id="15" class="nad-vl120to180-1"/>
+            <circle r="0.30" id="15" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-5.91,-1.84)" id="16" title="VL113">
-            <circle r="0.60" id="17" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="17" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-14.31,-1.32)" id="18" title="VL114">
-            <circle r="0.60" id="19" class="nad-vl120to180-0"/>
+            <circle r="0.30" id="19" class="nad-vl120to180-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22" class="nad-vl120to180-0" title="L22-23-1">
             <g>
-                <polyline points="-7.40,6.46 -6.85,8.18"/>
-                <g class="nad-edge-infos" transform="translate(-7.31,6.74)">
+                <polyline points="-7.49,6.17 -6.85,8.18"/>
+                <g class="nad-edge-infos" transform="translate(-7.40,6.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(162.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -159,8 +159,8 @@
         </g>
         <g id="25" class="nad-vl120to180-0" title="L23-24-1">
             <g>
-                <polyline points="-7.00,5.91 -5.58,5.90"/>
-                <g class="nad-edge-infos" transform="translate(-6.70,5.91)">
+                <polyline points="-7.30,5.91 -5.58,5.90"/>
+                <g class="nad-edge-infos" transform="translate(-7.00,5.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -180,8 +180,8 @@
         </g>
         <g id="28" class="nad-vl120to180-0" title="L23-25-1">
             <g>
-                <polyline points="-8.10,6.12 -9.42,6.64"/>
-                <g class="nad-edge-infos" transform="translate(-8.38,6.23)">
+                <polyline points="-7.82,6.01 -9.42,6.64"/>
+                <g class="nad-edge-infos" transform="translate(-8.10,6.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -201,8 +201,8 @@
         </g>
         <g id="29" class="nad-vl120to180-0" title="L23-32-1">
             <g>
-                <polyline points="-7.80,5.39 -8.79,3.11"/>
-                <g class="nad-edge-infos" transform="translate(-7.92,5.12)">
+                <polyline points="-7.68,5.67 -8.79,3.11"/>
+                <g class="nad-edge-infos" transform="translate(-7.80,5.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-23.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -220,8 +220,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.78,0.83 -8.79,3.11"/>
-                <g class="nad-edge-infos" transform="translate(-9.66,1.11)">
+                <polyline points="-9.90,0.56 -8.79,3.11"/>
+                <g class="nad-edge-infos" transform="translate(-9.78,0.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(156.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -241,8 +241,8 @@
         </g>
         <g id="30" class="nad-vl120to180-0" title="L25-27-1">
             <g>
-                <polyline points="-13.69,4.75 -12.68,5.85"/>
-                <g class="nad-edge-infos" transform="translate(-13.49,4.97)">
+                <polyline points="-13.90,4.53 -12.68,5.85"/>
+                <g class="nad-edge-infos" transform="translate(-13.69,4.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -262,8 +262,8 @@
         </g>
         <g id="33" class="nad-vl120to180-0" title="L27-28-1">
             <g>
-                <polyline points="-14.45,4.76 -15.56,6.06"/>
-                <g class="nad-edge-infos" transform="translate(-14.65,4.99)">
+                <polyline points="-14.26,4.53 -15.56,6.06"/>
+                <g class="nad-edge-infos" transform="translate(-14.45,4.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -283,8 +283,8 @@
         </g>
         <g id="34" class="nad-vl120to180-0" title="L27-32-1">
             <g>
-                <polyline points="-13.68,3.93 -12.05,2.32"/>
-                <g class="nad-edge-infos" transform="translate(-13.46,3.72)">
+                <polyline points="-13.89,4.14 -12.05,2.32"/>
+                <g class="nad-edge-infos" transform="translate(-13.68,3.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -302,8 +302,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.42,0.71 -12.05,2.32"/>
-                <g class="nad-edge-infos" transform="translate(-10.63,0.92)">
+                <polyline points="-10.20,0.50 -12.05,2.32"/>
+                <g class="nad-edge-infos" transform="translate(-10.42,0.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -323,8 +323,8 @@
         </g>
         <g id="37" class="nad-vl120to180-0" title="L27-115-1">
             <g>
-                <polyline points="-14.48,3.92 -15.55,2.81"/>
-                <g class="nad-edge-infos" transform="translate(-14.69,3.70)">
+                <polyline points="-14.27,4.13 -15.55,2.81"/>
+                <g class="nad-edge-infos" transform="translate(-14.48,3.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -344,8 +344,8 @@
         </g>
         <g id="40" title="T30-17-1">
             <g class="nad-vl120to180-1">
-                <polyline points="1.87,-6.23 -0.46,-5.79"/>
-                <g class="nad-edge-infos" transform="translate(1.57,-6.17)">
+                <polyline points="2.16,-6.28 -0.46,-5.79"/>
+                <g class="nad-edge-infos" transform="translate(1.87,-6.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -369,8 +369,8 @@
         </g>
         <g id="43" class="nad-vl120to180-1" title="L8-30-1">
             <g>
-                <polyline points="2.17,-6.84 1.38,-8.38"/>
-                <g class="nad-edge-infos" transform="translate(2.03,-7.10)">
+                <polyline points="2.31,-6.57 1.38,-8.38"/>
+                <g class="nad-edge-infos" transform="translate(2.17,-6.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -390,8 +390,8 @@
         </g>
         <g id="46" class="nad-vl120to180-1" title="L26-30-1">
             <g>
-                <polyline points="2.74,-6.80 3.58,-8.06"/>
-                <g class="nad-edge-infos" transform="translate(2.91,-7.05)">
+                <polyline points="2.58,-6.56 3.58,-8.06"/>
+                <g class="nad-edge-infos" transform="translate(2.74,-6.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -411,8 +411,8 @@
         </g>
         <g id="47" class="nad-vl120to180-1" title="L30-38-1">
             <g>
-                <polyline points="2.88,-5.98 5.19,-4.22"/>
-                <g class="nad-edge-infos" transform="translate(3.12,-5.80)">
+                <polyline points="2.64,-6.17 5.19,-4.22"/>
+                <g class="nad-edge-infos" transform="translate(2.88,-5.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(127.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -430,8 +430,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.49,-2.45 5.19,-4.22"/>
-                <g class="nad-edge-infos" transform="translate(7.26,-2.63)">
+                <polyline points="7.73,-2.27 5.19,-4.22"/>
+                <g class="nad-edge-infos" transform="translate(7.49,-2.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-52.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -451,8 +451,8 @@
         </g>
         <g id="48" class="nad-vl120to180-0" title="L17-31-1">
             <g>
-                <polyline points="-7.81,-5.49 -5.87,-5.39"/>
-                <g class="nad-edge-infos" transform="translate(-7.51,-5.48)">
+                <polyline points="-8.11,-5.51 -5.87,-5.39"/>
+                <g class="nad-edge-infos" transform="translate(-7.81,-5.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -472,8 +472,8 @@
         </g>
         <g id="51" class="nad-vl120to180-0" title="L29-31-1">
             <g>
-                <polyline points="-8.61,-6.05 -9.28,-7.54"/>
-                <g class="nad-edge-infos" transform="translate(-8.73,-6.32)">
+                <polyline points="-8.49,-5.77 -9.28,-7.54"/>
+                <g class="nad-edge-infos" transform="translate(-8.61,-6.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -493,8 +493,8 @@
         </g>
         <g id="52" class="nad-vl120to180-0" title="L31-32-1">
             <g>
-                <polyline points="-8.53,-4.98 -9.19,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(-8.61,-4.69)">
+                <polyline points="-8.45,-5.27 -9.19,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(-8.53,-4.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -512,8 +512,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.86,-0.24 -9.19,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(-9.78,-0.53)">
+                <polyline points="-9.94,0.05 -9.19,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(-9.86,-0.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -533,8 +533,8 @@
         </g>
         <g id="53" class="nad-vl120to180-0" title="L32-113-1">
             <g>
-                <polyline points="-9.51,0.04 -7.96,-0.77"/>
-                <g class="nad-edge-infos" transform="translate(-9.24,-0.09)">
+                <polyline points="-9.77,0.18 -7.96,-0.77"/>
+                <g class="nad-edge-infos" transform="translate(-9.51,0.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -552,8 +552,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.42,-1.58 -7.96,-0.77"/>
-                <g class="nad-edge-infos" transform="translate(-6.68,-1.44)">
+                <polyline points="-6.15,-1.72 -7.96,-0.77"/>
+                <g class="nad-edge-infos" transform="translate(-6.42,-1.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -573,8 +573,8 @@
         </g>
         <g id="54" class="nad-vl120to180-0" title="L32-114-1">
             <g>
-                <polyline points="-10.54,0.11 -12.16,-0.51"/>
-                <g class="nad-edge-infos" transform="translate(-10.83,0.00)">
+                <polyline points="-10.26,0.21 -12.16,-0.51"/>
+                <g class="nad-edge-infos" transform="translate(-10.54,0.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -592,8 +592,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-13.78,-1.12 -12.16,-0.51"/>
-                <g class="nad-edge-infos" transform="translate(-13.50,-1.01)">
+                <polyline points="-14.06,-1.22 -12.16,-0.51"/>
+                <g class="nad-edge-infos" transform="translate(-13.78,-1.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -613,8 +613,8 @@
         </g>
         <g id="57" class="nad-vl120to180-0" title="L35-37-1">
             <g>
-                <polyline points="8.99,5.88 7.68,7.18"/>
-                <g class="nad-edge-infos" transform="translate(8.77,6.09)">
+                <polyline points="9.20,5.67 7.68,7.18"/>
+                <g class="nad-edge-infos" transform="translate(8.99,5.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -634,8 +634,8 @@
         </g>
         <g id="60" class="nad-vl120to180-0" title="L33-37-1">
             <g>
-                <polyline points="9.45,6.05 9.65,8.03"/>
-                <g class="nad-edge-infos" transform="translate(9.48,6.35)">
+                <polyline points="9.42,5.75 9.65,8.03"/>
+                <g class="nad-edge-infos" transform="translate(9.45,6.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -655,8 +655,8 @@
         </g>
         <g id="63" class="nad-vl120to180-0" title="L34-37-1">
             <g>
-                <polyline points="8.86,5.27 7.58,4.77"/>
-                <g class="nad-edge-infos" transform="translate(8.58,5.16)">
+                <polyline points="9.14,5.38 7.58,4.77"/>
+                <g class="nad-edge-infos" transform="translate(8.86,5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -676,8 +676,8 @@
         </g>
         <g id="64" title="T38-37-1">
             <g class="nad-vl120to180-1">
-                <polyline points="8.05,-1.54 8.67,1.69"/>
-                <g class="nad-edge-infos" transform="translate(8.11,-1.25)">
+                <polyline points="8.00,-1.84 8.67,1.69"/>
+                <g class="nad-edge-infos" transform="translate(8.05,-1.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -696,8 +696,8 @@
                 <circle cx="8.65" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="9.28,4.92 8.67,1.69"/>
-                <g class="nad-edge-infos" transform="translate(9.23,4.63)">
+                <polyline points="9.34,5.21 8.67,1.69"/>
+                <g class="nad-edge-infos" transform="translate(9.28,4.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -718,8 +718,8 @@
         </g>
         <g id="67" class="nad-vl120to180-0" title="L37-39-1">
             <g>
-                <polyline points="9.90,5.22 11.19,4.55"/>
-                <g class="nad-edge-infos" transform="translate(10.16,5.08)">
+                <polyline points="9.63,5.36 11.19,4.55"/>
+                <g class="nad-edge-infos" transform="translate(9.90,5.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -739,8 +739,8 @@
         </g>
         <g id="70" class="nad-vl120to180-0" title="L37-40-1">
             <g>
-                <polyline points="9.87,5.78 11.47,6.79"/>
-                <g class="nad-edge-infos" transform="translate(10.13,5.94)">
+                <polyline points="9.62,5.62 11.47,6.79"/>
+                <g class="nad-edge-infos" transform="translate(9.87,5.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(122.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -760,8 +760,8 @@
         </g>
         <g id="71" class="nad-vl120to180-1" title="L38-65-1">
             <g>
-                <polyline points="8.41,-2.44 10.32,-3.85"/>
-                <g class="nad-edge-infos" transform="translate(8.65,-2.62)">
+                <polyline points="8.16,-2.26 10.32,-3.85"/>
+                <g class="nad-edge-infos" transform="translate(8.41,-2.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -779,8 +779,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="12.24,-5.26 10.32,-3.85"/>
-                <g class="nad-edge-infos" transform="translate(12.00,-5.08)">
+                <polyline points="12.48,-5.44 10.32,-3.85"/>
+                <g class="nad-edge-infos" transform="translate(12.24,-5.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -800,8 +800,8 @@
         </g>
         <g id="74" class="nad-vl120to180-1" title="L64-65-1">
             <g>
-                <polyline points="13.17,-5.92 14.56,-6.86"/>
-                <g class="nad-edge-infos" transform="translate(13.42,-6.08)">
+                <polyline points="12.92,-5.75 14.56,-6.86"/>
+                <g class="nad-edge-infos" transform="translate(13.17,-5.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -821,8 +821,8 @@
         </g>
         <g id="77" title="T65-66-1">
             <g class="nad-vl120to180-1">
-                <polyline points="12.58,-6.15 12.25,-7.68"/>
-                <g class="nad-edge-infos" transform="translate(12.52,-6.45)">
+                <polyline points="12.64,-5.86 12.25,-7.68"/>
+                <g class="nad-edge-infos" transform="translate(12.58,-6.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -846,8 +846,8 @@
         </g>
         <g id="80" class="nad-vl120to180-1" title="L65-68-1">
             <g>
-                <polyline points="13.17,-5.27 14.42,-4.39"/>
-                <g class="nad-edge-infos" transform="translate(13.41,-5.10)">
+                <polyline points="12.92,-5.44 14.42,-4.39"/>
+                <g class="nad-edge-infos" transform="translate(13.17,-5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -867,8 +867,8 @@
         </g>
         <g id="81" class="nad-vl120to180-0" title="L17-113-1">
             <g>
-                <polyline points="-5.57,-2.30 -4.63,-3.55"/>
-                <g class="nad-edge-infos" transform="translate(-5.39,-2.54)">
+                <polyline points="-5.75,-2.06 -4.63,-3.55"/>
+                <g class="nad-edge-infos" transform="translate(-5.57,-2.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -888,8 +888,8 @@
         </g>
         <g id="82" class="nad-vl120to180-0" title="L114-115-1">
             <g>
-                <polyline points="-14.72,-0.92 -15.66,-0.01"/>
-                <g class="nad-edge-infos" transform="translate(-14.94,-0.72)">
+                <polyline points="-14.50,-1.13 -15.66,-0.01"/>
+                <g class="nad-edge-infos" transform="translate(-14.72,-0.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -909,16 +909,16 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-6.97,5.92 -6.57,5.92"/>
-        <polyline id="2_text_edge" points="-13.48,4.33 -13.08,4.33"/>
-        <polyline id="4_text_edge" points="3.03,-6.33 3.43,-6.33"/>
-        <polyline id="6_text_edge" points="-7.78,-5.53 -7.38,-5.53"/>
-        <polyline id="8_text_edge" points="-9.41,0.31 -9.01,0.31"/>
-        <polyline id="10_text_edge" points="9.99,5.48 10.39,5.48"/>
-        <polyline id="12_text_edge" points="8.55,-2.10 8.95,-2.10"/>
-        <polyline id="14_text_edge" points="13.30,-5.60 13.70,-5.60"/>
-        <polyline id="16_text_edge" points="-5.31,-1.84 -4.91,-1.84"/>
-        <polyline id="18_text_edge" points="-13.71,-1.32 -13.31,-1.32"/>
+        <polyline id="0_text_edge" points="-7.27,5.92 -6.57,5.92"/>
+        <polyline id="2_text_edge" points="-13.78,4.33 -13.08,4.33"/>
+        <polyline id="4_text_edge" points="2.73,-6.33 3.43,-6.33"/>
+        <polyline id="6_text_edge" points="-8.08,-5.53 -7.38,-5.53"/>
+        <polyline id="8_text_edge" points="-9.71,0.31 -9.01,0.31"/>
+        <polyline id="10_text_edge" points="9.69,5.48 10.39,5.48"/>
+        <polyline id="12_text_edge" points="8.25,-2.10 8.95,-2.10"/>
+        <polyline id="14_text_edge" points="13.00,-5.60 13.70,-5.60"/>
+        <polyline id="16_text_edge" points="-5.61,-1.84 -4.91,-1.84"/>
+        <polyline id="18_text_edge" points="-14.01,-1.32 -13.31,-1.32"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-6.57" y="5.92" style="dominant-baseline:middle">VL23</text>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -40,53 +40,53 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(1.24,-7.06)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-1.45,-5.20)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(-2.52,-7.98)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(1.83,-3.36)" id="6" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(-1.29,-1.85)" id="8" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(-3.12,5.23)" id="10" class="nad-vl0to30" title="VL6">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(6.36,-2.01)" id="12" class="nad-vl0to30" title="VL7">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(10.44,-3.62)" id="14" class="nad-vl0to30" title="VL8">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(2.79,1.11)" id="16" class="nad-vl0to30" title="VL9">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-3.10,1.60)" id="18" class="nad-vl0to30" title="VL10">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(-6.76,3.49)" id="20" class="nad-vl0to30" title="VL11">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(-3.39,9.49)" id="22" class="nad-vl0to30" title="VL12">
-            <circle r="0.60" id="23"/>
+            <circle r="0.30" id="23"/>
         </g>
         <g transform="translate(0.04,8.18)" id="24" class="nad-vl0to30" title="VL13">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(3.62,5.82)" id="26" class="nad-vl0to30" title="VL14">
-            <circle r="0.60" id="27"/>
+            <circle r="0.30" id="27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="28" class="nad-vl120to180" title="L1-2-1">
             <g>
-                <polyline points="0.77,-6.73 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(0.52,-6.56)">
+                <polyline points="1.02,-6.90 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(0.77,-6.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -104,8 +104,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.98,-5.53 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(-0.73,-5.70)">
+                <polyline points="-1.22,-5.36 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(-0.98,-5.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -125,8 +125,8 @@
         </g>
         <g id="29" class="nad-vl120to180" title="L1-5-1">
             <g>
-                <polyline points="0.99,-6.54 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(0.86,-6.27)">
+                <polyline points="1.12,-6.81 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(0.99,-6.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -144,8 +144,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.04,-2.37 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(-0.91,-2.64)">
+                <polyline points="-1.17,-2.10 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(-1.04,-2.37)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -165,8 +165,8 @@
         </g>
         <g id="30" class="nad-vl120to180" title="L2-3-1">
             <g>
-                <polyline points="-1.65,-5.74 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-1.76,-6.02)">
+                <polyline points="-1.54,-5.46 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-1.65,-5.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -184,8 +184,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.31,-7.45 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-2.20,-7.17)">
+                <polyline points="-2.42,-7.73 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-2.31,-7.45)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -205,8 +205,8 @@
         </g>
         <g id="31" class="nad-vl120to180" title="L2-4-1">
             <g>
-                <polyline points="-0.95,-4.93 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(-0.69,-4.78)">
+                <polyline points="-1.21,-5.07 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(-0.95,-4.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -224,8 +224,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.34,-3.64 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(1.08,-3.79)">
+                <polyline points="1.60,-3.50 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(1.34,-3.64)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -245,8 +245,8 @@
         </g>
         <g id="32" class="nad-vl120to180" title="L2-5-1">
             <g>
-                <polyline points="-1.42,-4.63 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.40,-4.33)">
+                <polyline points="-1.43,-4.93 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.42,-4.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -264,8 +264,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.31,-2.42 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.33,-2.72)">
+                <polyline points="-1.30,-2.12 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.31,-2.42)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -285,8 +285,8 @@
         </g>
         <g id="33" class="nad-vl120to180" title="L3-4-1">
             <g>
-                <polyline points="-2.12,-7.57 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(-1.92,-7.35)">
+                <polyline points="-2.33,-7.78 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(-2.12,-7.57)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -304,8 +304,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.44,-3.78 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(1.24,-4.00)">
+                <polyline points="1.65,-3.56 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(1.44,-3.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -325,8 +325,8 @@
         </g>
         <g id="34" class="nad-vl120to180" title="L4-5-1">
             <g>
-                <polyline points="1.32,-3.12 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(1.05,-2.98)">
+                <polyline points="1.59,-3.25 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(1.32,-3.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -344,8 +344,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.77,-2.10 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(-0.50,-2.23)">
+                <polyline points="-1.04,-1.97 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(-0.77,-2.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -365,8 +365,8 @@
         </g>
         <g id="35" title="T4-7-1">
             <g class="nad-vl120to180">
-                <polyline points="2.38,-3.20 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(2.67,-3.11)">
+                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -385,8 +385,8 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.81,-2.17 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(5.52,-2.26)">
+                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -407,8 +407,8 @@
         </g>
         <g id="36" title="T4-9-1">
             <g class="nad-vl120to180">
-                <polyline points="1.95,-2.81 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.02,-2.51)">
+                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -427,8 +427,8 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.67,0.55 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.61,0.26)">
+                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -449,8 +449,8 @@
         </g>
         <g id="37" title="T5-6-1">
             <g class="nad-vl120to180">
-                <polyline points="-1.43,-1.30 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-1.50,-1.01)">
+                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -469,8 +469,8 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.97,4.67 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-2.90,4.38)">
+                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -491,8 +491,8 @@
         </g>
         <g id="38" class="nad-vl0to30" title="L6-11-1">
             <g>
-                <polyline points="-3.63,4.98 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.90,4.85)">
+                <polyline points="-3.36,5.11 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.63,4.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -510,8 +510,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.73 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-5.97,3.86)">
+                <polyline points="-6.52,3.60 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -531,8 +531,8 @@
         </g>
         <g id="39" class="nad-vl0to30" title="L6-12-1">
             <g>
-                <polyline points="-3.15,5.80 -3.26,7.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.17,6.09)">
+                <polyline points="-3.13,5.50 -3.26,7.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.15,5.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -550,8 +550,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.36,8.92 -3.26,7.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.34,8.62)">
+                <polyline points="-3.38,9.22 -3.26,7.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.36,8.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(3.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -571,8 +571,8 @@
         </g>
         <g id="40" class="nad-vl0to30" title="L6-13-1">
             <g>
-                <polyline points="-2.70,5.62 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-2.48,5.82)">
+                <polyline points="-2.92,5.41 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-2.70,5.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -590,8 +590,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.37,7.79 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-0.59,7.59)">
+                <polyline points="-0.15,8.00 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-0.37,7.79)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -611,8 +611,8 @@
         </g>
         <g id="41" class="nad-vl0to30" title="L7-8-1">
             <g>
-                <polyline points="6.89,-2.22 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(7.17,-2.33)">
+                <polyline points="6.61,-2.11 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(6.89,-2.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -630,8 +630,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.91,-3.41 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(9.63,-3.30)">
+                <polyline points="10.19,-3.52 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(9.91,-3.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -651,8 +651,8 @@
         </g>
         <g id="42" class="nad-vl0to30" title="L7-9-1">
             <g>
-                <polyline points="5.93,-1.63 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(5.70,-1.44)">
+                <polyline points="6.15,-1.83 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(5.93,-1.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -670,8 +670,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.22,0.73 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(3.45,0.53)">
+                <polyline points="3.00,0.93 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(3.22,0.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -691,8 +691,8 @@
         </g>
         <g id="43" class="nad-vl0to30" title="L9-10-1">
             <g>
-                <polyline points="2.23,1.15 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(1.93,1.18)">
+                <polyline points="2.53,1.13 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(2.23,1.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -710,8 +710,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.53,1.56 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(-2.23,1.53)">
+                <polyline points="-2.83,1.58 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(-2.53,1.56)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -731,8 +731,8 @@
         </g>
         <g id="44" class="nad-vl0to30" title="L9-14-1">
             <g>
-                <polyline points="2.89,1.67 3.21,3.46"/>
-                <g class="nad-edge-infos" transform="translate(2.94,1.96)">
+                <polyline points="2.84,1.37 3.21,3.46"/>
+                <g class="nad-edge-infos" transform="translate(2.89,1.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -750,8 +750,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.52,5.25 3.21,3.46"/>
-                <g class="nad-edge-infos" transform="translate(3.47,4.96)">
+                <polyline points="3.57,5.55 3.21,3.46"/>
+                <g class="nad-edge-infos" transform="translate(3.52,5.25)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-9.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -771,8 +771,8 @@
         </g>
         <g id="45" class="nad-vl0to30" title="L10-11-1">
             <g>
-                <polyline points="-3.61,1.87 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-3.87,2.00)">
+                <polyline points="-3.34,1.73 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-3.61,1.87)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -790,8 +790,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.23 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-5.99,3.09)">
+                <polyline points="-6.52,3.36 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -811,8 +811,8 @@
         </g>
         <g id="46" class="nad-vl0to30" title="L12-13-1">
             <g>
-                <polyline points="-2.86,9.29 -1.68,8.84"/>
-                <g class="nad-edge-infos" transform="translate(-2.58,9.18)">
+                <polyline points="-3.14,9.39 -1.68,8.84"/>
+                <g class="nad-edge-infos" transform="translate(-2.86,9.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -830,8 +830,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.49,8.39 -1.68,8.84"/>
-                <g class="nad-edge-infos" transform="translate(-0.77,8.49)">
+                <polyline points="-0.21,8.28 -1.68,8.84"/>
+                <g class="nad-edge-infos" transform="translate(-0.49,8.39)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -851,8 +851,8 @@
         </g>
         <g id="47" class="nad-vl0to30" title="L13-14-1">
             <g>
-                <polyline points="0.52,7.87 1.83,7.00"/>
-                <g class="nad-edge-infos" transform="translate(0.77,7.70)">
+                <polyline points="0.27,8.03 1.83,7.00"/>
+                <g class="nad-edge-infos" transform="translate(0.52,7.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -870,8 +870,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.14,6.13 1.83,7.00"/>
-                <g class="nad-edge-infos" transform="translate(2.89,6.30)">
+                <polyline points="3.39,5.97 1.83,7.00"/>
+                <g class="nad-edge-infos" transform="translate(3.14,6.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-123.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -891,20 +891,20 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="1.84,-7.06 2.24,-7.06"/>
-        <polyline id="2_text_edge" points="-0.85,-5.20 -0.45,-5.20"/>
-        <polyline id="4_text_edge" points="-1.92,-7.98 -1.52,-7.98"/>
-        <polyline id="6_text_edge" points="2.43,-3.36 2.83,-3.36"/>
-        <polyline id="8_text_edge" points="-0.69,-1.85 -0.29,-1.85"/>
-        <polyline id="10_text_edge" points="-2.52,5.23 -2.12,5.23"/>
-        <polyline id="12_text_edge" points="6.96,-2.01 7.36,-2.01"/>
-        <polyline id="14_text_edge" points="11.04,-3.62 11.44,-3.62"/>
-        <polyline id="16_text_edge" points="3.39,1.11 3.79,1.11"/>
-        <polyline id="18_text_edge" points="-2.50,1.60 -2.10,1.60"/>
-        <polyline id="20_text_edge" points="-6.16,3.49 -5.76,3.49"/>
-        <polyline id="22_text_edge" points="-2.79,9.49 -2.39,9.49"/>
-        <polyline id="24_text_edge" points="0.64,8.18 1.04,8.18"/>
-        <polyline id="26_text_edge" points="4.22,5.82 4.62,5.82"/>
+        <polyline id="0_text_edge" points="1.54,-7.06 2.24,-7.06"/>
+        <polyline id="2_text_edge" points="-1.15,-5.20 -0.45,-5.20"/>
+        <polyline id="4_text_edge" points="-2.22,-7.98 -1.52,-7.98"/>
+        <polyline id="6_text_edge" points="2.13,-3.36 2.83,-3.36"/>
+        <polyline id="8_text_edge" points="-0.99,-1.85 -0.29,-1.85"/>
+        <polyline id="10_text_edge" points="-2.82,5.23 -2.12,5.23"/>
+        <polyline id="12_text_edge" points="6.66,-2.01 7.36,-2.01"/>
+        <polyline id="14_text_edge" points="10.74,-3.62 11.44,-3.62"/>
+        <polyline id="16_text_edge" points="3.09,1.11 3.79,1.11"/>
+        <polyline id="18_text_edge" points="-2.80,1.60 -2.10,1.60"/>
+        <polyline id="20_text_edge" points="-6.46,3.49 -5.76,3.49"/>
+        <polyline id="22_text_edge" points="-3.09,9.49 -2.39,9.49"/>
+        <polyline id="24_text_edge" points="0.34,8.18 1.04,8.18"/>
+        <polyline id="26_text_edge" points="3.92,5.82 4.62,5.82"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="2.24" y="-7.06" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -40,53 +40,53 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(1.24,-7.06)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-1.45,-5.20)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(-2.52,-7.98)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(1.83,-3.36)" id="6" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(-1.29,-1.85)" id="8" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(-3.12,5.23)" id="10" class="nad-vl0to30" title="VL6">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(6.36,-2.01)" id="12" class="nad-vl0to30" title="VL7">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(10.44,-3.62)" id="14" class="nad-vl0to30" title="VL8">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(2.79,1.11)" id="16" class="nad-vl0to30" title="VL9">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-3.10,1.60)" id="18" class="nad-vl0to30" title="VL10">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(-6.76,3.49)" id="20" class="nad-vl0to30" title="VL11">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(-3.39,9.49)" id="22" class="nad-vl0to30" title="VL12">
-            <circle r="0.60" id="23"/>
+            <circle r="0.30" id="23"/>
         </g>
         <g transform="translate(0.04,8.18)" id="24" class="nad-vl0to30" title="VL13">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(3.62,5.82)" id="26" class="nad-vl0to30" title="VL14">
-            <circle class="nad-unknown-busnode" r="0.70"/>
+            <circle class="nad-unknown-busnode" r="0.40"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="27" class="nad-vl120to180" title="L1-2-1">
             <g>
-                <polyline points="0.77,-6.73 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(0.52,-6.56)">
+                <polyline points="1.02,-6.90 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(0.77,-6.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -104,8 +104,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.98,-5.53 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(-0.73,-5.70)">
+                <polyline points="-1.22,-5.36 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(-0.98,-5.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -125,8 +125,8 @@
         </g>
         <g id="28" class="nad-vl120to180" title="L1-5-1">
             <g>
-                <polyline points="0.99,-6.54 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(0.86,-6.27)">
+                <polyline points="1.12,-6.81 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(0.99,-6.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -144,8 +144,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.04,-2.37 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(-0.91,-2.64)">
+                <polyline points="-1.17,-2.10 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(-1.04,-2.37)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -165,8 +165,8 @@
         </g>
         <g id="29" class="nad-vl120to180" title="L2-3-1">
             <g>
-                <polyline points="-1.65,-5.74 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-1.76,-6.02)">
+                <polyline points="-1.54,-5.46 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-1.65,-5.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -184,8 +184,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.31,-7.45 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-2.20,-7.17)">
+                <polyline points="-2.42,-7.73 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-2.31,-7.45)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -205,8 +205,8 @@
         </g>
         <g id="30" class="nad-vl120to180" title="L2-4-1">
             <g>
-                <polyline points="-0.95,-4.93 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(-0.69,-4.78)">
+                <polyline points="-1.21,-5.07 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(-0.95,-4.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -224,8 +224,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.34,-3.64 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(1.08,-3.79)">
+                <polyline points="1.60,-3.50 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(1.34,-3.64)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -245,8 +245,8 @@
         </g>
         <g id="31" class="nad-vl120to180" title="L2-5-1">
             <g>
-                <polyline points="-1.42,-4.63 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.40,-4.33)">
+                <polyline points="-1.43,-4.93 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.42,-4.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -264,8 +264,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.31,-2.42 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.33,-2.72)">
+                <polyline points="-1.30,-2.12 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.31,-2.42)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -285,8 +285,8 @@
         </g>
         <g id="32" class="nad-vl120to180" title="L3-4-1">
             <g class="nad-disconnected">
-                <polyline points="-2.12,-7.57 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(-1.92,-7.35)">
+                <polyline points="-2.33,-7.78 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(-2.12,-7.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -304,8 +304,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.44,-3.78 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(1.24,-4.00)">
+                <polyline points="1.65,-3.56 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(1.44,-3.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -325,8 +325,8 @@
         </g>
         <g id="33" class="nad-vl120to180" title="L4-5-1">
             <g>
-                <polyline points="1.32,-3.12 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(1.05,-2.98)">
+                <polyline points="1.59,-3.25 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(1.32,-3.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -344,8 +344,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.77,-2.10 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(-0.50,-2.23)">
+                <polyline points="-1.04,-1.97 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(-0.77,-2.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -365,8 +365,8 @@
         </g>
         <g id="34" title="T4-7-1">
             <g class="nad-disconnected nad-disconnected">
-                <polyline points="2.38,-3.20 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(2.67,-3.11)">
+                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -385,8 +385,8 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.81,-2.17 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(5.52,-2.26)">
+                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -407,8 +407,8 @@
         </g>
         <g id="35" title="T4-9-1">
             <g class="nad-vl120to180">
-                <polyline points="1.95,-2.81 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.02,-2.51)">
+                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -427,8 +427,8 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.67,0.55 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.61,0.26)">
+                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -449,8 +449,8 @@
         </g>
         <g id="36" title="T5-6-1">
             <g class="nad-vl120to180">
-                <polyline points="-1.43,-1.30 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-1.50,-1.01)">
+                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -469,8 +469,8 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.97,4.67 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-2.90,4.38)">
+                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -491,8 +491,8 @@
         </g>
         <g id="37" class="nad-vl0to30" title="L6-11-1">
             <g>
-                <polyline points="-3.63,4.98 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.90,4.85)">
+                <polyline points="-3.36,5.11 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.63,4.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -510,8 +510,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.73 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-5.97,3.86)">
+                <polyline points="-6.52,3.60 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -531,8 +531,8 @@
         </g>
         <g id="38" class="nad-vl0to30" title="L6-12-1">
             <g>
-                <polyline points="-3.15,5.80 -3.26,7.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.17,6.09)">
+                <polyline points="-3.13,5.50 -3.26,7.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.15,5.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -550,8 +550,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.36,8.92 -3.26,7.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.34,8.62)">
+                <polyline points="-3.38,9.22 -3.26,7.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.36,8.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(3.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -571,8 +571,8 @@
         </g>
         <g id="39" class="nad-vl0to30" title="L6-13-1">
             <g>
-                <polyline points="-2.70,5.62 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-2.48,5.82)">
+                <polyline points="-2.92,5.41 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-2.70,5.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -590,8 +590,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.37,7.79 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-0.59,7.59)">
+                <polyline points="-0.15,8.00 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-0.37,7.79)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -611,8 +611,8 @@
         </g>
         <g id="40" class="nad-vl0to30" title="L7-8-1">
             <g>
-                <polyline points="6.89,-2.22 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(7.17,-2.33)">
+                <polyline points="6.61,-2.11 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(6.89,-2.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -630,8 +630,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.91,-3.41 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(9.63,-3.30)">
+                <polyline points="10.19,-3.52 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(9.91,-3.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -651,8 +651,8 @@
         </g>
         <g id="41" class="nad-vl0to30" title="L7-9-1">
             <g>
-                <polyline points="5.93,-1.63 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(5.70,-1.44)">
+                <polyline points="6.15,-1.83 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(5.93,-1.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -670,8 +670,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.22,0.73 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(3.45,0.53)">
+                <polyline points="3.00,0.93 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(3.22,0.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -691,8 +691,8 @@
         </g>
         <g id="42" class="nad-vl0to30" title="L9-10-1">
             <g>
-                <polyline points="2.23,1.15 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(1.93,1.18)">
+                <polyline points="2.53,1.13 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(2.23,1.15)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -710,8 +710,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.53,1.56 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(-2.23,1.53)">
+                <polyline points="-2.83,1.58 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(-2.53,1.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -731,8 +731,8 @@
         </g>
         <g id="43" title="L9-14-1">
             <g class="nad-disconnected">
-                <polyline points="2.89,1.67 3.19,3.40"/>
-                <g class="nad-edge-infos" transform="translate(2.94,1.96)">
+                <polyline points="2.84,1.37 3.19,3.40"/>
+                <g class="nad-edge-infos" transform="translate(2.89,1.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -750,8 +750,8 @@
                 </g>
             </g>
             <g class="nad-disconnected">
-                <polyline points="3.50,5.13 3.19,3.40"/>
-                <g class="nad-edge-infos" transform="translate(3.44,4.83)">
+                <polyline points="3.55,5.42 3.19,3.40"/>
+                <g class="nad-edge-infos" transform="translate(3.50,5.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -771,8 +771,8 @@
         </g>
         <g id="44" class="nad-vl0to30" title="L10-11-1">
             <g>
-                <polyline points="-3.61,1.87 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-3.87,2.00)">
+                <polyline points="-3.34,1.73 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-3.61,1.87)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -790,8 +790,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.23 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-5.99,3.09)">
+                <polyline points="-6.52,3.36 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -811,8 +811,8 @@
         </g>
         <g id="45" class="nad-vl0to30" title="L12-13-1">
             <g>
-                <polyline points="-2.86,9.29 -1.68,8.84"/>
-                <g class="nad-edge-infos" transform="translate(-2.58,9.18)">
+                <polyline points="-3.14,9.39 -1.68,8.84"/>
+                <g class="nad-edge-infos" transform="translate(-2.86,9.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -830,8 +830,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.49,8.39 -1.68,8.84"/>
-                <g class="nad-edge-infos" transform="translate(-0.77,8.49)">
+                <polyline points="-0.21,8.28 -1.68,8.84"/>
+                <g class="nad-edge-infos" transform="translate(-0.49,8.39)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -851,8 +851,8 @@
         </g>
         <g id="46" title="L13-14-1">
             <g class="nad-disconnected">
-                <polyline points="0.52,7.87 1.78,7.04"/>
-                <g class="nad-edge-infos" transform="translate(0.77,7.70)">
+                <polyline points="0.27,8.03 1.78,7.04"/>
+                <g class="nad-edge-infos" transform="translate(0.52,7.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -870,8 +870,8 @@
                 </g>
             </g>
             <g class="nad-disconnected">
-                <polyline points="3.03,6.20 1.78,7.04"/>
-                <g class="nad-edge-infos" transform="translate(2.78,6.37)">
+                <polyline points="3.28,6.04 1.78,7.04"/>
+                <g class="nad-edge-infos" transform="translate(3.03,6.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -891,20 +891,20 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="1.84,-7.06 2.24,-7.06"/>
-        <polyline id="2_text_edge" points="-0.85,-5.20 -0.45,-5.20"/>
-        <polyline id="4_text_edge" points="-1.92,-7.98 -1.52,-7.98"/>
-        <polyline id="6_text_edge" points="2.43,-3.36 2.83,-3.36"/>
-        <polyline id="8_text_edge" points="-0.69,-1.85 -0.29,-1.85"/>
-        <polyline id="10_text_edge" points="-2.52,5.23 -2.12,5.23"/>
-        <polyline id="12_text_edge" points="6.96,-2.01 7.36,-2.01"/>
-        <polyline id="14_text_edge" points="11.04,-3.62 11.44,-3.62"/>
-        <polyline id="16_text_edge" points="3.39,1.11 3.79,1.11"/>
-        <polyline id="18_text_edge" points="-2.50,1.60 -2.10,1.60"/>
-        <polyline id="20_text_edge" points="-6.16,3.49 -5.76,3.49"/>
-        <polyline id="22_text_edge" points="-2.79,9.49 -2.39,9.49"/>
-        <polyline id="24_text_edge" points="0.64,8.18 1.04,8.18"/>
-        <polyline id="26_text_edge" points="4.22,5.82 4.62,5.82"/>
+        <polyline id="0_text_edge" points="1.54,-7.06 2.24,-7.06"/>
+        <polyline id="2_text_edge" points="-1.15,-5.20 -0.45,-5.20"/>
+        <polyline id="4_text_edge" points="-2.22,-7.98 -1.52,-7.98"/>
+        <polyline id="6_text_edge" points="2.13,-3.36 2.83,-3.36"/>
+        <polyline id="8_text_edge" points="-0.99,-1.85 -0.29,-1.85"/>
+        <polyline id="10_text_edge" points="-2.82,5.23 -2.12,5.23"/>
+        <polyline id="12_text_edge" points="6.66,-2.01 7.36,-2.01"/>
+        <polyline id="14_text_edge" points="10.74,-3.62 11.44,-3.62"/>
+        <polyline id="16_text_edge" points="3.09,1.11 3.79,1.11"/>
+        <polyline id="18_text_edge" points="-2.80,1.60 -2.10,1.60"/>
+        <polyline id="20_text_edge" points="-6.46,3.49 -5.76,3.49"/>
+        <polyline id="22_text_edge" points="-3.09,9.49 -2.39,9.49"/>
+        <polyline id="24_text_edge" points="0.34,8.18 1.04,8.18"/>
+        <polyline id="26_text_edge" points="3.92,5.82 4.62,5.82"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="2.24" y="-7.06" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -40,43 +40,43 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(1.24,-7.06)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-1.45,-5.20)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(-2.52,-7.98)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(1.83,-3.36)" id="6" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(-1.29,-1.85)" id="8" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(-3.12,5.23)" id="10" class="nad-vl0to30" title="VL6">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(6.36,-2.01)" id="12" class="nad-vl0to30" title="VL7">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(10.44,-3.62)" id="14" class="nad-vl0to30" title="VL8">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(2.79,1.11)" id="16" class="nad-vl0to30" title="VL9">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-3.10,1.60)" id="18" class="nad-vl0to30" title="VL10">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(-6.76,3.49)" id="20" class="nad-vl0to30" title="VL11">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(-3.39,9.49)" id="22" class="nad-vl0to30" title="VL12">
             <circle r="0.15" id="23"/>
         </g>
         <g transform="translate(0.04,8.18)" id="24" class="nad-vl0to30" title="VL13">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(3.62,5.82)" id="26" class="nad-vl0to30" title="VL14">
             <circle r="0.15" id="27"/>
@@ -85,8 +85,8 @@
     <g class="nad-branch-edges">
         <g id="28" class="nad-vl120to180" title="L1-2-1">
             <g>
-                <polyline points="0.77,-6.73 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(0.52,-6.56)">
+                <polyline points="1.02,-6.90 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(0.77,-6.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -104,8 +104,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.98,-5.53 -0.10,-6.13"/>
-                <g class="nad-edge-infos" transform="translate(-0.73,-5.70)">
+                <polyline points="-1.22,-5.36 -0.10,-6.13"/>
+                <g class="nad-edge-infos" transform="translate(-0.98,-5.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -125,8 +125,8 @@
         </g>
         <g id="29" class="nad-vl120to180" title="L1-5-1">
             <g>
-                <polyline points="0.99,-6.54 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(0.86,-6.27)">
+                <polyline points="1.12,-6.81 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(0.99,-6.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -144,8 +144,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.04,-2.37 -0.02,-4.46"/>
-                <g class="nad-edge-infos" transform="translate(-0.91,-2.64)">
+                <polyline points="-1.17,-2.10 -0.02,-4.46"/>
+                <g class="nad-edge-infos" transform="translate(-1.04,-2.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -165,8 +165,8 @@
         </g>
         <g id="30" class="nad-vl120to180" title="L2-3-1">
             <g>
-                <polyline points="-1.65,-5.74 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-1.76,-6.02)">
+                <polyline points="-1.54,-5.46 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-1.65,-5.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -184,8 +184,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.31,-7.45 -1.98,-6.59"/>
-                <g class="nad-edge-infos" transform="translate(-2.20,-7.17)">
+                <polyline points="-2.42,-7.73 -1.98,-6.59"/>
+                <g class="nad-edge-infos" transform="translate(-2.31,-7.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -205,8 +205,8 @@
         </g>
         <g id="31" class="nad-vl120to180" title="L2-4-1">
             <g>
-                <polyline points="-0.95,-4.93 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(-0.69,-4.78)">
+                <polyline points="-1.21,-5.07 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(-0.95,-4.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -224,8 +224,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.34,-3.64 0.19,-4.28"/>
-                <g class="nad-edge-infos" transform="translate(1.08,-3.79)">
+                <polyline points="1.60,-3.50 0.19,-4.28"/>
+                <g class="nad-edge-infos" transform="translate(1.34,-3.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -245,8 +245,8 @@
         </g>
         <g id="32" class="nad-vl120to180" title="L2-5-1">
             <g>
-                <polyline points="-1.42,-4.63 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.40,-4.33)">
+                <polyline points="-1.43,-4.93 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.42,-4.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -264,8 +264,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.31,-2.42 -1.37,-3.53"/>
-                <g class="nad-edge-infos" transform="translate(-1.33,-2.72)">
+                <polyline points="-1.30,-2.12 -1.37,-3.53"/>
+                <g class="nad-edge-infos" transform="translate(-1.31,-2.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -285,8 +285,8 @@
         </g>
         <g id="33" class="nad-vl120to180" title="L3-4-1">
             <g>
-                <polyline points="-2.12,-7.57 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(-1.92,-7.35)">
+                <polyline points="-2.33,-7.78 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(-2.12,-7.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -304,8 +304,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.44,-3.78 -0.34,-5.67"/>
-                <g class="nad-edge-infos" transform="translate(1.24,-4.00)">
+                <polyline points="1.65,-3.56 -0.34,-5.67"/>
+                <g class="nad-edge-infos" transform="translate(1.44,-3.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -325,8 +325,8 @@
         </g>
         <g id="34" class="nad-vl120to180" title="L4-5-1">
             <g>
-                <polyline points="1.32,-3.12 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(1.05,-2.98)">
+                <polyline points="1.59,-3.25 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(1.32,-3.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -344,8 +344,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.77,-2.10 0.27,-2.61"/>
-                <g class="nad-edge-infos" transform="translate(-0.50,-2.23)">
+                <polyline points="-1.04,-1.97 0.27,-2.61"/>
+                <g class="nad-edge-infos" transform="translate(-0.77,-2.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -365,8 +365,8 @@
         </g>
         <g id="35" title="T4-7-1">
             <g class="nad-vl120to180">
-                <polyline points="2.38,-3.20 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(2.67,-3.11)">
+                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -385,8 +385,8 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.81,-2.17 4.10,-2.69"/>
-                <g class="nad-edge-infos" transform="translate(5.52,-2.26)">
+                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -407,8 +407,8 @@
         </g>
         <g id="36" title="T4-9-1">
             <g class="nad-vl120to180">
-                <polyline points="1.95,-2.81 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.02,-2.51)">
+                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -427,8 +427,8 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.67,0.55 2.31,-1.13"/>
-                <g class="nad-edge-infos" transform="translate(2.61,0.26)">
+                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -449,8 +449,8 @@
         </g>
         <g id="37" title="T5-6-1">
             <g class="nad-vl120to180">
-                <polyline points="-1.43,-1.30 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-1.50,-1.01)">
+                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -469,8 +469,8 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.97,4.67 -2.20,1.69"/>
-                <g class="nad-edge-infos" transform="translate(-2.90,4.38)">
+                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -491,8 +491,8 @@
         </g>
         <g id="38" class="nad-vl0to30" title="L6-11-1">
             <g>
-                <polyline points="-3.63,4.98 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-3.90,4.85)">
+                <polyline points="-3.36,5.11 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-3.63,4.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -510,8 +510,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.73 -4.94,4.36"/>
-                <g class="nad-edge-infos" transform="translate(-5.97,3.86)">
+                <polyline points="-6.52,3.60 -4.94,4.36"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -531,8 +531,8 @@
         </g>
         <g id="39" class="nad-vl0to30" title="L6-12-1">
             <g>
-                <polyline points="-3.15,5.80 -3.27,7.58"/>
-                <g class="nad-edge-infos" transform="translate(-3.17,6.09)">
+                <polyline points="-3.13,5.50 -3.26,7.43"/>
+                <g class="nad-edge-infos" transform="translate(-3.15,5.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -550,7 +550,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.39,9.37 -3.27,7.58"/>
+                <polyline points="-3.39,9.37 -3.26,7.43"/>
                 <g class="nad-edge-infos" transform="translate(-3.37,9.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.75)">
@@ -571,8 +571,8 @@
         </g>
         <g id="40" class="nad-vl0to30" title="L6-13-1">
             <g>
-                <polyline points="-2.70,5.62 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-2.48,5.82)">
+                <polyline points="-2.92,5.41 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-2.70,5.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -590,8 +590,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.37,7.79 -1.54,6.70"/>
-                <g class="nad-edge-infos" transform="translate(-0.59,7.59)">
+                <polyline points="-0.15,8.00 -1.54,6.70"/>
+                <g class="nad-edge-infos" transform="translate(-0.37,7.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -611,8 +611,8 @@
         </g>
         <g id="41" class="nad-vl0to30" title="L7-8-1">
             <g>
-                <polyline points="6.89,-2.22 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(7.17,-2.33)">
+                <polyline points="6.61,-2.11 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(6.89,-2.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -630,8 +630,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.91,-3.41 8.40,-2.82"/>
-                <g class="nad-edge-infos" transform="translate(9.63,-3.30)">
+                <polyline points="10.19,-3.52 8.40,-2.82"/>
+                <g class="nad-edge-infos" transform="translate(9.91,-3.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -651,8 +651,8 @@
         </g>
         <g id="42" class="nad-vl0to30" title="L7-9-1">
             <g>
-                <polyline points="5.93,-1.63 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(5.70,-1.44)">
+                <polyline points="6.15,-1.83 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(5.93,-1.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -670,8 +670,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.22,0.73 4.58,-0.45"/>
-                <g class="nad-edge-infos" transform="translate(3.45,0.53)">
+                <polyline points="3.00,0.93 4.58,-0.45"/>
+                <g class="nad-edge-infos" transform="translate(3.22,0.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -691,8 +691,8 @@
         </g>
         <g id="43" class="nad-vl0to30" title="L9-10-1">
             <g>
-                <polyline points="2.23,1.15 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(1.93,1.18)">
+                <polyline points="2.53,1.13 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(2.23,1.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -710,8 +710,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.53,1.56 -0.15,1.36"/>
-                <g class="nad-edge-infos" transform="translate(-2.23,1.53)">
+                <polyline points="-2.83,1.58 -0.15,1.36"/>
+                <g class="nad-edge-infos" transform="translate(-2.53,1.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -731,8 +731,8 @@
         </g>
         <g id="44" class="nad-vl0to30" title="L9-14-1">
             <g>
-                <polyline points="2.89,1.67 3.24,3.68"/>
-                <g class="nad-edge-infos" transform="translate(2.94,1.96)">
+                <polyline points="2.84,1.37 3.22,3.53"/>
+                <g class="nad-edge-infos" transform="translate(2.89,1.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -750,7 +750,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.60,5.70 3.24,3.68"/>
+                <polyline points="3.60,5.70 3.22,3.53"/>
                 <g class="nad-edge-infos" transform="translate(3.54,5.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.90)">
@@ -771,8 +771,8 @@
         </g>
         <g id="45" class="nad-vl0to30" title="L10-11-1">
             <g>
-                <polyline points="-3.61,1.87 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-3.87,2.00)">
+                <polyline points="-3.34,1.73 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-3.61,1.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -790,8 +790,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.25,3.23 -4.93,2.55"/>
-                <g class="nad-edge-infos" transform="translate(-5.99,3.09)">
+                <polyline points="-6.52,3.36 -4.93,2.55"/>
+                <g class="nad-edge-infos" transform="translate(-6.25,3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -811,7 +811,7 @@
         </g>
         <g id="46" class="nad-vl0to30" title="L12-13-1">
             <g>
-                <polyline points="-3.28,9.45 -1.89,8.92"/>
+                <polyline points="-3.28,9.45 -1.75,8.86"/>
                 <g class="nad-edge-infos" transform="translate(-3.00,9.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.22)">
@@ -830,8 +830,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.49,8.39 -1.89,8.92"/>
-                <g class="nad-edge-infos" transform="translate(-0.77,8.49)">
+                <polyline points="-0.21,8.28 -1.75,8.86"/>
+                <g class="nad-edge-infos" transform="translate(-0.49,8.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -851,8 +851,8 @@
         </g>
         <g id="47" class="nad-vl0to30" title="L13-14-1">
             <g>
-                <polyline points="0.52,7.87 2.02,6.88"/>
-                <g class="nad-edge-infos" transform="translate(0.77,7.70)">
+                <polyline points="0.27,8.03 1.89,6.96"/>
+                <g class="nad-edge-infos" transform="translate(0.52,7.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -870,7 +870,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.52,5.88 2.02,6.88"/>
+                <polyline points="3.52,5.88 1.89,6.96"/>
                 <g class="nad-edge-infos" transform="translate(3.27,6.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.52)">
@@ -891,19 +891,19 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="1.84,-7.06 2.24,-7.06"/>
-        <polyline id="2_text_edge" points="-0.85,-5.20 -0.45,-5.20"/>
-        <polyline id="4_text_edge" points="-1.92,-7.98 -1.52,-7.98"/>
-        <polyline id="6_text_edge" points="2.43,-3.36 2.83,-3.36"/>
-        <polyline id="8_text_edge" points="-0.69,-1.85 -0.29,-1.85"/>
-        <polyline id="10_text_edge" points="-2.52,5.23 -2.12,5.23"/>
-        <polyline id="12_text_edge" points="6.96,-2.01 7.36,-2.01"/>
-        <polyline id="14_text_edge" points="11.04,-3.62 11.44,-3.62"/>
-        <polyline id="16_text_edge" points="3.39,1.11 3.79,1.11"/>
-        <polyline id="18_text_edge" points="-2.50,1.60 -2.10,1.60"/>
-        <polyline id="20_text_edge" points="-6.16,3.49 -5.76,3.49"/>
+        <polyline id="0_text_edge" points="1.54,-7.06 2.24,-7.06"/>
+        <polyline id="2_text_edge" points="-1.15,-5.20 -0.45,-5.20"/>
+        <polyline id="4_text_edge" points="-2.22,-7.98 -1.52,-7.98"/>
+        <polyline id="6_text_edge" points="2.13,-3.36 2.83,-3.36"/>
+        <polyline id="8_text_edge" points="-0.99,-1.85 -0.29,-1.85"/>
+        <polyline id="10_text_edge" points="-2.82,5.23 -2.12,5.23"/>
+        <polyline id="12_text_edge" points="6.66,-2.01 7.36,-2.01"/>
+        <polyline id="14_text_edge" points="10.74,-3.62 11.44,-3.62"/>
+        <polyline id="16_text_edge" points="3.09,1.11 3.79,1.11"/>
+        <polyline id="18_text_edge" points="-2.80,1.60 -2.10,1.60"/>
+        <polyline id="20_text_edge" points="-6.46,3.49 -5.76,3.49"/>
         <polyline id="22_text_edge" points="-3.24,9.49 -2.39,9.49"/>
-        <polyline id="24_text_edge" points="0.64,8.18 1.04,8.18"/>
+        <polyline id="24_text_edge" points="0.34,8.18 1.04,8.18"/>
         <polyline id="26_text_edge" points="3.77,5.82 4.62,5.82"/>
     </g>
     <g class="nad-text-nodes">

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -34,53 +34,53 @@
     <metadata></metadata>
     <g class="nad-vl-nodes">
         <g transform="translate(-3.85,-1.22)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-5.07,-4.78)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(-3.27,-8.47)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(0.33,-4.33)" id="6" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(-6.40,-0.23)" id="8" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(-4.43,7.58)" id="10" class="nad-vl0to30" title="VL6">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(6.87,-5.07)" id="12" class="nad-vl0to30" title="VL7">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(8.99,-10.14)" id="14" class="nad-vl0to30" title="VL8">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(6.16,0.70)" id="16" class="nad-vl0to30" title="VL9">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(7.24,4.99)" id="18" class="nad-vl0to30" title="VL10">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(1.33,5.99)" id="20" class="nad-vl0to30" title="VL11">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(-5.48,12.37)" id="22" class="nad-vl0to30" title="VL12">
-            <circle r="0.60" id="23"/>
+            <circle r="0.30" id="23"/>
         </g>
         <g transform="translate(-1.07,11.72)" id="24" class="nad-vl0to30" title="VL13">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(4.52,9.07)" id="26" class="nad-vl0to30" title="VL14">
-            <circle r="0.60" id="27"/>
+            <circle r="0.30" id="27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="28" class="nad-vl120to180" title="L1-2-1">
             <g>
-                <polyline points="-4.04,-1.76 -4.46,-3.00"/>
-                <g class="nad-edge-infos" transform="translate(-4.13,-2.05)">
+                <polyline points="-3.94,-1.48 -4.46,-3.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.04,-1.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -98,8 +98,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.89,-4.24 -4.46,-3.00"/>
-                <g class="nad-edge-infos" transform="translate(-4.79,-3.96)">
+                <polyline points="-4.99,-4.52 -4.46,-3.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.89,-4.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -119,8 +119,8 @@
         </g>
         <g id="29" class="nad-vl120to180" title="L1-5-1">
             <g>
-                <polyline points="-4.38,-1.02 -5.12,-0.73"/>
-                <g class="nad-edge-infos" transform="translate(-4.66,-0.91)">
+                <polyline points="-4.10,-1.12 -5.12,-0.73"/>
+                <g class="nad-edge-infos" transform="translate(-4.38,-1.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -138,8 +138,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.86,-0.44 -5.12,-0.73"/>
-                <g class="nad-edge-infos" transform="translate(-5.59,-0.55)">
+                <polyline points="-6.14,-0.33 -5.12,-0.73"/>
+                <g class="nad-edge-infos" transform="translate(-5.86,-0.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -159,8 +159,8 @@
         </g>
         <g id="30" class="nad-vl120to180" title="L2-3-1">
             <g>
-                <polyline points="-4.82,-5.29 -4.17,-6.62"/>
-                <g class="nad-edge-infos" transform="translate(-4.69,-5.56)">
+                <polyline points="-4.96,-5.02 -4.17,-6.62"/>
+                <g class="nad-edge-infos" transform="translate(-4.82,-5.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -178,8 +178,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.52,-7.96 -4.17,-6.62"/>
-                <g class="nad-edge-infos" transform="translate(-3.65,-7.69)">
+                <polyline points="-3.39,-8.23 -4.17,-6.62"/>
+                <g class="nad-edge-infos" transform="translate(-3.52,-7.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -199,8 +199,8 @@
         </g>
         <g id="31" class="nad-vl120to180" title="L2-4-1">
             <g>
-                <polyline points="-4.51,-4.73 -2.37,-4.55"/>
-                <g class="nad-edge-infos" transform="translate(-4.21,-4.71)">
+                <polyline points="-4.81,-4.76 -2.37,-4.55"/>
+                <g class="nad-edge-infos" transform="translate(-4.51,-4.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(94.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -218,8 +218,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.24,-4.38 -2.37,-4.55"/>
-                <g class="nad-edge-infos" transform="translate(-0.54,-4.40)">
+                <polyline points="0.06,-4.35 -2.37,-4.55"/>
+                <g class="nad-edge-infos" transform="translate(-0.24,-4.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-85.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -239,8 +239,8 @@
         </g>
         <g id="32" class="nad-vl120to180" title="L2-5-1">
             <g>
-                <polyline points="-5.23,-4.23 -5.74,-2.50"/>
-                <g class="nad-edge-infos" transform="translate(-5.32,-3.94)">
+                <polyline points="-5.15,-4.52 -5.74,-2.50"/>
+                <g class="nad-edge-infos" transform="translate(-5.23,-4.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-163.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -258,8 +258,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.24,-0.78 -5.74,-2.50"/>
-                <g class="nad-edge-infos" transform="translate(-6.15,-1.06)">
+                <polyline points="-6.32,-0.49 -5.74,-2.50"/>
+                <g class="nad-edge-infos" transform="translate(-6.24,-0.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(16.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -279,8 +279,8 @@
         </g>
         <g id="33" class="nad-vl120to180" title="L3-4-1">
             <g>
-                <polyline points="-2.89,-8.04 -1.47,-6.40"/>
-                <g class="nad-edge-infos" transform="translate(-2.70,-7.81)">
+                <polyline points="-3.09,-8.26 -1.47,-6.40"/>
+                <g class="nad-edge-infos" transform="translate(-2.89,-8.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -298,8 +298,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.04,-4.76 -1.47,-6.40"/>
-                <g class="nad-edge-infos" transform="translate(-0.24,-4.99)">
+                <polyline points="0.15,-4.53 -1.47,-6.40"/>
+                <g class="nad-edge-infos" transform="translate(-0.04,-4.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -319,8 +319,8 @@
         </g>
         <g id="34" class="nad-vl120to180" title="L4-5-1">
             <g>
-                <polyline points="-0.16,-4.03 -3.03,-2.28"/>
-                <g class="nad-edge-infos" transform="translate(-0.41,-3.88)">
+                <polyline points="0.10,-4.19 -3.03,-2.28"/>
+                <g class="nad-edge-infos" transform="translate(-0.16,-4.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -338,8 +338,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.91,-0.53 -3.03,-2.28"/>
-                <g class="nad-edge-infos" transform="translate(-5.65,-0.68)">
+                <polyline points="-6.17,-0.37 -3.03,-2.28"/>
+                <g class="nad-edge-infos" transform="translate(-5.91,-0.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -359,8 +359,8 @@
         </g>
         <g id="35" title="T4-7-1">
             <g class="nad-vl120to180">
-                <polyline points="0.90,-4.39 3.60,-4.70"/>
-                <g class="nad-edge-infos" transform="translate(1.19,-4.43)">
+                <polyline points="0.60,-4.36 3.60,-4.70"/>
+                <g class="nad-edge-infos" transform="translate(0.90,-4.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(83.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -379,8 +379,8 @@
                 <circle cx="3.50" cy="-4.69" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="6.30,-5.00 3.60,-4.70"/>
-                <g class="nad-edge-infos" transform="translate(6.00,-4.97)">
+                <polyline points="6.60,-5.04 3.60,-4.70"/>
+                <g class="nad-edge-infos" transform="translate(6.30,-5.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-96.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -401,8 +401,8 @@
         </g>
         <g id="36" title="T4-9-1">
             <g class="nad-vl120to180">
-                <polyline points="0.76,-3.96 3.25,-1.81"/>
-                <g class="nad-edge-infos" transform="translate(0.99,-3.76)">
+                <polyline points="0.53,-4.15 3.25,-1.81"/>
+                <g class="nad-edge-infos" transform="translate(0.76,-3.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -421,8 +421,8 @@
                 <circle cx="3.17" cy="-1.88" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.73,0.33 3.25,-1.81"/>
-                <g class="nad-edge-infos" transform="translate(5.50,0.13)">
+                <polyline points="5.96,0.52 3.25,-1.81"/>
+                <g class="nad-edge-infos" transform="translate(5.73,0.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -443,8 +443,8 @@
         </g>
         <g id="37" title="T5-6-1">
             <g class="nad-vl120to180">
-                <polyline points="-6.26,0.32 -5.41,3.68"/>
-                <g class="nad-edge-infos" transform="translate(-6.18,0.61)">
+                <polyline points="-6.33,0.03 -5.41,3.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.26,0.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -463,8 +463,8 @@
                 <circle cx="-5.44" cy="3.58" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-4.57,7.03 -5.41,3.68"/>
-                <g class="nad-edge-infos" transform="translate(-4.65,6.74)">
+                <polyline points="-4.50,7.32 -5.41,3.68"/>
+                <g class="nad-edge-infos" transform="translate(-4.57,7.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -485,8 +485,8 @@
         </g>
         <g id="38" class="nad-vl0to30" title="L6-11-1">
             <g>
-                <polyline points="-3.88,7.43 -1.55,6.79"/>
-                <g class="nad-edge-infos" transform="translate(-3.59,7.35)">
+                <polyline points="-4.17,7.51 -1.55,6.79"/>
+                <g class="nad-edge-infos" transform="translate(-3.88,7.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -504,8 +504,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.78,6.14 -1.55,6.79"/>
-                <g class="nad-edge-infos" transform="translate(0.49,6.22)">
+                <polyline points="1.07,6.07 -1.55,6.79"/>
+                <g class="nad-edge-infos" transform="translate(0.78,6.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -525,8 +525,8 @@
         </g>
         <g id="39" class="nad-vl0to30" title="L6-12-1">
             <g>
-                <polyline points="-4.56,8.14 -4.96,9.98"/>
-                <g class="nad-edge-infos" transform="translate(-4.62,8.43)">
+                <polyline points="-4.49,7.85 -4.96,9.98"/>
+                <g class="nad-edge-infos" transform="translate(-4.56,8.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-167.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -544,8 +544,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.36,11.81 -4.96,9.98"/>
-                <g class="nad-edge-infos" transform="translate(-5.29,11.52)">
+                <polyline points="-5.42,12.10 -4.96,9.98"/>
+                <g class="nad-edge-infos" transform="translate(-5.36,11.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(12.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -565,8 +565,8 @@
         </g>
         <g id="40" class="nad-vl0to30" title="L6-13-1">
             <g>
-                <polyline points="-4.07,8.03 -2.75,9.65"/>
-                <g class="nad-edge-infos" transform="translate(-3.88,8.26)">
+                <polyline points="-4.26,7.79 -2.75,9.65"/>
+                <g class="nad-edge-infos" transform="translate(-4.07,8.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -584,8 +584,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.43,11.27 -2.75,9.65"/>
-                <g class="nad-edge-infos" transform="translate(-1.62,11.04)">
+                <polyline points="-1.24,11.51 -2.75,9.65"/>
+                <g class="nad-edge-infos" transform="translate(-1.43,11.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -605,8 +605,8 @@
         </g>
         <g id="41" class="nad-vl0to30" title="L7-8-1">
             <g>
-                <polyline points="7.09,-5.59 7.93,-7.60"/>
-                <g class="nad-edge-infos" transform="translate(7.20,-5.87)">
+                <polyline points="6.97,-5.32 7.93,-7.60"/>
+                <g class="nad-edge-infos" transform="translate(7.09,-5.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -624,8 +624,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.77,-9.62 7.93,-7.60"/>
-                <g class="nad-edge-infos" transform="translate(8.65,-9.34)">
+                <polyline points="8.89,-9.89 7.93,-7.60"/>
+                <g class="nad-edge-infos" transform="translate(8.77,-9.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -645,8 +645,8 @@
         </g>
         <g id="42" class="nad-vl0to30" title="L7-9-1">
             <g>
-                <polyline points="6.80,-4.50 6.51,-2.18"/>
-                <g class="nad-edge-infos" transform="translate(6.76,-4.20)">
+                <polyline points="6.83,-4.80 6.51,-2.18"/>
+                <g class="nad-edge-infos" transform="translate(6.80,-4.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -664,8 +664,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.23,0.13 6.51,-2.18"/>
-                <g class="nad-edge-infos" transform="translate(6.27,-0.16)">
+                <polyline points="6.19,0.43 6.51,-2.18"/>
+                <g class="nad-edge-infos" transform="translate(6.23,0.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -685,8 +685,8 @@
         </g>
         <g id="43" class="nad-vl0to30" title="L9-10-1">
             <g>
-                <polyline points="6.30,1.25 6.70,2.85"/>
-                <g class="nad-edge-infos" transform="translate(6.37,1.54)">
+                <polyline points="6.23,0.96 6.70,2.85"/>
+                <g class="nad-edge-infos" transform="translate(6.30,1.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -704,8 +704,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="7.10,4.44 6.70,2.85"/>
-                <g class="nad-edge-infos" transform="translate(7.03,4.15)">
+                <polyline points="7.18,4.73 6.70,2.85"/>
+                <g class="nad-edge-infos" transform="translate(7.10,4.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -725,8 +725,8 @@
         </g>
         <g id="44" class="nad-vl0to30" title="L9-14-1">
             <g>
-                <polyline points="6.05,1.26 5.34,4.89"/>
-                <g class="nad-edge-infos" transform="translate(5.99,1.55)">
+                <polyline points="6.11,0.96 5.34,4.89"/>
+                <g class="nad-edge-infos" transform="translate(6.05,1.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -744,8 +744,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.63,8.51 5.34,4.89"/>
-                <g class="nad-edge-infos" transform="translate(4.69,8.22)">
+                <polyline points="4.57,8.81 5.34,4.89"/>
+                <g class="nad-edge-infos" transform="translate(4.63,8.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -765,8 +765,8 @@
         </g>
         <g id="45" class="nad-vl0to30" title="L10-11-1">
             <g>
-                <polyline points="6.68,5.09 4.29,5.49"/>
-                <g class="nad-edge-infos" transform="translate(6.39,5.14)">
+                <polyline points="6.98,5.04 4.29,5.49"/>
+                <g class="nad-edge-infos" transform="translate(6.68,5.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -784,8 +784,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.89,5.90 4.29,5.49"/>
-                <g class="nad-edge-infos" transform="translate(2.19,5.85)">
+                <polyline points="1.60,5.95 4.29,5.49"/>
+                <g class="nad-edge-infos" transform="translate(1.89,5.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -805,8 +805,8 @@
         </g>
         <g id="46" class="nad-vl0to30" title="L12-13-1">
             <g>
-                <polyline points="-4.91,12.28 -3.27,12.04"/>
-                <g class="nad-edge-infos" transform="translate(-4.62,12.24)">
+                <polyline points="-5.21,12.33 -3.27,12.04"/>
+                <g class="nad-edge-infos" transform="translate(-4.91,12.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -824,8 +824,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.63,11.80 -3.27,12.04"/>
-                <g class="nad-edge-infos" transform="translate(-1.93,11.84)">
+                <polyline points="-1.34,11.76 -3.27,12.04"/>
+                <g class="nad-edge-infos" transform="translate(-1.63,11.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -845,8 +845,8 @@
         </g>
         <g id="47" class="nad-vl0to30" title="L13-14-1">
             <g>
-                <polyline points="-0.55,11.47 1.73,10.39"/>
-                <g class="nad-edge-infos" transform="translate(-0.28,11.34)">
+                <polyline points="-0.82,11.60 1.73,10.39"/>
+                <g class="nad-edge-infos" transform="translate(-0.55,11.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -864,8 +864,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.01,9.32 1.73,10.39"/>
-                <g class="nad-edge-infos" transform="translate(3.74,9.45)">
+                <polyline points="4.28,9.19 1.73,10.39"/>
+                <g class="nad-edge-infos" transform="translate(4.01,9.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-115.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -885,20 +885,20 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-3.94,-0.63 -4.41,2.71"/>
-        <polyline id="2_text_edge" points="-5.62,-5.03 -9.54,-6.82"/>
-        <polyline id="4_text_edge" points="-3.48,-9.03 -4.88,-12.66"/>
-        <polyline id="6_text_edge" points="0.54,-4.89 1.93,-8.52"/>
-        <polyline id="8_text_edge" points="-6.99,-0.18 -11.41,0.16"/>
-        <polyline id="10_text_edge" points="-5.03,7.65 -9.30,8.09"/>
-        <polyline id="12_text_edge" points="7.46,-5.14 11.55,-5.63"/>
-        <polyline id="14_text_edge" points="9.22,-10.70 10.55,-13.92"/>
-        <polyline id="16_text_edge" points="6.76,0.67 11.00,0.48"/>
-        <polyline id="18_text_edge" points="7.80,5.23 11.67,6.88"/>
-        <polyline id="20_text_edge" points="1.41,5.40 1.75,2.62"/>
-        <polyline id="22_text_edge" points="-5.92,12.77 -8.81,15.34"/>
-        <polyline id="24_text_edge" points="-0.97,12.31 -0.28,16.21"/>
-        <polyline id="26_text_edge" points="4.87,9.57 7.15,12.83"/>
+        <polyline id="0_text_edge" points="-3.89,-0.93 -4.41,2.71"/>
+        <polyline id="2_text_edge" points="-5.35,-4.90 -9.54,-6.82"/>
+        <polyline id="4_text_edge" points="-3.37,-8.75 -4.88,-12.66"/>
+        <polyline id="6_text_edge" points="0.44,-4.61 1.93,-8.52"/>
+        <polyline id="8_text_edge" points="-6.69,-0.21 -11.41,0.16"/>
+        <polyline id="10_text_edge" points="-4.73,7.61 -9.30,8.09"/>
+        <polyline id="12_text_edge" points="7.17,-5.10 11.55,-5.63"/>
+        <polyline id="14_text_edge" points="9.10,-10.42 10.55,-13.92"/>
+        <polyline id="16_text_edge" points="6.46,0.69 11.00,0.48"/>
+        <polyline id="18_text_edge" points="7.52,5.11 11.67,6.88"/>
+        <polyline id="20_text_edge" points="1.37,5.70 1.75,2.62"/>
+        <polyline id="22_text_edge" points="-5.70,12.57 -8.81,15.34"/>
+        <polyline id="24_text_edge" points="-1.02,12.01 -0.28,16.21"/>
+        <polyline id="26_text_edge" points="4.69,9.32 7.15,12.83"/>
     </g>
     <g class="nad-text-nodes">
         <text x="-4.41" y="2.71" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -40,83 +40,83 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1.47,1.63)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-2.44,5.90)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(1.66,-1.23)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(0.53,-6.64)" id="6" class="nad-vl180to300" title="VL24">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(0.41,9.61)" id="8" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(1.99,2.84)" id="10" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(5.72,4.17)" id="12" class="nad-vl120to180" title="VL9">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(5.08,6.46)" id="14" class="nad-vl120to180" title="VL10">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(7.57,1.12)" id="16" class="nad-vl180to300" title="VL11">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(8.11,7.22)" id="18" class="nad-vl180to300" title="VL12">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(0.81,6.60)" id="20" class="nad-vl120to180" title="VL6">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(10.48,14.67)" id="22" class="nad-vl120to180" title="VL7">
-            <circle r="0.60" id="23"/>
+            <circle r="0.30" id="23"/>
         </g>
         <g transform="translate(8.57,10.45)" id="24" class="nad-vl180to300" title="VL8">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(10.11,4.96)" id="26" class="nad-vl180to300" title="VL13">
-            <circle r="0.60" id="27"/>
+            <circle r="0.30" id="27"/>
         </g>
         <g transform="translate(3.90,-3.92)" id="28" class="nad-vl180to300" title="VL14">
-            <circle r="0.60" id="29"/>
+            <circle r="0.30" id="29"/>
         </g>
         <g transform="translate(-3.06,-8.50)" id="30" class="nad-vl180to300" title="VL15">
-            <circle r="0.60" id="31"/>
+            <circle r="0.30" id="31"/>
         </g>
         <g transform="translate(-4.24,-4.13)" id="32" class="nad-vl180to300" title="VL16">
-            <circle r="0.60" id="33"/>
+            <circle r="0.30" id="33"/>
         </g>
         <g transform="translate(-8.54,-7.99)" id="34" class="nad-vl180to300" title="VL17">
-            <circle r="0.60" id="35"/>
+            <circle r="0.30" id="35"/>
         </g>
         <g transform="translate(-11.03,-10.30)" id="36" class="nad-vl180to300" title="VL18">
-            <circle r="0.60" id="37"/>
+            <circle r="0.30" id="37"/>
         </g>
         <g transform="translate(-6.80,2.47)" id="38" class="nad-vl180to300" title="VL19">
-            <circle r="0.60" id="39"/>
+            <circle r="0.30" id="39"/>
         </g>
         <g transform="translate(-4.18,8.90)" id="40" class="nad-vl180to300" title="VL20">
-            <circle r="0.60" id="41"/>
+            <circle r="0.30" id="41"/>
         </g>
         <g transform="translate(-6.32,-11.50)" id="42" class="nad-vl180to300" title="VL21">
-            <circle r="0.60" id="43"/>
+            <circle r="0.30" id="43"/>
         </g>
         <g transform="translate(-8.69,-13.46)" id="44" class="nad-vl180to300" title="VL22">
-            <circle r="0.60" id="45"/>
+            <circle r="0.30" id="45"/>
         </g>
         <g transform="translate(4.41,9.80)" id="46" class="nad-vl180to300" title="VL23">
-            <circle r="0.60" id="47"/>
+            <circle r="0.30" id="47"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="48" class="nad-vl120to180" title="L-1-2-1 ">
             <g>
-                <polyline points="-1.59,2.19 -1.95,3.77"/>
-                <g class="nad-edge-infos" transform="translate(-1.66,2.48)">
+                <polyline points="-1.53,1.90 -1.95,3.77"/>
+                <g class="nad-edge-infos" transform="translate(-1.59,2.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-167.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -134,8 +134,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.31,5.35 -1.95,3.77"/>
-                <g class="nad-edge-infos" transform="translate(-2.24,5.06)">
+                <polyline points="-2.38,5.64 -1.95,3.77"/>
+                <g class="nad-edge-infos" transform="translate(-2.31,5.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(12.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -155,8 +155,8 @@
         </g>
         <g id="49" class="nad-vl120to180" title="L-3-1-1 ">
             <g>
-                <polyline points="1.24,-0.85 0.09,0.20"/>
-                <g class="nad-edge-infos" transform="translate(1.01,-0.65)">
+                <polyline points="1.46,-1.05 0.09,0.20"/>
+                <g class="nad-edge-infos" transform="translate(1.24,-0.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -174,8 +174,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.05,1.25 0.09,0.20"/>
-                <g class="nad-edge-infos" transform="translate(-0.82,1.04)">
+                <polyline points="-1.27,1.45 0.09,0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.05,1.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -195,8 +195,8 @@
         </g>
         <g id="50" class="nad-vl120to180" title="L-1-5-1 ">
             <g>
-                <polyline points="-0.93,1.82 0.26,2.24"/>
-                <g class="nad-edge-infos" transform="translate(-0.64,1.92)">
+                <polyline points="-1.21,1.72 0.26,2.24"/>
+                <g class="nad-edge-infos" transform="translate(-0.93,1.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -214,8 +214,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.45,2.65 0.26,2.24"/>
-                <g class="nad-edge-infos" transform="translate(1.17,2.55)">
+                <polyline points="1.74,2.75 0.26,2.24"/>
+                <g class="nad-edge-infos" transform="translate(1.45,2.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -235,8 +235,8 @@
         </g>
         <g id="51" class="nad-vl120to180" title="L-2-4-1 ">
             <g>
-                <polyline points="-2.09,6.36 -1.01,7.75"/>
-                <g class="nad-edge-infos" transform="translate(-1.91,6.59)">
+                <polyline points="-2.27,6.12 -1.01,7.75"/>
+                <g class="nad-edge-infos" transform="translate(-2.09,6.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(142.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -254,8 +254,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.06,9.15 -1.01,7.75"/>
-                <g class="nad-edge-infos" transform="translate(-0.12,8.92)">
+                <polyline points="0.24,9.39 -1.01,7.75"/>
+                <g class="nad-edge-infos" transform="translate(0.06,9.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-37.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -275,8 +275,8 @@
         </g>
         <g id="52" class="nad-vl120to180" title="L-2-6-1 ">
             <g>
-                <polyline points="-1.88,6.02 -0.81,6.25"/>
-                <g class="nad-edge-infos" transform="translate(-1.59,6.09)">
+                <polyline points="-2.17,5.96 -0.81,6.25"/>
+                <g class="nad-edge-infos" transform="translate(-1.88,6.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -294,8 +294,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.26,6.48 -0.81,6.25"/>
-                <g class="nad-edge-infos" transform="translate(-0.04,6.42)">
+                <polyline points="0.55,6.55 -0.81,6.25"/>
+                <g class="nad-edge-infos" transform="translate(0.26,6.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -315,8 +315,8 @@
         </g>
         <g id="53" title="T-24-3-1 ">
             <g class="nad-vl180to300">
-                <polyline points="0.65,-6.09 1.09,-3.94"/>
-                <g class="nad-edge-infos" transform="translate(0.71,-5.79)">
+                <polyline points="0.59,-6.38 1.09,-3.94"/>
+                <g class="nad-edge-infos" transform="translate(0.65,-6.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -335,8 +335,8 @@
                 <circle cx="1.07" cy="-4.04" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="1.54,-1.79 1.09,-3.94"/>
-                <g class="nad-edge-infos" transform="translate(1.48,-2.09)">
+                <polyline points="1.60,-1.50 1.09,-3.94"/>
+                <g class="nad-edge-infos" transform="translate(1.54,-1.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -357,8 +357,8 @@
         </g>
         <g id="54" class="nad-vl120to180" title="L-3-9-1 ">
             <g>
-                <polyline points="2.00,-0.78 3.69,1.47"/>
-                <g class="nad-edge-infos" transform="translate(2.18,-0.54)">
+                <polyline points="1.82,-1.02 3.69,1.47"/>
+                <g class="nad-edge-infos" transform="translate(2.00,-0.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -376,8 +376,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.38,3.71 3.69,1.47"/>
-                <g class="nad-edge-infos" transform="translate(5.20,3.47)">
+                <polyline points="5.56,3.95 3.69,1.47"/>
+                <g class="nad-edge-infos" transform="translate(5.38,3.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -397,8 +397,8 @@
         </g>
         <g id="55" class="nad-vl180to300" title="L-15-24-1 ">
             <g>
-                <polyline points="-2.56,-8.23 -1.26,-7.57"/>
-                <g class="nad-edge-infos" transform="translate(-2.29,-8.10)">
+                <polyline points="-2.82,-8.37 -1.26,-7.57"/>
+                <g class="nad-edge-infos" transform="translate(-2.56,-8.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -416,8 +416,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.03,-6.91 -1.26,-7.57"/>
-                <g class="nad-edge-infos" transform="translate(-0.24,-7.04)">
+                <polyline points="0.29,-6.77 -1.26,-7.57"/>
+                <g class="nad-edge-infos" transform="translate(0.03,-6.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -437,8 +437,8 @@
         </g>
         <g id="56" class="nad-vl120to180" title="L-4-9-1 ">
             <g>
-                <polyline points="0.81,9.20 3.06,6.89"/>
-                <g class="nad-edge-infos" transform="translate(1.02,8.98)">
+                <polyline points="0.60,9.41 3.06,6.89"/>
+                <g class="nad-edge-infos" transform="translate(0.81,9.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -456,8 +456,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.32,4.58 3.06,6.89"/>
-                <g class="nad-edge-infos" transform="translate(5.11,4.79)">
+                <polyline points="5.53,4.36 3.06,6.89"/>
+                <g class="nad-edge-infos" transform="translate(5.32,4.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -477,8 +477,8 @@
         </g>
         <g id="57" title="T-5-10-1 ">
             <g class="nad-vl120to180">
-                <polyline points="2.36,3.28 3.54,4.65"/>
-                <g class="nad-edge-infos" transform="translate(2.56,3.50)">
+                <polyline points="2.17,3.05 3.54,4.65"/>
+                <g class="nad-edge-infos" transform="translate(2.36,3.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -497,8 +497,8 @@
                 <circle cx="3.47" cy="4.58" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="4.71,6.03 3.54,4.65"/>
-                <g class="nad-edge-infos" transform="translate(4.52,5.80)">
+                <polyline points="4.90,6.26 3.54,4.65"/>
+                <g class="nad-edge-infos" transform="translate(4.71,6.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -519,8 +519,8 @@
         </g>
         <g id="58" title="T-11-9-1 ">
             <g class="nad-vl180to300">
-                <polyline points="7.27,1.61 6.64,2.64"/>
-                <g class="nad-edge-infos" transform="translate(7.12,1.86)">
+                <polyline points="7.43,1.35 6.64,2.64"/>
+                <g class="nad-edge-infos" transform="translate(7.27,1.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -539,8 +539,8 @@
                 <circle cx="6.70" cy="2.56" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="6.02,3.68 6.64,2.64"/>
-                <g class="nad-edge-infos" transform="translate(6.17,3.42)">
+                <polyline points="5.86,3.94 6.64,2.64"/>
+                <g class="nad-edge-infos" transform="translate(6.02,3.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -561,8 +561,8 @@
         </g>
         <g id="59" title="T-9-12-1 ">
             <g class="nad-vl120to180">
-                <polyline points="6.07,4.62 6.92,5.70"/>
-                <g class="nad-edge-infos" transform="translate(6.26,4.85)">
+                <polyline points="5.89,4.38 6.92,5.70"/>
+                <g class="nad-edge-infos" transform="translate(6.07,4.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -581,8 +581,8 @@
                 <circle cx="6.86" cy="5.62" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="7.76,6.78 6.92,5.70"/>
-                <g class="nad-edge-infos" transform="translate(7.58,6.54)">
+                <polyline points="7.95,7.01 6.92,5.70"/>
+                <g class="nad-edge-infos" transform="translate(7.76,6.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -603,8 +603,8 @@
         </g>
         <g id="60" class="nad-vl180to300" title="L-8-9-1 ">
             <g>
-                <polyline points="8.34,9.93 7.15,7.31"/>
-                <g class="nad-edge-infos" transform="translate(8.21,9.66)">
+                <polyline points="8.46,10.21 7.15,7.31"/>
+                <g class="nad-edge-infos" transform="translate(8.34,9.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -622,8 +622,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.96,4.69 7.15,7.31"/>
-                <g class="nad-edge-infos" transform="translate(6.08,4.96)">
+                <polyline points="5.83,4.42 7.15,7.31"/>
+                <g class="nad-edge-infos" transform="translate(5.96,4.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -643,8 +643,8 @@
         </g>
         <g id="61" title="T-11-10-1 ">
             <g class="nad-vl180to300">
-                <polyline points="7.33,1.64 6.32,3.79"/>
-                <g class="nad-edge-infos" transform="translate(7.20,1.91)">
+                <polyline points="7.45,1.37 6.32,3.79"/>
+                <g class="nad-edge-infos" transform="translate(7.33,1.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -663,8 +663,8 @@
                 <circle cx="6.37" cy="3.70" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="5.32,5.95 6.32,3.79"/>
-                <g class="nad-edge-infos" transform="translate(5.45,5.67)">
+                <polyline points="5.19,6.22 6.32,3.79"/>
+                <g class="nad-edge-infos" transform="translate(5.32,5.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -685,8 +685,8 @@
         </g>
         <g id="62" title="T-12-10-1 ">
             <g class="nad-vl180to300">
-                <polyline points="7.56,7.09 6.60,6.84"/>
-                <g class="nad-edge-infos" transform="translate(7.27,7.01)">
+                <polyline points="7.85,7.16 6.60,6.84"/>
+                <g class="nad-edge-infos" transform="translate(7.56,7.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.92)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -705,8 +705,8 @@
                 <circle cx="6.69" cy="6.87" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="5.63,6.60 6.60,6.84"/>
-                <g class="nad-edge-infos" transform="translate(5.92,6.67)">
+                <polyline points="5.34,6.53 6.60,6.84"/>
+                <g class="nad-edge-infos" transform="translate(5.63,6.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -727,8 +727,8 @@
         </g>
         <g id="63" class="nad-vl120to180" title="L-10-6-1 ">
             <g>
-                <polyline points="4.51,6.48 2.95,6.53"/>
-                <g class="nad-edge-infos" transform="translate(4.21,6.49)">
+                <polyline points="4.81,6.47 2.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(4.51,6.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -746,8 +746,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.38,6.59 2.95,6.53"/>
-                <g class="nad-edge-infos" transform="translate(1.68,6.58)">
+                <polyline points="1.08,6.60 2.95,6.53"/>
+                <g class="nad-edge-infos" transform="translate(1.38,6.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -767,8 +767,8 @@
         </g>
         <g id="64" class="nad-vl180to300" title="L-8-10-1 ">
             <g>
-                <polyline points="8.20,10.02 6.83,8.46"/>
-                <g class="nad-edge-infos" transform="translate(8.00,9.80)">
+                <polyline points="8.39,10.25 6.83,8.46"/>
+                <g class="nad-edge-infos" transform="translate(8.20,10.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -786,8 +786,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.46,6.89 6.83,8.46"/>
-                <g class="nad-edge-infos" transform="translate(5.65,7.12)">
+                <polyline points="5.26,6.67 6.83,8.46"/>
+                <g class="nad-edge-infos" transform="translate(5.46,6.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -807,8 +807,8 @@
         </g>
         <g id="65" class="nad-vl180to300" title="L-11-13-1 ">
             <g>
-                <polyline points="7.88,1.60 8.84,3.04"/>
-                <g class="nad-edge-infos" transform="translate(8.05,1.85)">
+                <polyline points="7.72,1.35 8.84,3.04"/>
+                <g class="nad-edge-infos" transform="translate(7.88,1.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -826,8 +826,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.80,4.49 8.84,3.04"/>
-                <g class="nad-edge-infos" transform="translate(9.63,4.24)">
+                <polyline points="9.96,4.74 8.84,3.04"/>
+                <g class="nad-edge-infos" transform="translate(9.80,4.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -847,8 +847,8 @@
         </g>
         <g id="66" class="nad-vl180to300" title="L-11-14-1 ">
             <g>
-                <polyline points="7.23,0.66 5.73,-1.40"/>
-                <g class="nad-edge-infos" transform="translate(7.06,0.42)">
+                <polyline points="7.41,0.90 5.73,-1.40"/>
+                <g class="nad-edge-infos" transform="translate(7.23,0.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -866,8 +866,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.23,-3.46 5.73,-1.40"/>
-                <g class="nad-edge-infos" transform="translate(4.41,-3.22)">
+                <polyline points="4.06,-3.70 5.73,-1.40"/>
+                <g class="nad-edge-infos" transform="translate(4.23,-3.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -887,8 +887,8 @@
         </g>
         <g id="67" class="nad-vl180to300" title="L-12-13-1 ">
             <g>
-                <polyline points="8.49,6.80 9.11,6.09"/>
-                <g class="nad-edge-infos" transform="translate(8.69,6.57)">
+                <polyline points="8.29,7.02 9.11,6.09"/>
+                <g class="nad-edge-infos" transform="translate(8.49,6.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -906,8 +906,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.73,5.39 9.11,6.09"/>
-                <g class="nad-edge-infos" transform="translate(9.54,5.62)">
+                <polyline points="9.93,5.17 9.11,6.09"/>
+                <g class="nad-edge-infos" transform="translate(9.73,5.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -927,8 +927,8 @@
         </g>
         <g id="68" class="nad-vl180to300" title="L-12-23-1 ">
             <g>
-                <polyline points="7.64,7.55 6.26,8.51"/>
-                <g class="nad-edge-infos" transform="translate(7.40,7.72)">
+                <polyline points="7.89,7.38 6.26,8.51"/>
+                <g class="nad-edge-infos" transform="translate(7.64,7.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -946,8 +946,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.88,9.47 6.26,8.51"/>
-                <g class="nad-edge-infos" transform="translate(5.13,9.30)">
+                <polyline points="4.63,9.64 6.26,8.51"/>
+                <g class="nad-edge-infos" transform="translate(4.88,9.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -967,8 +967,8 @@
         </g>
         <g id="69" class="nad-vl120to180" title="L-7-8-1 ">
             <g>
-                <polyline points="10.24,14.15 9.52,12.56"/>
-                <g class="nad-edge-infos" transform="translate(10.12,13.88)">
+                <polyline points="10.37,14.43 9.52,12.56"/>
+                <g class="nad-edge-infos" transform="translate(10.24,14.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -986,8 +986,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.81,10.97 9.52,12.56"/>
-                <g class="nad-edge-infos" transform="translate(8.93,11.25)">
+                <polyline points="8.68,10.70 9.52,12.56"/>
+                <g class="nad-edge-infos" transform="translate(8.81,10.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1007,8 +1007,8 @@
         </g>
         <g id="70" class="nad-vl180to300" title="L-23-13-1 ">
             <g>
-                <polyline points="4.85,9.43 7.26,7.38"/>
-                <g class="nad-edge-infos" transform="translate(5.08,9.24)">
+                <polyline points="4.62,9.62 7.26,7.38"/>
+                <g class="nad-edge-infos" transform="translate(4.85,9.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1026,8 +1026,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="9.68,5.33 7.26,7.38"/>
-                <g class="nad-edge-infos" transform="translate(9.45,5.53)">
+                <polyline points="9.91,5.14 7.26,7.38"/>
+                <g class="nad-edge-infos" transform="translate(9.68,5.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1047,8 +1047,8 @@
         </g>
         <g id="71" class="nad-vl180to300" title="L-14-16-1 ">
             <g>
-                <polyline points="3.33,-3.94 -0.17,-4.03"/>
-                <g class="nad-edge-infos" transform="translate(3.03,-3.95)">
+                <polyline points="3.63,-3.93 -0.17,-4.03"/>
+                <g class="nad-edge-infos" transform="translate(3.33,-3.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1066,8 +1066,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.67,-4.12 -0.17,-4.03"/>
-                <g class="nad-edge-infos" transform="translate(-3.37,-4.11)">
+                <polyline points="-3.97,-4.13 -0.17,-4.03"/>
+                <g class="nad-edge-infos" transform="translate(-3.67,-4.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1087,8 +1087,8 @@
         </g>
         <g id="72" class="nad-vl180to300" title="L-16-15-1 ">
             <g>
-                <polyline points="-4.09,-4.68 -3.65,-6.31"/>
-                <g class="nad-edge-infos" transform="translate(-4.02,-4.97)">
+                <polyline points="-4.17,-4.39 -3.65,-6.31"/>
+                <g class="nad-edge-infos" transform="translate(-4.09,-4.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1106,8 +1106,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.21,-7.94 -3.65,-6.31"/>
-                <g class="nad-edge-infos" transform="translate(-3.29,-7.66)">
+                <polyline points="-3.13,-8.23 -3.65,-6.31"/>
+                <g class="nad-edge-infos" transform="translate(-3.21,-7.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1127,7 +1127,7 @@
         </g>
         <g id="73" class="nad-vl180to300" title="L-15-21-1 ">
             <g>
-                <polyline points="-3.23,-9.04 -3.30,-9.26 -4.42,-10.29"/>
+                <polyline points="-3.14,-8.75 -3.30,-9.26 -4.42,-10.29"/>
                 <g class="nad-edge-infos" transform="translate(-3.52,-9.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.36)">
@@ -1146,7 +1146,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.77,-11.37 -5.54,-11.32 -4.42,-10.29"/>
+                <polyline points="-6.06,-11.44 -5.54,-11.32 -4.42,-10.29"/>
                 <g class="nad-edge-infos" transform="translate(-5.32,-11.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.64)">
@@ -1167,7 +1167,7 @@
         </g>
         <g id="74" class="nad-vl180to300" title="L-21-15-2 ">
             <g>
-                <polyline points="-6.15,-10.96 -6.09,-10.74 -4.96,-9.70"/>
+                <polyline points="-6.24,-11.24 -6.09,-10.74 -4.96,-9.70"/>
                 <g class="nad-edge-infos" transform="translate(-5.86,-10.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.64)">
@@ -1186,7 +1186,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.62,-8.62 -3.84,-8.67 -4.96,-9.70"/>
+                <polyline points="-3.33,-8.55 -3.84,-8.67 -4.96,-9.70"/>
                 <g class="nad-edge-infos" transform="translate(-4.06,-8.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.36)">
@@ -1207,8 +1207,8 @@
         </g>
         <g id="75" class="nad-vl180to300" title="L-16-17-1 ">
             <g>
-                <polyline points="-4.67,-4.51 -6.39,-6.06"/>
-                <g class="nad-edge-infos" transform="translate(-4.89,-4.71)">
+                <polyline points="-4.44,-4.31 -6.39,-6.06"/>
+                <g class="nad-edge-infos" transform="translate(-4.67,-4.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1226,8 +1226,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.12,-7.61 -6.39,-6.06"/>
-                <g class="nad-edge-infos" transform="translate(-7.89,-7.41)">
+                <polyline points="-8.34,-7.81 -6.39,-6.06"/>
+                <g class="nad-edge-infos" transform="translate(-8.12,-7.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1247,8 +1247,8 @@
         </g>
         <g id="76" class="nad-vl180to300" title="L-16-19-1 ">
             <g>
-                <polyline points="-4.45,-3.60 -5.52,-0.83"/>
-                <g class="nad-edge-infos" transform="translate(-4.56,-3.32)">
+                <polyline points="-4.34,-3.88 -5.52,-0.83"/>
+                <g class="nad-edge-infos" transform="translate(-4.45,-3.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1266,8 +1266,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.60,1.93 -5.52,-0.83"/>
-                <g class="nad-edge-infos" transform="translate(-6.49,1.65)">
+                <polyline points="-6.71,2.21 -5.52,-0.83"/>
+                <g class="nad-edge-infos" transform="translate(-6.60,1.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1287,8 +1287,8 @@
         </g>
         <g id="77" class="nad-vl180to300" title="L-17-18-1 ">
             <g>
-                <polyline points="-8.96,-8.38 -9.79,-9.15"/>
-                <g class="nad-edge-infos" transform="translate(-9.18,-8.58)">
+                <polyline points="-8.74,-8.17 -9.79,-9.15"/>
+                <g class="nad-edge-infos" transform="translate(-8.96,-8.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1306,8 +1306,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.62,-9.91 -9.79,-9.15"/>
-                <g class="nad-edge-infos" transform="translate(-10.40,-9.71)">
+                <polyline points="-10.84,-10.12 -9.79,-9.15"/>
+                <g class="nad-edge-infos" transform="translate(-10.62,-9.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1327,8 +1327,8 @@
         </g>
         <g id="78" class="nad-vl180to300" title="L-17-22-1 ">
             <g>
-                <polyline points="-8.56,-8.56 -8.62,-10.72"/>
-                <g class="nad-edge-infos" transform="translate(-8.56,-8.86)">
+                <polyline points="-8.55,-8.26 -8.62,-10.72"/>
+                <g class="nad-edge-infos" transform="translate(-8.56,-8.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1346,8 +1346,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.68,-12.89 -8.62,-10.72"/>
-                <g class="nad-edge-infos" transform="translate(-8.67,-12.59)">
+                <polyline points="-8.68,-13.19 -8.62,-10.72"/>
+                <g class="nad-edge-infos" transform="translate(-8.68,-12.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1367,7 +1367,7 @@
         </g>
         <g id="79" class="nad-vl180to300" title="L-18-21-1 ">
             <g>
-                <polyline points="-10.49,-10.15 -10.26,-10.08 -8.58,-10.51"/>
+                <polyline points="-10.78,-10.23 -10.26,-10.08 -8.58,-10.51"/>
                 <g class="nad-edge-infos" transform="translate(-9.97,-10.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.73)">
@@ -1386,7 +1386,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.73,-11.10 -6.90,-10.94 -8.58,-10.51"/>
+                <polyline points="-6.52,-11.31 -6.90,-10.94 -8.58,-10.51"/>
                 <g class="nad-edge-infos" transform="translate(-7.19,-10.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.27)">
@@ -1407,7 +1407,7 @@
         </g>
         <g id="80" class="nad-vl180to300" title="L-18-21-2 ">
             <g>
-                <polyline points="-10.63,-10.70 -10.46,-10.86 -8.78,-11.29"/>
+                <polyline points="-10.84,-10.49 -10.46,-10.86 -8.78,-11.29"/>
                 <g class="nad-edge-infos" transform="translate(-10.17,-10.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.73)">
@@ -1426,7 +1426,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.87,-11.65 -7.09,-11.72 -8.78,-11.29"/>
+                <polyline points="-6.58,-11.57 -7.09,-11.72 -8.78,-11.29"/>
                 <g class="nad-edge-infos" transform="translate(-7.38,-11.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.27)">
@@ -1447,7 +1447,7 @@
         </g>
         <g id="81" class="nad-vl180to300" title="L-19-20-1 ">
             <g>
-                <polyline points="-6.88,3.03 -6.91,3.26 -5.86,5.84"/>
+                <polyline points="-6.84,2.73 -6.91,3.26 -5.86,5.84"/>
                 <g class="nad-edge-infos" transform="translate(-6.80,3.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.81)">
@@ -1466,7 +1466,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.63,8.55 -4.81,8.41 -5.86,5.84"/>
+                <polyline points="-4.39,8.74 -4.81,8.41 -5.86,5.84"/>
                 <g class="nad-edge-infos" transform="translate(-4.92,8.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.19)">
@@ -1487,7 +1487,7 @@
         </g>
         <g id="82" class="nad-vl180to300" title="L-19-20-2 ">
             <g>
-                <polyline points="-6.35,2.81 -6.17,2.96 -5.12,5.53"/>
+                <polyline points="-6.59,2.63 -6.17,2.96 -5.12,5.53"/>
                 <g class="nad-edge-infos" transform="translate(-6.06,3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.81)">
@@ -1506,7 +1506,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.10,8.34 -4.07,8.11 -5.12,5.53"/>
+                <polyline points="-4.14,8.64 -4.07,8.11 -5.12,5.53"/>
                 <g class="nad-edge-infos" transform="translate(-4.18,7.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.19)">
@@ -1527,7 +1527,7 @@
         </g>
         <g id="83" class="nad-vl180to300" title="L-20-23-1 ">
             <g>
-                <polyline points="-3.72,9.24 -3.53,9.37 0.08,9.75"/>
+                <polyline points="-3.96,9.06 -3.53,9.37 0.08,9.75"/>
                 <g class="nad-edge-infos" transform="translate(-3.23,9.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.95)">
@@ -1546,7 +1546,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.89,10.03 3.68,10.12 0.08,9.75"/>
+                <polyline points="4.17,9.91 3.68,10.12 0.08,9.75"/>
                 <g class="nad-edge-infos" transform="translate(3.38,10.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.05)">
@@ -1567,7 +1567,7 @@
         </g>
         <g id="84" class="nad-vl180to300" title="L-20-23-2 ">
             <g>
-                <polyline points="-3.66,8.67 -3.45,8.58 0.16,8.95"/>
+                <polyline points="-3.93,8.79 -3.45,8.58 0.16,8.95"/>
                 <g class="nad-edge-infos" transform="translate(-3.15,8.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.95)">
@@ -1586,7 +1586,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.95,9.46 3.76,9.33 0.16,8.95"/>
+                <polyline points="4.19,9.64 3.76,9.33 0.16,8.95"/>
                 <g class="nad-edge-infos" transform="translate(3.47,9.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.05)">
@@ -1607,8 +1607,8 @@
         </g>
         <g id="85" class="nad-vl180to300" title="L-21-22-1 ">
             <g>
-                <polyline points="-6.76,-11.86 -7.51,-12.48"/>
-                <g class="nad-edge-infos" transform="translate(-6.99,-12.05)">
+                <polyline points="-6.53,-11.67 -7.51,-12.48"/>
+                <g class="nad-edge-infos" transform="translate(-6.76,-11.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1626,8 +1626,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.25,-13.09 -7.51,-12.48"/>
-                <g class="nad-edge-infos" transform="translate(-8.02,-12.90)">
+                <polyline points="-8.48,-13.28 -7.51,-12.48"/>
+                <g class="nad-edge-infos" transform="translate(-8.25,-13.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1647,30 +1647,30 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-0.87,1.63 -0.47,1.63"/>
-        <polyline id="2_text_edge" points="-1.84,5.90 -1.44,5.90"/>
-        <polyline id="4_text_edge" points="2.26,-1.23 2.66,-1.23"/>
-        <polyline id="6_text_edge" points="1.13,-6.64 1.53,-6.64"/>
-        <polyline id="8_text_edge" points="1.01,9.61 1.41,9.61"/>
-        <polyline id="10_text_edge" points="2.59,2.84 2.99,2.84"/>
-        <polyline id="12_text_edge" points="6.32,4.17 6.72,4.17"/>
-        <polyline id="14_text_edge" points="5.68,6.46 6.08,6.46"/>
-        <polyline id="16_text_edge" points="8.17,1.12 8.57,1.12"/>
-        <polyline id="18_text_edge" points="8.71,7.22 9.11,7.22"/>
-        <polyline id="20_text_edge" points="1.41,6.60 1.81,6.60"/>
-        <polyline id="22_text_edge" points="11.08,14.67 11.48,14.67"/>
-        <polyline id="24_text_edge" points="9.17,10.45 9.57,10.45"/>
-        <polyline id="26_text_edge" points="10.71,4.96 11.11,4.96"/>
-        <polyline id="28_text_edge" points="4.50,-3.92 4.90,-3.92"/>
-        <polyline id="30_text_edge" points="-2.46,-8.50 -2.06,-8.50"/>
-        <polyline id="32_text_edge" points="-3.64,-4.13 -3.24,-4.13"/>
-        <polyline id="34_text_edge" points="-7.94,-7.99 -7.54,-7.99"/>
-        <polyline id="36_text_edge" points="-10.43,-10.30 -10.03,-10.30"/>
-        <polyline id="38_text_edge" points="-6.20,2.47 -5.80,2.47"/>
-        <polyline id="40_text_edge" points="-3.58,8.90 -3.18,8.90"/>
-        <polyline id="42_text_edge" points="-5.72,-11.50 -5.32,-11.50"/>
-        <polyline id="44_text_edge" points="-8.09,-13.46 -7.69,-13.46"/>
-        <polyline id="46_text_edge" points="5.01,9.80 5.41,9.80"/>
+        <polyline id="0_text_edge" points="-1.17,1.63 -0.47,1.63"/>
+        <polyline id="2_text_edge" points="-2.14,5.90 -1.44,5.90"/>
+        <polyline id="4_text_edge" points="1.96,-1.23 2.66,-1.23"/>
+        <polyline id="6_text_edge" points="0.83,-6.64 1.53,-6.64"/>
+        <polyline id="8_text_edge" points="0.71,9.61 1.41,9.61"/>
+        <polyline id="10_text_edge" points="2.29,2.84 2.99,2.84"/>
+        <polyline id="12_text_edge" points="6.02,4.17 6.72,4.17"/>
+        <polyline id="14_text_edge" points="5.38,6.46 6.08,6.46"/>
+        <polyline id="16_text_edge" points="7.87,1.12 8.57,1.12"/>
+        <polyline id="18_text_edge" points="8.41,7.22 9.11,7.22"/>
+        <polyline id="20_text_edge" points="1.11,6.60 1.81,6.60"/>
+        <polyline id="22_text_edge" points="10.78,14.67 11.48,14.67"/>
+        <polyline id="24_text_edge" points="8.87,10.45 9.57,10.45"/>
+        <polyline id="26_text_edge" points="10.41,4.96 11.11,4.96"/>
+        <polyline id="28_text_edge" points="4.20,-3.92 4.90,-3.92"/>
+        <polyline id="30_text_edge" points="-2.76,-8.50 -2.06,-8.50"/>
+        <polyline id="32_text_edge" points="-3.94,-4.13 -3.24,-4.13"/>
+        <polyline id="34_text_edge" points="-8.24,-7.99 -7.54,-7.99"/>
+        <polyline id="36_text_edge" points="-10.73,-10.30 -10.03,-10.30"/>
+        <polyline id="38_text_edge" points="-6.50,2.47 -5.80,2.47"/>
+        <polyline id="40_text_edge" points="-3.88,8.90 -3.18,8.90"/>
+        <polyline id="42_text_edge" points="-6.02,-11.50 -5.32,-11.50"/>
+        <polyline id="44_text_edge" points="-8.39,-13.46 -7.69,-13.46"/>
+        <polyline id="46_text_edge" points="4.71,9.80 5.41,9.80"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-0.47" y="1.63" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -40,101 +40,101 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-10.10,10.07)" id="0" class="nad-vl120to180" title="VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-5.57,8.59)" id="2" class="nad-vl120to180" title="VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(-9.76,6.48)" id="4" class="nad-vl120to180" title="VL3">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(-4.75,4.32)" id="6" class="nad-vl120to180" title="VL4">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(-4.47,13.01)" id="8" class="nad-vl120to180" title="VL5">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
         <g transform="translate(-1.63,4.30)" id="10" class="nad-vl120to180" title="VL6">
-            <circle r="0.60" id="11"/>
+            <circle r="0.30" id="11"/>
         </g>
         <g transform="translate(-1.53,10.53)" id="12" class="nad-vl120to180" title="VL7">
-            <circle r="0.60" id="13"/>
+            <circle r="0.30" id="13"/>
         </g>
         <g transform="translate(2.52,7.64)" id="14" class="nad-vl120to180" title="VL8">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(-6.18,-2.61)" id="16" class="nad-vl0to30" title="VL9">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-4.29,-5.40)" id="18" class="nad-vl30to50" title="VL10">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(-10.18,-7.67)" id="20" class="nad-vl0to30" title="VL11">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
         <g transform="translate(1.52,-1.76)" id="22" class="nad-vl30to50" title="VL12">
-            <circle r="0.60" id="23"/>
+            <circle r="0.30" id="23"/>
         </g>
         <g transform="translate(6.45,-0.80)" id="24" class="nad-vl0to30" title="VL13">
-            <circle r="0.60" id="25"/>
+            <circle r="0.30" id="25"/>
         </g>
         <g transform="translate(1.95,1.31)" id="26" class="nad-vl30to50" title="VL14">
-            <circle r="0.60" id="27"/>
+            <circle r="0.30" id="27"/>
         </g>
         <g transform="translate(-1.43,-1.13)" id="28" class="nad-vl30to50" title="VL15">
-            <circle r="0.60" id="29"/>
+            <circle r="0.30" id="29"/>
         </g>
         <g transform="translate(2.55,-9.39)" id="30" class="nad-vl30to50" title="VL16">
-            <circle r="0.60" id="31"/>
+            <circle r="0.30" id="31"/>
         </g>
         <g transform="translate(-1.19,-11.42)" id="32" class="nad-vl30to50" title="VL17">
-            <circle r="0.60" id="33"/>
+            <circle r="0.30" id="33"/>
         </g>
         <g transform="translate(-8.46,0.41)" id="34" class="nad-vl30to50" title="VL18">
-            <circle r="0.60" id="35"/>
+            <circle r="0.30" id="35"/>
         </g>
         <g transform="translate(-12.96,-0.70)" id="36" class="nad-vl30to50" title="VL19">
-            <circle r="0.60" id="37"/>
+            <circle r="0.30" id="37"/>
         </g>
         <g transform="translate(-10.78,-3.97)" id="38" class="nad-vl30to50" title="VL20">
-            <circle r="0.60" id="39"/>
+            <circle r="0.30" id="39"/>
         </g>
         <g transform="translate(-4.59,-9.41)" id="40" class="nad-vl30to50" title="VL21">
-            <circle r="0.60" id="41"/>
+            <circle r="0.30" id="41"/>
         </g>
         <g transform="translate(-0.41,-7.56)" id="42" class="nad-vl30to50" title="VL22">
-            <circle r="0.60" id="43"/>
+            <circle r="0.30" id="43"/>
         </g>
         <g transform="translate(3.78,-4.82)" id="44" class="nad-vl30to50" title="VL23">
-            <circle r="0.60" id="45"/>
+            <circle r="0.30" id="45"/>
         </g>
         <g transform="translate(7.01,-6.56)" id="46" class="nad-vl30to50" title="VL24">
-            <circle r="0.60" id="47"/>
+            <circle r="0.30" id="47"/>
         </g>
         <g transform="translate(12.13,-2.87)" id="48" class="nad-vl30to50" title="VL25">
-            <circle r="0.60" id="49"/>
+            <circle r="0.30" id="49"/>
         </g>
         <g transform="translate(15.56,-5.57)" id="50" class="nad-vl30to50" title="VL26">
-            <circle r="0.60" id="51"/>
+            <circle r="0.30" id="51"/>
         </g>
         <g transform="translate(11.87,3.69)" id="52" class="nad-vl30to50" title="VL27">
-            <circle r="0.60" id="53"/>
+            <circle r="0.30" id="53"/>
         </g>
         <g transform="translate(5.71,5.90)" id="54" class="nad-vl120to180" title="VL28">
-            <circle r="0.60" id="55"/>
+            <circle r="0.30" id="55"/>
         </g>
         <g transform="translate(15.98,4.91)" id="56" class="nad-vl30to50" title="VL29">
-            <circle r="0.60" id="57"/>
+            <circle r="0.30" id="57"/>
         </g>
         <g transform="translate(14.01,7.51)" id="58" class="nad-vl30to50" title="VL30">
-            <circle r="0.60" id="59"/>
+            <circle r="0.30" id="59"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="60" class="nad-vl120to180" title="L1-2-1">
             <g>
-                <polyline points="-9.56,9.89 -7.83,9.33"/>
-                <g class="nad-edge-infos" transform="translate(-9.27,9.80)">
+                <polyline points="-9.84,9.98 -7.83,9.33"/>
+                <g class="nad-edge-infos" transform="translate(-9.56,9.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -152,8 +152,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.11,8.77 -7.83,9.33"/>
-                <g class="nad-edge-infos" transform="translate(-6.40,8.86)">
+                <polyline points="-5.83,8.68 -7.83,9.33"/>
+                <g class="nad-edge-infos" transform="translate(-6.11,8.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -173,8 +173,8 @@
         </g>
         <g id="61" class="nad-vl120to180" title="L1-3-1">
             <g>
-                <polyline points="-10.05,9.50 -9.93,8.27"/>
-                <g class="nad-edge-infos" transform="translate(-10.02,9.20)">
+                <polyline points="-10.07,9.80 -9.93,8.27"/>
+                <g class="nad-edge-infos" transform="translate(-10.05,9.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -192,8 +192,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.82,7.05 -9.93,8.27"/>
-                <g class="nad-edge-infos" transform="translate(-9.84,7.35)">
+                <polyline points="-9.79,6.75 -9.93,8.27"/>
+                <g class="nad-edge-infos" transform="translate(-9.82,7.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -213,8 +213,8 @@
         </g>
         <g id="62" class="nad-vl120to180" title="L2-4-1">
             <g>
-                <polyline points="-5.46,8.03 -5.16,6.46"/>
-                <g class="nad-edge-infos" transform="translate(-5.41,7.74)">
+                <polyline points="-5.52,8.33 -5.16,6.46"/>
+                <g class="nad-edge-infos" transform="translate(-5.46,8.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -232,8 +232,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.86,4.88 -5.16,6.46"/>
-                <g class="nad-edge-infos" transform="translate(-4.91,5.17)">
+                <polyline points="-4.80,4.59 -5.16,6.46"/>
+                <g class="nad-edge-infos" transform="translate(-4.86,4.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -253,8 +253,8 @@
         </g>
         <g id="63" class="nad-vl120to180" title="L2-5-1">
             <g>
-                <polyline points="-5.43,9.15 -5.02,10.80"/>
-                <g class="nad-edge-infos" transform="translate(-5.36,9.44)">
+                <polyline points="-5.51,8.85 -5.02,10.80"/>
+                <g class="nad-edge-infos" transform="translate(-5.43,9.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(166.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -272,8 +272,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.61,12.45 -5.02,10.80"/>
-                <g class="nad-edge-infos" transform="translate(-4.68,12.16)">
+                <polyline points="-4.54,12.74 -5.02,10.80"/>
+                <g class="nad-edge-infos" transform="translate(-4.61,12.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-13.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -293,8 +293,8 @@
         </g>
         <g id="64" class="nad-vl120to180" title="L2-6-1">
             <g>
-                <polyline points="-5.19,8.17 -3.60,6.45"/>
-                <g class="nad-edge-infos" transform="translate(-4.98,7.95)">
+                <polyline points="-5.39,8.39 -3.60,6.45"/>
+                <g class="nad-edge-infos" transform="translate(-5.19,8.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -312,8 +312,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.01,4.72 -3.60,6.45"/>
-                <g class="nad-edge-infos" transform="translate(-2.22,4.94)">
+                <polyline points="-1.81,4.50 -3.60,6.45"/>
+                <g class="nad-edge-infos" transform="translate(-2.01,4.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -333,8 +333,8 @@
         </g>
         <g id="65" class="nad-vl120to180" title="L3-4-1">
             <g>
-                <polyline points="-9.24,6.26 -7.26,5.40"/>
-                <g class="nad-edge-infos" transform="translate(-8.96,6.14)">
+                <polyline points="-9.51,6.37 -7.26,5.40"/>
+                <g class="nad-edge-infos" transform="translate(-9.24,6.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -352,8 +352,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.27,4.55 -7.26,5.40"/>
-                <g class="nad-edge-infos" transform="translate(-5.55,4.66)">
+                <polyline points="-5.00,4.43 -7.26,5.40"/>
+                <g class="nad-edge-infos" transform="translate(-5.27,4.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -373,8 +373,8 @@
         </g>
         <g id="66" class="nad-vl120to180" title="L4-6-1">
             <g>
-                <polyline points="-4.18,4.32 -3.19,4.31"/>
-                <g class="nad-edge-infos" transform="translate(-3.88,4.31)">
+                <polyline points="-4.48,4.32 -3.19,4.31"/>
+                <g class="nad-edge-infos" transform="translate(-4.18,4.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -392,8 +392,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.20,4.30 -3.19,4.31"/>
-                <g class="nad-edge-infos" transform="translate(-2.50,4.31)">
+                <polyline points="-1.90,4.30 -3.19,4.31"/>
+                <g class="nad-edge-infos" transform="translate(-2.20,4.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -413,8 +413,8 @@
         </g>
         <g id="67" title="T4-12-1">
             <g class="nad-vl120to180">
-                <polyline points="-4.34,3.92 -1.62,1.28"/>
-                <g class="nad-edge-infos" transform="translate(-4.13,3.71)">
+                <polyline points="-4.56,4.13 -1.62,1.28"/>
+                <g class="nad-edge-infos" transform="translate(-4.34,3.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -433,8 +433,8 @@
                 <circle cx="-1.69" cy="1.35" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="1.11,-1.36 -1.62,1.28"/>
-                <g class="nad-edge-infos" transform="translate(0.89,-1.15)">
+                <polyline points="1.32,-1.57 -1.62,1.28"/>
+                <g class="nad-edge-infos" transform="translate(1.11,-1.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -455,8 +455,8 @@
         </g>
         <g id="68" class="nad-vl120to180" title="L5-7-1">
             <g>
-                <polyline points="-4.04,12.64 -3.00,11.77"/>
-                <g class="nad-edge-infos" transform="translate(-3.81,12.45)">
+                <polyline points="-4.27,12.83 -3.00,11.77"/>
+                <g class="nad-edge-infos" transform="translate(-4.04,12.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -474,8 +474,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.97,10.90 -3.00,11.77"/>
-                <g class="nad-edge-infos" transform="translate(-2.20,11.09)">
+                <polyline points="-1.74,10.71 -3.00,11.77"/>
+                <g class="nad-edge-infos" transform="translate(-1.97,10.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -495,8 +495,8 @@
         </g>
         <g id="69" class="nad-vl120to180" title="L6-7-1">
             <g>
-                <polyline points="-1.62,4.87 -1.58,7.42"/>
-                <g class="nad-edge-infos" transform="translate(-1.62,5.17)">
+                <polyline points="-1.63,4.57 -1.58,7.42"/>
+                <g class="nad-edge-infos" transform="translate(-1.62,4.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -514,8 +514,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.54,9.96 -1.58,7.42"/>
-                <g class="nad-edge-infos" transform="translate(-1.55,9.66)">
+                <polyline points="-1.54,10.26 -1.58,7.42"/>
+                <g class="nad-edge-infos" transform="translate(-1.54,9.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -535,8 +535,8 @@
         </g>
         <g id="70" class="nad-vl120to180" title="L6-8-1">
             <g>
-                <polyline points="-1.19,4.66 0.45,5.97"/>
-                <g class="nad-edge-infos" transform="translate(-0.95,4.85)">
+                <polyline points="-1.42,4.47 0.45,5.97"/>
+                <g class="nad-edge-infos" transform="translate(-1.19,4.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(128.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -554,8 +554,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.08,7.28 0.45,5.97"/>
-                <g class="nad-edge-infos" transform="translate(1.84,7.10)">
+                <polyline points="2.31,7.47 0.45,5.97"/>
+                <g class="nad-edge-infos" transform="translate(2.08,7.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-51.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -575,8 +575,8 @@
         </g>
         <g id="71" title="T6-9-1">
             <g class="nad-vl120to180">
-                <polyline points="-1.94,3.83 -3.91,0.85"/>
-                <g class="nad-edge-infos" transform="translate(-2.11,3.58)">
+                <polyline points="-1.78,4.08 -3.91,0.85"/>
+                <g class="nad-edge-infos" transform="translate(-1.94,3.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -595,8 +595,8 @@
                 <circle cx="-3.85" cy="0.93" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-5.87,-2.13 -3.91,0.85"/>
-                <g class="nad-edge-infos" transform="translate(-5.70,-1.88)">
+                <polyline points="-6.04,-2.38 -3.91,0.85"/>
+                <g class="nad-edge-infos" transform="translate(-5.87,-2.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -617,8 +617,8 @@
         </g>
         <g id="72" title="T6-10-1">
             <g class="nad-vl120to180">
-                <polyline points="-1.78,3.75 -2.96,-0.55"/>
-                <g class="nad-edge-infos" transform="translate(-1.86,3.46)">
+                <polyline points="-1.70,4.04 -2.96,-0.55"/>
+                <g class="nad-edge-infos" transform="translate(-1.78,3.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -637,8 +637,8 @@
                 <circle cx="-2.93" cy="-0.45" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-4.14,-4.85 -2.96,-0.55"/>
-                <g class="nad-edge-infos" transform="translate(-4.06,-4.56)">
+                <polyline points="-4.22,-5.14 -2.96,-0.55"/>
+                <g class="nad-edge-infos" transform="translate(-4.14,-4.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -659,8 +659,8 @@
         </g>
         <g id="73" class="nad-vl120to180" title="L6-28-1">
             <g>
-                <polyline points="-1.07,4.42 2.04,5.10"/>
-                <g class="nad-edge-infos" transform="translate(-0.78,4.49)">
+                <polyline points="-1.37,4.36 2.04,5.10"/>
+                <g class="nad-edge-infos" transform="translate(-1.07,4.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -678,8 +678,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.15,5.78 2.04,5.10"/>
-                <g class="nad-edge-infos" transform="translate(4.86,5.72)">
+                <polyline points="5.45,5.85 2.04,5.10"/>
+                <g class="nad-edge-infos" transform="translate(5.15,5.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -699,8 +699,8 @@
         </g>
         <g id="74" class="nad-vl120to180" title="L8-28-1">
             <g>
-                <polyline points="3.02,7.37 4.12,6.77"/>
-                <g class="nad-edge-infos" transform="translate(3.28,7.23)">
+                <polyline points="2.76,7.51 4.12,6.77"/>
+                <g class="nad-edge-infos" transform="translate(3.02,7.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -718,8 +718,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.21,6.18 4.12,6.77"/>
-                <g class="nad-edge-infos" transform="translate(4.95,6.32)">
+                <polyline points="5.47,6.03 4.12,6.77"/>
+                <g class="nad-edge-infos" transform="translate(5.21,6.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -739,8 +739,8 @@
         </g>
         <g id="75" class="nad-vl0to30" title="L9-11-1">
             <g>
-                <polyline points="-6.54,-3.06 -8.18,-5.14"/>
-                <g class="nad-edge-infos" transform="translate(-6.72,-3.29)">
+                <polyline points="-6.35,-2.82 -8.18,-5.14"/>
+                <g class="nad-edge-infos" transform="translate(-6.54,-3.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -758,8 +758,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.82,-7.22 -8.18,-5.14"/>
-                <g class="nad-edge-infos" transform="translate(-9.64,-6.99)">
+                <polyline points="-10.01,-7.46 -8.18,-5.14"/>
+                <g class="nad-edge-infos" transform="translate(-9.82,-7.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -779,8 +779,8 @@
         </g>
         <g id="76" class="nad-vl0to30" title="L9-10-1">
             <g>
-                <polyline points="-5.86,-3.08 -5.24,-4.00"/>
-                <g class="nad-edge-infos" transform="translate(-5.70,-3.33)">
+                <polyline points="-6.03,-2.83 -5.24,-4.00"/>
+                <g class="nad-edge-infos" transform="translate(-5.86,-3.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -798,8 +798,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.61,-4.92 -5.24,-4.00"/>
-                <g class="nad-edge-infos" transform="translate(-4.78,-4.68)">
+                <polyline points="-4.44,-5.17 -5.24,-4.00"/>
+                <g class="nad-edge-infos" transform="translate(-4.61,-4.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -819,8 +819,8 @@
         </g>
         <g id="77" class="nad-vl30to50" title="L10-20-1">
             <g>
-                <polyline points="-4.85,-5.27 -7.54,-4.68"/>
-                <g class="nad-edge-infos" transform="translate(-5.14,-5.21)">
+                <polyline points="-4.56,-5.34 -7.54,-4.68"/>
+                <g class="nad-edge-infos" transform="translate(-4.85,-5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -838,8 +838,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.22,-4.10 -7.54,-4.68"/>
-                <g class="nad-edge-infos" transform="translate(-9.93,-4.16)">
+                <polyline points="-10.52,-4.03 -7.54,-4.68"/>
+                <g class="nad-edge-infos" transform="translate(-10.22,-4.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -859,8 +859,8 @@
         </g>
         <g id="78" class="nad-vl30to50" title="L10-17-1">
             <g>
-                <polyline points="-4.03,-5.90 -2.74,-8.41"/>
-                <g class="nad-edge-infos" transform="translate(-3.89,-6.17)">
+                <polyline points="-4.17,-5.64 -2.74,-8.41"/>
+                <g class="nad-edge-infos" transform="translate(-4.03,-5.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -878,8 +878,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.45,-10.91 -2.74,-8.41"/>
-                <g class="nad-edge-infos" transform="translate(-1.58,-10.65)">
+                <polyline points="-1.31,-11.18 -2.74,-8.41"/>
+                <g class="nad-edge-infos" transform="translate(-1.45,-10.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -899,8 +899,8 @@
         </g>
         <g id="79" class="nad-vl30to50" title="L10-21-1">
             <g>
-                <polyline points="-4.34,-5.96 -4.44,-7.40"/>
-                <g class="nad-edge-infos" transform="translate(-4.36,-6.26)">
+                <polyline points="-4.31,-5.67 -4.44,-7.40"/>
+                <g class="nad-edge-infos" transform="translate(-4.34,-5.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -918,8 +918,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.55,-8.85 -4.44,-7.40"/>
-                <g class="nad-edge-infos" transform="translate(-4.53,-8.55)">
+                <polyline points="-4.57,-9.14 -4.44,-7.40"/>
+                <g class="nad-edge-infos" transform="translate(-4.55,-8.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -939,8 +939,8 @@
         </g>
         <g id="80" class="nad-vl30to50" title="L10-22-1">
             <g>
-                <polyline points="-3.80,-5.67 -2.35,-6.48"/>
-                <g class="nad-edge-infos" transform="translate(-3.53,-5.82)">
+                <polyline points="-4.06,-5.53 -2.35,-6.48"/>
+                <g class="nad-edge-infos" transform="translate(-3.80,-5.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -958,8 +958,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.91,-7.28 -2.35,-6.48"/>
-                <g class="nad-edge-infos" transform="translate(-1.17,-7.13)">
+                <polyline points="-0.65,-7.43 -2.35,-6.48"/>
+                <g class="nad-edge-infos" transform="translate(-0.91,-7.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -979,8 +979,8 @@
         </g>
         <g id="81" class="nad-vl30to50" title="L12-13-1">
             <g>
-                <polyline points="2.08,-1.65 3.98,-1.28"/>
-                <g class="nad-edge-infos" transform="translate(2.37,-1.59)">
+                <polyline points="1.78,-1.71 3.98,-1.28"/>
+                <g class="nad-edge-infos" transform="translate(2.08,-1.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(100.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -998,8 +998,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.89,-0.91 3.98,-1.28"/>
-                <g class="nad-edge-infos" transform="translate(5.59,-0.97)">
+                <polyline points="6.18,-0.86 3.98,-1.28"/>
+                <g class="nad-edge-infos" transform="translate(5.89,-0.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-79.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1019,8 +1019,8 @@
         </g>
         <g id="82" class="nad-vl30to50" title="L12-14-1">
             <g>
-                <polyline points="1.60,-1.19 1.73,-0.22"/>
-                <g class="nad-edge-infos" transform="translate(1.64,-0.90)">
+                <polyline points="1.56,-1.49 1.73,-0.22"/>
+                <g class="nad-edge-infos" transform="translate(1.60,-1.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(172.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1038,8 +1038,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.87,0.75 1.73,-0.22"/>
-                <g class="nad-edge-infos" transform="translate(1.83,0.45)">
+                <polyline points="1.91,1.04 1.73,-0.22"/>
+                <g class="nad-edge-infos" transform="translate(1.87,0.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1059,8 +1059,8 @@
         </g>
         <g id="83" class="nad-vl30to50" title="L12-15-1">
             <g>
-                <polyline points="0.96,-1.64 0.04,-1.45"/>
-                <g class="nad-edge-infos" transform="translate(0.67,-1.58)">
+                <polyline points="1.25,-1.70 0.04,-1.45"/>
+                <g class="nad-edge-infos" transform="translate(0.96,-1.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1078,8 +1078,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.87,-1.25 0.04,-1.45"/>
-                <g class="nad-edge-infos" transform="translate(-0.58,-1.31)">
+                <polyline points="-1.16,-1.19 0.04,-1.45"/>
+                <g class="nad-edge-infos" transform="translate(-0.87,-1.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1099,8 +1099,8 @@
         </g>
         <g id="84" class="nad-vl30to50" title="L12-16-1">
             <g>
-                <polyline points="1.59,-2.32 2.03,-5.58"/>
-                <g class="nad-edge-infos" transform="translate(1.63,-2.62)">
+                <polyline points="1.55,-2.02 2.03,-5.58"/>
+                <g class="nad-edge-infos" transform="translate(1.59,-2.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1118,8 +1118,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.47,-8.83 2.03,-5.58"/>
-                <g class="nad-edge-infos" transform="translate(2.43,-8.53)">
+                <polyline points="2.51,-9.13 2.03,-5.58"/>
+                <g class="nad-edge-infos" transform="translate(2.47,-8.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1139,8 +1139,8 @@
         </g>
         <g id="85" class="nad-vl30to50" title="L14-15-1">
             <g>
-                <polyline points="1.48,0.98 0.26,0.09"/>
-                <g class="nad-edge-infos" transform="translate(1.24,0.80)">
+                <polyline points="1.73,1.15 0.26,0.09"/>
+                <g class="nad-edge-infos" transform="translate(1.48,0.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1158,8 +1158,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.97,-0.80 0.26,0.09"/>
-                <g class="nad-edge-infos" transform="translate(-0.72,-0.62)">
+                <polyline points="-1.21,-0.97 0.26,0.09"/>
+                <g class="nad-edge-infos" transform="translate(-0.97,-0.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1179,8 +1179,8 @@
         </g>
         <g id="86" class="nad-vl30to50" title="L15-18-1">
             <g>
-                <polyline points="-1.99,-1.01 -4.95,-0.36"/>
-                <g class="nad-edge-infos" transform="translate(-2.28,-0.95)">
+                <polyline points="-1.69,-1.08 -4.95,-0.36"/>
+                <g class="nad-edge-infos" transform="translate(-1.99,-1.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1198,8 +1198,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-7.91,0.29 -4.95,-0.36"/>
-                <g class="nad-edge-infos" transform="translate(-7.61,0.22)">
+                <polyline points="-8.20,0.35 -4.95,-0.36"/>
+                <g class="nad-edge-infos" transform="translate(-7.91,0.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1219,8 +1219,8 @@
         </g>
         <g id="87" class="nad-vl30to50" title="L15-23-1">
             <g>
-                <polyline points="-0.96,-1.46 1.18,-2.98"/>
-                <g class="nad-edge-infos" transform="translate(-0.72,-1.64)">
+                <polyline points="-1.21,-1.29 1.18,-2.98"/>
+                <g class="nad-edge-infos" transform="translate(-0.96,-1.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1238,8 +1238,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.31,-4.49 1.18,-2.98"/>
-                <g class="nad-edge-infos" transform="translate(3.07,-4.32)">
+                <polyline points="3.56,-4.67 1.18,-2.98"/>
+                <g class="nad-edge-infos" transform="translate(3.31,-4.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1259,8 +1259,8 @@
         </g>
         <g id="88" class="nad-vl30to50" title="L16-17-1">
             <g>
-                <polyline points="2.05,-9.67 0.68,-10.41"/>
-                <g class="nad-edge-infos" transform="translate(1.78,-9.81)">
+                <polyline points="2.31,-9.52 0.68,-10.41"/>
+                <g class="nad-edge-infos" transform="translate(2.05,-9.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1278,8 +1278,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.68,-11.15 0.68,-10.41"/>
-                <g class="nad-edge-infos" transform="translate(-0.42,-11.00)">
+                <polyline points="-0.95,-11.29 0.68,-10.41"/>
+                <g class="nad-edge-infos" transform="translate(-0.68,-11.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(118.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1299,8 +1299,8 @@
         </g>
         <g id="89" class="nad-vl30to50" title="L18-19-1">
             <g>
-                <polyline points="-9.02,0.27 -10.71,-0.15"/>
-                <g class="nad-edge-infos" transform="translate(-9.31,0.20)">
+                <polyline points="-8.72,0.34 -10.71,-0.15"/>
+                <g class="nad-edge-infos" transform="translate(-9.02,0.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1318,8 +1318,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.41,-0.56 -10.71,-0.15"/>
-                <g class="nad-edge-infos" transform="translate(-12.12,-0.49)">
+                <polyline points="-12.70,-0.64 -10.71,-0.15"/>
+                <g class="nad-edge-infos" transform="translate(-12.41,-0.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1339,8 +1339,8 @@
         </g>
         <g id="90" class="nad-vl30to50" title="L19-20-1">
             <g>
-                <polyline points="-12.65,-1.18 -11.87,-2.34"/>
-                <g class="nad-edge-infos" transform="translate(-12.48,-1.42)">
+                <polyline points="-12.81,-0.93 -11.87,-2.34"/>
+                <g class="nad-edge-infos" transform="translate(-12.65,-1.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1358,8 +1358,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.10,-3.50 -11.87,-2.34"/>
-                <g class="nad-edge-infos" transform="translate(-11.26,-3.25)">
+                <polyline points="-10.93,-3.75 -11.87,-2.34"/>
+                <g class="nad-edge-infos" transform="translate(-11.10,-3.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-146.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1379,8 +1379,8 @@
         </g>
         <g id="91" class="nad-vl30to50" title="L21-22-1">
             <g>
-                <polyline points="-4.07,-9.18 -2.50,-8.49"/>
-                <g class="nad-edge-infos" transform="translate(-3.80,-9.06)">
+                <polyline points="-4.35,-9.30 -2.50,-8.49"/>
+                <g class="nad-edge-infos" transform="translate(-4.07,-9.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1398,8 +1398,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.93,-7.79 -2.50,-8.49"/>
-                <g class="nad-edge-infos" transform="translate(-1.21,-7.91)">
+                <polyline points="-0.66,-7.67 -2.50,-8.49"/>
+                <g class="nad-edge-infos" transform="translate(-0.93,-7.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1419,8 +1419,8 @@
         </g>
         <g id="92" class="nad-vl30to50" title="L22-24-1">
             <g>
-                <polyline points="0.15,-7.48 3.30,-7.06"/>
-                <g class="nad-edge-infos" transform="translate(0.45,-7.44)">
+                <polyline points="-0.14,-7.52 3.30,-7.06"/>
+                <g class="nad-edge-infos" transform="translate(0.15,-7.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1438,8 +1438,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.45,-6.64 3.30,-7.06"/>
-                <g class="nad-edge-infos" transform="translate(6.15,-6.68)">
+                <polyline points="6.75,-6.60 3.30,-7.06"/>
+                <g class="nad-edge-infos" transform="translate(6.45,-6.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1459,8 +1459,8 @@
         </g>
         <g id="93" class="nad-vl30to50" title="L23-24-1">
             <g>
-                <polyline points="4.28,-5.09 5.40,-5.69"/>
-                <g class="nad-edge-infos" transform="translate(4.55,-5.23)">
+                <polyline points="4.02,-4.95 5.40,-5.69"/>
+                <g class="nad-edge-infos" transform="translate(4.28,-5.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1478,8 +1478,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.51,-6.29 5.40,-5.69"/>
-                <g class="nad-edge-infos" transform="translate(6.25,-6.15)">
+                <polyline points="6.78,-6.43 5.40,-5.69"/>
+                <g class="nad-edge-infos" transform="translate(6.51,-6.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1499,8 +1499,8 @@
         </g>
         <g id="94" class="nad-vl30to50" title="L24-25-1">
             <g>
-                <polyline points="7.48,-6.23 9.57,-4.71"/>
-                <g class="nad-edge-infos" transform="translate(7.72,-6.05)">
+                <polyline points="7.23,-6.40 9.57,-4.71"/>
+                <g class="nad-edge-infos" transform="translate(7.48,-6.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1518,8 +1518,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.66,-3.20 9.57,-4.71"/>
-                <g class="nad-edge-infos" transform="translate(11.42,-3.38)">
+                <polyline points="11.91,-3.02 9.57,-4.71"/>
+                <g class="nad-edge-infos" transform="translate(11.66,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1539,8 +1539,8 @@
         </g>
         <g id="95" class="nad-vl30to50" title="L25-26-1">
             <g>
-                <polyline points="12.57,-3.22 13.84,-4.22"/>
-                <g class="nad-edge-infos" transform="translate(12.81,-3.40)">
+                <polyline points="12.34,-3.03 13.84,-4.22"/>
+                <g class="nad-edge-infos" transform="translate(12.57,-3.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1558,8 +1558,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="15.11,-5.22 13.84,-4.22"/>
-                <g class="nad-edge-infos" transform="translate(14.87,-5.03)">
+                <polyline points="15.34,-5.40 13.84,-4.22"/>
+                <g class="nad-edge-infos" transform="translate(15.11,-5.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1579,8 +1579,8 @@
         </g>
         <g id="96" class="nad-vl30to50" title="L25-27-1">
             <g>
-                <polyline points="12.10,-2.30 12.00,0.41"/>
-                <g class="nad-edge-infos" transform="translate(12.09,-2.00)">
+                <polyline points="12.12,-2.60 12.00,0.41"/>
+                <g class="nad-edge-infos" transform="translate(12.10,-2.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1598,8 +1598,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.90,3.12 12.00,0.41"/>
-                <g class="nad-edge-infos" transform="translate(11.91,2.82)">
+                <polyline points="11.88,3.42 12.00,0.41"/>
+                <g class="nad-edge-infos" transform="translate(11.90,3.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(2.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1619,8 +1619,8 @@
         </g>
         <g id="97" title="T28-27-1">
             <g class="nad-vl120to180">
-                <polyline points="6.25,5.71 8.79,4.80"/>
-                <g class="nad-edge-infos" transform="translate(6.53,5.61)">
+                <polyline points="5.97,5.81 8.79,4.80"/>
+                <g class="nad-edge-infos" transform="translate(6.25,5.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1639,8 +1639,8 @@
                 <circle cx="8.70" cy="4.83" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="11.34,3.88 8.79,4.80"/>
-                <g class="nad-edge-infos" transform="translate(11.05,3.99)">
+                <polyline points="11.62,3.78 8.79,4.80"/>
+                <g class="nad-edge-infos" transform="translate(11.34,3.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1661,8 +1661,8 @@
         </g>
         <g id="98" class="nad-vl30to50" title="L27-29-1">
             <g>
-                <polyline points="12.42,3.85 13.93,4.30"/>
-                <g class="nad-edge-infos" transform="translate(12.71,3.94)">
+                <polyline points="12.13,3.77 13.93,4.30"/>
+                <g class="nad-edge-infos" transform="translate(12.42,3.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1680,8 +1680,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="15.44,4.75 13.93,4.30"/>
-                <g class="nad-edge-infos" transform="translate(15.15,4.66)">
+                <polyline points="15.72,4.83 13.93,4.30"/>
+                <g class="nad-edge-infos" transform="translate(15.44,4.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1701,8 +1701,8 @@
         </g>
         <g id="99" class="nad-vl30to50" title="L27-30-1">
             <g>
-                <polyline points="12.15,4.19 12.94,5.60"/>
-                <g class="nad-edge-infos" transform="translate(12.30,4.45)">
+                <polyline points="12.01,3.93 12.94,5.60"/>
+                <g class="nad-edge-infos" transform="translate(12.15,4.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1720,8 +1720,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="13.73,7.02 12.94,5.60"/>
-                <g class="nad-edge-infos" transform="translate(13.59,6.76)">
+                <polyline points="13.88,7.28 12.94,5.60"/>
+                <g class="nad-edge-infos" transform="translate(13.73,7.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-29.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1741,8 +1741,8 @@
         </g>
         <g id="100" class="nad-vl30to50" title="L29-30-1">
             <g>
-                <polyline points="15.64,5.37 15.00,6.21"/>
-                <g class="nad-edge-infos" transform="translate(15.46,5.60)">
+                <polyline points="15.82,5.13 15.00,6.21"/>
+                <g class="nad-edge-infos" transform="translate(15.64,5.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1760,8 +1760,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="14.36,7.06 15.00,6.21"/>
-                <g class="nad-edge-infos" transform="translate(14.54,6.82)">
+                <polyline points="14.17,7.30 15.00,6.21"/>
+                <g class="nad-edge-infos" transform="translate(14.36,7.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1781,36 +1781,36 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-9.50,10.07 -9.10,10.07"/>
-        <polyline id="2_text_edge" points="-4.97,8.59 -4.57,8.59"/>
-        <polyline id="4_text_edge" points="-9.16,6.48 -8.76,6.48"/>
-        <polyline id="6_text_edge" points="-4.15,4.32 -3.75,4.32"/>
-        <polyline id="8_text_edge" points="-3.87,13.01 -3.47,13.01"/>
-        <polyline id="10_text_edge" points="-1.03,4.30 -0.63,4.30"/>
-        <polyline id="12_text_edge" points="-0.93,10.53 -0.53,10.53"/>
-        <polyline id="14_text_edge" points="3.12,7.64 3.52,7.64"/>
-        <polyline id="16_text_edge" points="-5.58,-2.61 -5.18,-2.61"/>
-        <polyline id="18_text_edge" points="-3.69,-5.40 -3.29,-5.40"/>
-        <polyline id="20_text_edge" points="-9.58,-7.67 -9.18,-7.67"/>
-        <polyline id="22_text_edge" points="2.12,-1.76 2.52,-1.76"/>
-        <polyline id="24_text_edge" points="7.05,-0.80 7.45,-0.80"/>
-        <polyline id="26_text_edge" points="2.55,1.31 2.95,1.31"/>
-        <polyline id="28_text_edge" points="-0.83,-1.13 -0.43,-1.13"/>
-        <polyline id="30_text_edge" points="3.15,-9.39 3.55,-9.39"/>
-        <polyline id="32_text_edge" points="-0.59,-11.42 -0.19,-11.42"/>
-        <polyline id="34_text_edge" points="-7.86,0.41 -7.46,0.41"/>
-        <polyline id="36_text_edge" points="-12.36,-0.70 -11.96,-0.70"/>
-        <polyline id="38_text_edge" points="-10.18,-3.97 -9.78,-3.97"/>
-        <polyline id="40_text_edge" points="-3.99,-9.41 -3.59,-9.41"/>
-        <polyline id="42_text_edge" points="0.19,-7.56 0.59,-7.56"/>
-        <polyline id="44_text_edge" points="4.38,-4.82 4.78,-4.82"/>
-        <polyline id="46_text_edge" points="7.61,-6.56 8.01,-6.56"/>
-        <polyline id="48_text_edge" points="12.73,-2.87 13.13,-2.87"/>
-        <polyline id="50_text_edge" points="16.16,-5.57 16.56,-5.57"/>
-        <polyline id="52_text_edge" points="12.47,3.69 12.87,3.69"/>
-        <polyline id="54_text_edge" points="6.31,5.90 6.71,5.90"/>
-        <polyline id="56_text_edge" points="16.58,4.91 16.98,4.91"/>
-        <polyline id="58_text_edge" points="14.61,7.51 15.01,7.51"/>
+        <polyline id="0_text_edge" points="-9.80,10.07 -9.10,10.07"/>
+        <polyline id="2_text_edge" points="-5.27,8.59 -4.57,8.59"/>
+        <polyline id="4_text_edge" points="-9.46,6.48 -8.76,6.48"/>
+        <polyline id="6_text_edge" points="-4.45,4.32 -3.75,4.32"/>
+        <polyline id="8_text_edge" points="-4.17,13.01 -3.47,13.01"/>
+        <polyline id="10_text_edge" points="-1.33,4.30 -0.63,4.30"/>
+        <polyline id="12_text_edge" points="-1.23,10.53 -0.53,10.53"/>
+        <polyline id="14_text_edge" points="2.82,7.64 3.52,7.64"/>
+        <polyline id="16_text_edge" points="-5.88,-2.61 -5.18,-2.61"/>
+        <polyline id="18_text_edge" points="-3.99,-5.40 -3.29,-5.40"/>
+        <polyline id="20_text_edge" points="-9.88,-7.67 -9.18,-7.67"/>
+        <polyline id="22_text_edge" points="1.82,-1.76 2.52,-1.76"/>
+        <polyline id="24_text_edge" points="6.75,-0.80 7.45,-0.80"/>
+        <polyline id="26_text_edge" points="2.25,1.31 2.95,1.31"/>
+        <polyline id="28_text_edge" points="-1.13,-1.13 -0.43,-1.13"/>
+        <polyline id="30_text_edge" points="2.85,-9.39 3.55,-9.39"/>
+        <polyline id="32_text_edge" points="-0.89,-11.42 -0.19,-11.42"/>
+        <polyline id="34_text_edge" points="-8.16,0.41 -7.46,0.41"/>
+        <polyline id="36_text_edge" points="-12.66,-0.70 -11.96,-0.70"/>
+        <polyline id="38_text_edge" points="-10.48,-3.97 -9.78,-3.97"/>
+        <polyline id="40_text_edge" points="-4.29,-9.41 -3.59,-9.41"/>
+        <polyline id="42_text_edge" points="-0.11,-7.56 0.59,-7.56"/>
+        <polyline id="44_text_edge" points="4.08,-4.82 4.78,-4.82"/>
+        <polyline id="46_text_edge" points="7.31,-6.56 8.01,-6.56"/>
+        <polyline id="48_text_edge" points="12.43,-2.87 13.13,-2.87"/>
+        <polyline id="50_text_edge" points="15.86,-5.57 16.56,-5.57"/>
+        <polyline id="52_text_edge" points="12.17,3.69 12.87,3.69"/>
+        <polyline id="54_text_edge" points="6.01,5.90 6.71,5.90"/>
+        <polyline id="56_text_edge" points="16.28,4.91 16.98,4.91"/>
+        <polyline id="58_text_edge" points="14.31,7.51 15.01,7.51"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-9.10" y="10.07" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -105,182 +105,182 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-3.19,-19.24)" id="0" title="VL1">
-            <circle r="0.60" id="1" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="1" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-1.97,-15.97)" id="2" title="VL2">
-            <circle r="0.60" id="3" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="3" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(0.51,-11.05)" id="4" title="VL3">
-            <circle r="0.60" id="5" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="5" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(7.39,-4.16)" id="6" title="VL4">
-            <circle r="0.60" id="7" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="7" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(10.74,-1.87)" id="8" title="VL5">
-            <circle r="0.60" id="9" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="9" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(12.15,-4.80)" id="10" title="VL6">
-            <circle r="0.60" id="11" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="11" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(16.05,-4.19)" id="12" title="VL7">
-            <circle r="0.60" id="13" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="13" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(11.67,-8.29)" id="14" title="VL8">
-            <circle r="0.60" id="15" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="15" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(5.56,-11.43)" id="16" title="VL9">
-            <circle r="0.60" id="17" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="17" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(2.93,-13.06)" id="18" title="VL10">
-            <circle r="0.60" id="19" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="19" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1.30,-6.08)" id="20" title="VL11">
-            <circle r="0.60" id="21" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="21" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1.93,-16.51)" id="22" title="VL12">
-            <circle r="0.60" id="23" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="23" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-3.07,-11.25)" id="24" title="VL13">
-            <circle r="0.60" id="25" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="25" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-9.71,-14.11)" id="26" title="VL14">
-            <circle r="0.60" id="27" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="27" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-5.84,-13.83)" id="28" title="VL15">
-            <circle r="0.60" id="29" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="29" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-1.17,-22.02)" id="30" title="VL16">
-            <circle r="0.60" id="31" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="31" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1.93,-20.57)" id="32" title="VL17">
-            <circle r="0.60" id="33" class="nad-vl0to30-0"/>
+            <circle r="0.30" id="33" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(8.29,1.91)" id="34" title="VL18">
-            <circle r="0.60" id="35" class="nad-vl0to30-1"/>
+            <circle r="0.30" id="35" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(8.64,6.37)" id="36" title="VL19">
-            <circle r="0.60" id="37" class="nad-vl0to30-1"/>
+            <circle r="0.30" id="37" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(5.92,9.36)" id="38" title="VL20">
-            <circle r="0.60" id="39" class="nad-vl0to30-1"/>
+            <circle r="0.30" id="39" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(1.61,9.80)" id="40" title="VL21">
-            <circle r="0.60" id="41" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="41" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-2.85,9.09)" id="42" title="VL22">
-            <circle r="0.60" id="43" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="43" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(1.75,14.60)" id="44" title="VL23">
-            <circle r="0.60" id="45" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="45" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(6.98,17.50)" id="46" title="VL24">
-            <circle r="0.60" id="47" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="47" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(4.60,21.73)" id="48" title="VL25">
-            <circle r="0.60" id="49" class="nad-vl0to30-3"/>
+            <circle r="0.30" id="49" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(12.66,15.31)" id="50" title="VL26">
-            <circle r="0.60" id="51" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="51" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(16.85,11.38)" id="52" title="VL27">
-            <circle r="0.60" id="53" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="53" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(19.32,6.15)" id="54" title="VL28">
-            <circle r="0.60" id="55" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="55" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(19.95,-0.06)" id="56" title="VL29">
-            <circle r="0.60" id="57" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="57" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(0.45,23.86)" id="58" title="VL30">
-            <circle r="0.60" id="59" class="nad-vl0to30-3"/>
+            <circle r="0.30" id="59" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(-4.30,23.93)" id="60" title="VL31">
-            <circle r="0.60" id="61" class="nad-vl0to30-3"/>
+            <circle r="0.30" id="61" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(-9.26,22.82)" id="62" title="VL32">
-            <circle r="0.60" id="63" class="nad-vl0to30-3"/>
+            <circle r="0.30" id="63" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(-11.31,26.12)" id="64" title="VL33">
-            <circle r="0.60" id="65" class="nad-vl0to30-3"/>
+            <circle r="0.30" id="65" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(-13.01,19.37)" id="66" title="VL34">
-            <circle r="0.60" id="67" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="67" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-15.67,15.22)" id="68" title="VL35">
-            <circle r="0.60" id="69" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="69" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-15.81,9.86)" id="70" title="VL36">
-            <circle r="0.60" id="71" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="71" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-14.88,5.83)" id="72" title="VL37">
-            <circle r="0.60" id="73" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="73" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-10.96,0.69)" id="74" title="VL38">
-            <circle r="0.60" id="75" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="75" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-11.87,9.83)" id="76" title="VL39">
-            <circle r="0.60" id="77" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="77" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-11.24,6.19)" id="78" title="VL40">
-            <circle r="0.60" id="79" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="79" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-1.66,-0.12)" id="80" title="VL41">
-            <circle r="0.60" id="81" class="nad-vl0to30-5"/>
+            <circle r="0.30" id="81" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-2.59,3.35)" id="82" title="VL42">
-            <circle r="0.60" id="83" class="nad-vl0to30-5"/>
+            <circle r="0.30" id="83" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(1.47,-2.09)" id="84" title="VL43">
-            <circle r="0.60" id="85" class="nad-vl0to30-5"/>
+            <circle r="0.30" id="85" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-12.42,-5.52)" id="86" title="VL44">
-            <circle r="0.60" id="87" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="87" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-10.56,-10.15)" id="88" title="VL45">
-            <circle r="0.60" id="89" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="89" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-15.59,-12.59)" id="90" title="VL46">
-            <circle r="0.60" id="91" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="91" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-17.69,-7.91)" id="92" title="VL47">
-            <circle r="0.60" id="93" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="93" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-14.63,-3.04)" id="94" title="VL48">
-            <circle r="0.60" id="95" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="95" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-8.84,-4.51)" id="96" title="VL49">
-            <circle r="0.60" id="97" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="97" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-5.49,-5.85)" id="98" title="VL50">
-            <circle r="0.60" id="99" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="99" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-1.79,-8.13)" id="100" title="VL51">
-            <circle r="0.60" id="101" class="nad-vl0to30-2"/>
+            <circle r="0.30" id="101" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(22.40,-4.53)" id="102" title="VL52">
-            <circle r="0.60" id="103" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="103" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(21.39,-9.49)" id="104" title="VL53">
-            <circle r="0.60" id="105" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="105" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(17.65,-13.02)" id="106" title="VL54">
-            <circle r="0.60" id="107" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="107" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(12.15,-13.89)" id="108" title="VL55">
-            <circle r="0.60" id="109" class="nad-vl0to30-4"/>
+            <circle r="0.30" id="109" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(-6.15,4.49)" id="110" title="VL56">
-            <circle r="0.60" id="111" class="nad-vl0to30-5"/>
+            <circle r="0.30" id="111" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-7.96,8.86)" id="112" title="VL57">
-            <circle r="0.60" id="113" class="nad-vl0to30-5"/>
+            <circle r="0.30" id="113" class="nad-vl0to30-5"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="114" class="nad-vl0to30-0" title="L1-2-1">
             <g>
-                <polyline points="-2.99,-18.71 -2.58,-17.61"/>
-                <g class="nad-edge-infos" transform="translate(-2.89,-18.43)">
+                <polyline points="-3.10,-18.99 -2.58,-17.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.99,-18.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -298,8 +298,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.17,-16.51 -2.58,-17.61"/>
-                <g class="nad-edge-infos" transform="translate(-2.28,-16.79)">
+                <polyline points="-2.07,-16.23 -2.58,-17.61"/>
+                <g class="nad-edge-infos" transform="translate(-2.17,-16.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -319,8 +319,8 @@
         </g>
         <g id="115" class="nad-vl0to30-0" title="L1-15-1">
             <g>
-                <polyline points="-3.44,-18.73 -4.52,-16.54"/>
-                <g class="nad-edge-infos" transform="translate(-3.58,-18.46)">
+                <polyline points="-3.31,-19.00 -4.52,-16.54"/>
+                <g class="nad-edge-infos" transform="translate(-3.44,-18.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -338,8 +338,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.59,-14.34 -4.52,-16.54"/>
-                <g class="nad-edge-infos" transform="translate(-5.46,-14.61)">
+                <polyline points="-5.72,-14.07 -4.52,-16.54"/>
+                <g class="nad-edge-infos" transform="translate(-5.59,-14.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -359,8 +359,8 @@
         </g>
         <g id="116" class="nad-vl0to30-0" title="L1-16-1">
             <g>
-                <polyline points="-2.86,-19.70 -2.18,-20.63"/>
-                <g class="nad-edge-infos" transform="translate(-2.68,-19.95)">
+                <polyline points="-3.03,-19.46 -2.18,-20.63"/>
+                <g class="nad-edge-infos" transform="translate(-2.86,-19.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -378,8 +378,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.50,-21.56 -2.18,-20.63"/>
-                <g class="nad-edge-infos" transform="translate(-1.68,-21.32)">
+                <polyline points="-1.33,-21.81 -2.18,-20.63"/>
+                <g class="nad-edge-infos" transform="translate(-1.50,-21.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-143.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -399,8 +399,8 @@
         </g>
         <g id="117" class="nad-vl0to30-0" title="L1-17-1">
             <g>
-                <polyline points="-2.64,-19.39 -0.63,-19.91"/>
-                <g class="nad-edge-infos" transform="translate(-2.35,-19.46)">
+                <polyline points="-2.93,-19.31 -0.63,-19.91"/>
+                <g class="nad-edge-infos" transform="translate(-2.64,-19.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -418,8 +418,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.37,-20.43 -0.63,-19.91"/>
-                <g class="nad-edge-infos" transform="translate(1.08,-20.36)">
+                <polyline points="1.66,-20.51 -0.63,-19.91"/>
+                <g class="nad-edge-infos" transform="translate(1.37,-20.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -439,8 +439,8 @@
         </g>
         <g id="118" class="nad-vl0to30-0" title="L2-3-1">
             <g>
-                <polyline points="-1.71,-15.46 -0.73,-13.51"/>
-                <g class="nad-edge-infos" transform="translate(-1.58,-15.20)">
+                <polyline points="-1.85,-15.73 -0.73,-13.51"/>
+                <g class="nad-edge-infos" transform="translate(-1.71,-15.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -458,8 +458,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.25,-11.56 -0.73,-13.51"/>
-                <g class="nad-edge-infos" transform="translate(0.12,-11.83)">
+                <polyline points="0.39,-11.29 -0.73,-13.51"/>
+                <g class="nad-edge-infos" transform="translate(0.25,-11.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -479,8 +479,8 @@
         </g>
         <g id="119" class="nad-vl0to30-0" title="L3-4-1">
             <g>
-                <polyline points="0.91,-10.65 3.95,-7.60"/>
-                <g class="nad-edge-infos" transform="translate(1.12,-10.44)">
+                <polyline points="0.70,-10.86 3.95,-7.60"/>
+                <g class="nad-edge-infos" transform="translate(0.91,-10.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -498,8 +498,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.99,-4.56 3.95,-7.60"/>
-                <g class="nad-edge-infos" transform="translate(6.78,-4.77)">
+                <polyline points="7.20,-4.35 3.95,-7.60"/>
+                <g class="nad-edge-infos" transform="translate(6.99,-4.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -519,8 +519,8 @@
         </g>
         <g id="120" class="nad-vl0to30-0" title="L3-15-1">
             <g>
-                <polyline points="-0.02,-11.28 -2.67,-12.44"/>
-                <g class="nad-edge-infos" transform="translate(-0.29,-11.40)">
+                <polyline points="0.26,-11.16 -2.67,-12.44"/>
+                <g class="nad-edge-infos" transform="translate(-0.02,-11.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -538,8 +538,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.32,-13.60 -2.67,-12.44"/>
-                <g class="nad-edge-infos" transform="translate(-5.04,-13.48)">
+                <polyline points="-5.59,-13.72 -2.67,-12.44"/>
+                <g class="nad-edge-infos" transform="translate(-5.32,-13.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -559,8 +559,8 @@
         </g>
         <g id="121" class="nad-vl0to30-0" title="L4-5-1">
             <g>
-                <polyline points="7.86,-3.84 9.07,-3.01"/>
-                <g class="nad-edge-infos" transform="translate(8.11,-3.67)">
+                <polyline points="7.62,-4.01 9.07,-3.01"/>
+                <g class="nad-edge-infos" transform="translate(7.86,-3.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(124.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -578,8 +578,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="10.27,-2.19 9.07,-3.01"/>
-                <g class="nad-edge-infos" transform="translate(10.03,-2.36)">
+                <polyline points="10.52,-2.02 9.07,-3.01"/>
+                <g class="nad-edge-infos" transform="translate(10.27,-2.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-55.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -599,8 +599,8 @@
         </g>
         <g id="122" class="nad-vl0to30-0" title="L4-6-1">
             <g>
-                <polyline points="7.96,-4.23 9.77,-4.48"/>
-                <g class="nad-edge-infos" transform="translate(8.25,-4.27)">
+                <polyline points="7.66,-4.19 9.77,-4.48"/>
+                <g class="nad-edge-infos" transform="translate(7.96,-4.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -618,8 +618,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.59,-4.72 9.77,-4.48"/>
-                <g class="nad-edge-infos" transform="translate(11.29,-4.68)">
+                <polyline points="11.88,-4.76 9.77,-4.48"/>
+                <g class="nad-edge-infos" transform="translate(11.59,-4.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -639,7 +639,7 @@
         </g>
         <g id="123" title="T4-18-1">
             <g class="nad-vl0to30-0">
-                <polyline points="7.18,-3.63 7.10,-3.41 7.44,-1.06"/>
+                <polyline points="7.29,-3.91 7.10,-3.41 7.44,-1.06"/>
                 <g class="nad-edge-infos" transform="translate(7.14,-3.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.61)">
@@ -659,7 +659,7 @@
                 <circle cx="7.43" cy="-1.16" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="7.93,1.47 7.79,1.29 7.44,-1.06"/>
+                <polyline points="8.12,1.70 7.79,1.29 7.44,-1.06"/>
                 <g class="nad-edge-infos" transform="translate(7.75,0.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.39)">
@@ -681,7 +681,7 @@
         </g>
         <g id="124" title="T4-18-2">
             <g class="nad-vl0to30-0">
-                <polyline points="7.75,-3.71 7.89,-3.53 8.24,-1.18"/>
+                <polyline points="7.56,-3.95 7.89,-3.53 8.24,-1.18"/>
                 <g class="nad-edge-infos" transform="translate(7.93,-3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.61)">
@@ -701,7 +701,7 @@
                 <circle cx="8.22" cy="-1.28" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="8.50,1.38 8.58,1.17 8.24,-1.18"/>
+                <polyline points="8.39,1.66 8.58,1.17 8.24,-1.18"/>
                 <g class="nad-edge-infos" transform="translate(8.54,0.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.39)">
@@ -723,8 +723,8 @@
         </g>
         <g id="125" class="nad-vl0to30-0" title="L5-6-1">
             <g>
-                <polyline points="10.99,-2.38 11.45,-3.34"/>
-                <g class="nad-edge-infos" transform="translate(11.12,-2.65)">
+                <polyline points="10.86,-2.11 11.45,-3.34"/>
+                <g class="nad-edge-infos" transform="translate(10.99,-2.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -742,8 +742,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.90,-4.29 11.45,-3.34"/>
-                <g class="nad-edge-infos" transform="translate(11.77,-4.02)">
+                <polyline points="12.03,-4.56 11.45,-3.34"/>
+                <g class="nad-edge-infos" transform="translate(11.90,-4.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -763,8 +763,8 @@
         </g>
         <g id="126" class="nad-vl0to30-0" title="L6-7-1">
             <g>
-                <polyline points="12.71,-4.71 14.10,-4.50"/>
-                <g class="nad-edge-infos" transform="translate(13.01,-4.67)">
+                <polyline points="12.42,-4.76 14.10,-4.50"/>
+                <g class="nad-edge-infos" transform="translate(12.71,-4.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -782,8 +782,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="15.48,-4.28 14.10,-4.50"/>
-                <g class="nad-edge-infos" transform="translate(15.19,-4.33)">
+                <polyline points="15.78,-4.23 14.10,-4.50"/>
+                <g class="nad-edge-infos" transform="translate(15.48,-4.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -803,8 +803,8 @@
         </g>
         <g id="127" class="nad-vl0to30-0" title="L6-8-1">
             <g>
-                <polyline points="12.07,-5.37 11.91,-6.55"/>
-                <g class="nad-edge-infos" transform="translate(12.03,-5.66)">
+                <polyline points="12.11,-5.07 11.91,-6.55"/>
+                <g class="nad-edge-infos" transform="translate(12.07,-5.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -822,8 +822,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="11.75,-7.73 11.91,-6.55"/>
-                <g class="nad-edge-infos" transform="translate(11.79,-7.43)">
+                <polyline points="11.71,-8.03 11.91,-6.55"/>
+                <g class="nad-edge-infos" transform="translate(11.75,-7.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(172.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -843,8 +843,8 @@
         </g>
         <g id="128" class="nad-vl0to30-0" title="L7-8-1">
             <g>
-                <polyline points="15.63,-4.58 13.86,-6.24"/>
-                <g class="nad-edge-infos" transform="translate(15.41,-4.79)">
+                <polyline points="15.85,-4.38 13.86,-6.24"/>
+                <g class="nad-edge-infos" transform="translate(15.63,-4.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -862,8 +862,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="12.09,-7.90 13.86,-6.24"/>
-                <g class="nad-edge-infos" transform="translate(12.31,-7.70)">
+                <polyline points="11.87,-8.11 13.86,-6.24"/>
+                <g class="nad-edge-infos" transform="translate(12.09,-7.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -883,8 +883,8 @@
         </g>
         <g id="129" title="T7-29-1">
             <g class="nad-vl0to30-0">
-                <polyline points="16.44,-3.78 18.00,-2.13"/>
-                <g class="nad-edge-infos" transform="translate(16.64,-3.56)">
+                <polyline points="16.23,-4.00 18.00,-2.13"/>
+                <g class="nad-edge-infos" transform="translate(16.44,-3.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -903,8 +903,8 @@
                 <circle cx="17.93" cy="-2.20" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="19.56,-0.48 18.00,-2.13"/>
-                <g class="nad-edge-infos" transform="translate(19.35,-0.70)">
+                <polyline points="19.76,-0.26 18.00,-2.13"/>
+                <g class="nad-edge-infos" transform="translate(19.56,-0.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -925,8 +925,8 @@
         </g>
         <g id="130" class="nad-vl0to30-0" title="L8-9-1">
             <g>
-                <polyline points="11.16,-8.55 8.62,-9.86"/>
-                <g class="nad-edge-infos" transform="translate(10.90,-8.69)">
+                <polyline points="11.43,-8.42 8.62,-9.86"/>
+                <g class="nad-edge-infos" transform="translate(11.16,-8.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -944,8 +944,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.07,-11.17 8.62,-9.86"/>
-                <g class="nad-edge-infos" transform="translate(6.34,-11.03)">
+                <polyline points="5.80,-11.30 8.62,-9.86"/>
+                <g class="nad-edge-infos" transform="translate(6.07,-11.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -965,8 +965,8 @@
         </g>
         <g id="131" class="nad-vl0to30-0" title="L9-10-1">
             <g>
-                <polyline points="5.08,-11.73 4.25,-12.24"/>
-                <g class="nad-edge-infos" transform="translate(4.82,-11.89)">
+                <polyline points="5.34,-11.57 4.25,-12.24"/>
+                <g class="nad-edge-infos" transform="translate(5.08,-11.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -984,8 +984,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.41,-12.76 4.25,-12.24"/>
-                <g class="nad-edge-infos" transform="translate(3.67,-12.60)">
+                <polyline points="3.16,-12.92 4.25,-12.24"/>
+                <g class="nad-edge-infos" transform="translate(3.41,-12.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1005,8 +1005,8 @@
         </g>
         <g id="132" class="nad-vl0to30-0" title="L9-11-1">
             <g>
-                <polyline points="5.21,-10.98 3.43,-8.75"/>
-                <g class="nad-edge-infos" transform="translate(5.02,-10.75)">
+                <polyline points="5.40,-11.22 3.43,-8.75"/>
+                <g class="nad-edge-infos" transform="translate(5.21,-10.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1024,8 +1024,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.66,-6.53 3.43,-8.75"/>
-                <g class="nad-edge-infos" transform="translate(1.85,-6.76)">
+                <polyline points="1.47,-6.29 3.43,-8.75"/>
+                <g class="nad-edge-infos" transform="translate(1.66,-6.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1045,8 +1045,8 @@
         </g>
         <g id="133" class="nad-vl0to30-0" title="L9-12-1">
             <g>
-                <polyline points="5.23,-11.89 3.75,-13.97"/>
-                <g class="nad-edge-infos" transform="translate(5.06,-12.14)">
+                <polyline points="5.41,-11.65 3.75,-13.97"/>
+                <g class="nad-edge-infos" transform="translate(5.23,-11.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1064,8 +1064,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.26,-16.05 3.75,-13.97"/>
-                <g class="nad-edge-infos" transform="translate(2.44,-15.80)">
+                <polyline points="2.09,-16.29 3.75,-13.97"/>
+                <g class="nad-edge-infos" transform="translate(2.26,-16.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1085,8 +1085,8 @@
         </g>
         <g id="134" class="nad-vl0to30-0" title="L9-13-1">
             <g>
-                <polyline points="4.99,-11.42 1.25,-11.34"/>
-                <g class="nad-edge-infos" transform="translate(4.69,-11.41)">
+                <polyline points="5.29,-11.42 1.25,-11.34"/>
+                <g class="nad-edge-infos" transform="translate(4.99,-11.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1104,8 +1104,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.50,-11.26 1.25,-11.34"/>
-                <g class="nad-edge-infos" transform="translate(-2.20,-11.26)">
+                <polyline points="-2.80,-11.25 1.25,-11.34"/>
+                <g class="nad-edge-infos" transform="translate(-2.50,-11.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1125,8 +1125,8 @@
         </g>
         <g id="135" title="T9-55-1">
             <g class="nad-vl0to30-0">
-                <polyline points="6.10,-11.63 8.86,-12.66"/>
-                <g class="nad-edge-infos" transform="translate(6.38,-11.73)">
+                <polyline points="5.82,-11.52 8.86,-12.66"/>
+                <g class="nad-edge-infos" transform="translate(6.10,-11.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1145,8 +1145,8 @@
                 <circle cx="8.76" cy="-12.62" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="11.61,-13.69 8.86,-12.66"/>
-                <g class="nad-edge-infos" transform="translate(11.33,-13.59)">
+                <polyline points="11.89,-13.80 8.86,-12.66"/>
+                <g class="nad-edge-infos" transform="translate(11.61,-13.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1167,8 +1167,8 @@
         </g>
         <g id="136" class="nad-vl0to30-0" title="L10-12-1">
             <g>
-                <polyline points="2.77,-13.61 2.43,-14.79"/>
-                <g class="nad-edge-infos" transform="translate(2.69,-13.90)">
+                <polyline points="2.85,-13.32 2.43,-14.79"/>
+                <g class="nad-edge-infos" transform="translate(2.77,-13.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1186,8 +1186,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.09,-15.96 2.43,-14.79"/>
-                <g class="nad-edge-infos" transform="translate(2.17,-15.68)">
+                <polyline points="2.01,-16.25 2.43,-14.79"/>
+                <g class="nad-edge-infos" transform="translate(2.09,-15.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1207,8 +1207,8 @@
         </g>
         <g id="137" title="T10-51-1">
             <g class="nad-vl0to30-0">
-                <polyline points="2.53,-12.65 0.57,-10.60"/>
-                <g class="nad-edge-infos" transform="translate(2.32,-12.43)">
+                <polyline points="2.74,-12.87 0.57,-10.60"/>
+                <g class="nad-edge-infos" transform="translate(2.53,-12.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1227,8 +1227,8 @@
                 <circle cx="0.64" cy="-10.67" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-1.40,-8.55 0.57,-10.60"/>
-                <g class="nad-edge-infos" transform="translate(-1.19,-8.76)">
+                <polyline points="-1.61,-8.33 0.57,-10.60"/>
+                <g class="nad-edge-infos" transform="translate(-1.40,-8.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1249,8 +1249,8 @@
         </g>
         <g id="138" class="nad-vl0to30-0" title="L11-13-1">
             <g>
-                <polyline points="0.93,-6.52 -0.89,-8.66"/>
-                <g class="nad-edge-infos" transform="translate(0.74,-6.74)">
+                <polyline points="1.13,-6.29 -0.89,-8.66"/>
+                <g class="nad-edge-infos" transform="translate(0.93,-6.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1268,8 +1268,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.71,-10.81 -0.89,-8.66"/>
-                <g class="nad-edge-infos" transform="translate(-2.51,-10.58)">
+                <polyline points="-2.90,-11.04 -0.89,-8.66"/>
+                <g class="nad-edge-infos" transform="translate(-2.71,-10.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1289,8 +1289,8 @@
         </g>
         <g id="139" title="T11-41-1">
             <g class="nad-vl0to30-0">
-                <polyline points="1.05,-5.57 -0.18,-3.10"/>
-                <g class="nad-edge-infos" transform="translate(0.92,-5.30)">
+                <polyline points="1.18,-5.84 -0.18,-3.10"/>
+                <g class="nad-edge-infos" transform="translate(1.05,-5.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1309,8 +1309,8 @@
                 <circle cx="-0.13" cy="-3.19" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-1.40,-0.63 -0.18,-3.10"/>
-                <g class="nad-edge-infos" transform="translate(-1.27,-0.90)">
+                <polyline points="-1.54,-0.36 -0.18,-3.10"/>
+                <g class="nad-edge-infos" transform="translate(-1.40,-0.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1331,8 +1331,8 @@
         </g>
         <g id="140" title="T11-43-1">
             <g class="nad-vl0to30-0">
-                <polyline points="1.33,-5.51 1.39,-4.09"/>
-                <g class="nad-edge-infos" transform="translate(1.34,-5.21)">
+                <polyline points="1.31,-5.81 1.39,-4.09"/>
+                <g class="nad-edge-infos" transform="translate(1.33,-5.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1351,8 +1351,8 @@
                 <circle cx="1.38" cy="-4.19" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="1.45,-2.66 1.39,-4.09"/>
-                <g class="nad-edge-infos" transform="translate(1.43,-2.96)">
+                <polyline points="1.46,-2.36 1.39,-4.09"/>
+                <g class="nad-edge-infos" transform="translate(1.45,-2.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-2.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1373,8 +1373,8 @@
         </g>
         <g id="141" class="nad-vl0to30-0" title="L12-13-1">
             <g>
-                <polyline points="1.54,-16.10 -0.57,-13.88"/>
-                <g class="nad-edge-infos" transform="translate(1.33,-15.88)">
+                <polyline points="1.75,-16.32 -0.57,-13.88"/>
+                <g class="nad-edge-infos" transform="translate(1.54,-16.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1392,8 +1392,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.68,-11.66 -0.57,-13.88"/>
-                <g class="nad-edge-infos" transform="translate(-2.47,-11.88)">
+                <polyline points="-2.89,-11.44 -0.57,-13.88"/>
+                <g class="nad-edge-infos" transform="translate(-2.68,-11.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1413,8 +1413,8 @@
         </g>
         <g id="142" class="nad-vl0to30-0" title="L12-16-1">
             <g>
-                <polyline points="1.65,-17.01 0.38,-19.27"/>
-                <g class="nad-edge-infos" transform="translate(1.51,-17.27)">
+                <polyline points="1.80,-16.75 0.38,-19.27"/>
+                <g class="nad-edge-infos" transform="translate(1.65,-17.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-29.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1432,8 +1432,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-0.89,-21.53 0.38,-19.27"/>
-                <g class="nad-edge-infos" transform="translate(-0.74,-21.27)">
+                <polyline points="-1.04,-21.79 0.38,-19.27"/>
+                <g class="nad-edge-infos" transform="translate(-0.89,-21.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1453,8 +1453,8 @@
         </g>
         <g id="143" class="nad-vl0to30-0" title="L12-17-1">
             <g>
-                <polyline points="1.93,-17.08 1.93,-18.54"/>
-                <g class="nad-edge-infos" transform="translate(1.93,-17.38)">
+                <polyline points="1.93,-16.78 1.93,-18.54"/>
+                <g class="nad-edge-infos" transform="translate(1.93,-17.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1472,8 +1472,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.93,-20.00 1.93,-18.54"/>
-                <g class="nad-edge-infos" transform="translate(1.93,-19.70)">
+                <polyline points="1.93,-20.30 1.93,-18.54"/>
+                <g class="nad-edge-infos" transform="translate(1.93,-20.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1493,8 +1493,8 @@
         </g>
         <g id="144" class="nad-vl0to30-0" title="L13-14-1">
             <g>
-                <polyline points="-3.60,-11.47 -6.39,-12.68"/>
-                <g class="nad-edge-infos" transform="translate(-3.87,-11.59)">
+                <polyline points="-3.32,-11.35 -6.39,-12.68"/>
+                <g class="nad-edge-infos" transform="translate(-3.60,-11.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1512,8 +1512,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.19,-13.89 -6.39,-12.68"/>
-                <g class="nad-edge-infos" transform="translate(-8.91,-13.77)">
+                <polyline points="-9.46,-14.00 -6.39,-12.68"/>
+                <g class="nad-edge-infos" transform="translate(-9.19,-13.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1533,8 +1533,8 @@
         </g>
         <g id="145" class="nad-vl0to30-0" title="L13-15-1">
             <g>
-                <polyline points="-3.49,-11.63 -4.46,-12.54"/>
-                <g class="nad-edge-infos" transform="translate(-3.71,-11.84)">
+                <polyline points="-3.27,-11.43 -4.46,-12.54"/>
+                <g class="nad-edge-infos" transform="translate(-3.49,-11.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1552,8 +1552,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.43,-13.44 -4.46,-12.54"/>
-                <g class="nad-edge-infos" transform="translate(-5.21,-13.23)">
+                <polyline points="-5.64,-13.64 -4.46,-12.54"/>
+                <g class="nad-edge-infos" transform="translate(-5.43,-13.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1573,8 +1573,8 @@
         </g>
         <g id="146" title="T13-49-1">
             <g class="nad-vl0to30-0">
-                <polyline points="-3.45,-10.81 -5.96,-7.88"/>
-                <g class="nad-edge-infos" transform="translate(-3.64,-10.59)">
+                <polyline points="-3.25,-11.04 -5.96,-7.88"/>
+                <g class="nad-edge-infos" transform="translate(-3.45,-10.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1593,8 +1593,8 @@
                 <circle cx="-5.89" cy="-7.95" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-8.47,-4.94 -5.96,-7.88"/>
-                <g class="nad-edge-infos" transform="translate(-8.28,-5.17)">
+                <polyline points="-8.67,-4.71 -5.96,-7.88"/>
+                <g class="nad-edge-infos" transform="translate(-8.47,-4.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1615,8 +1615,8 @@
         </g>
         <g id="147" class="nad-vl0to30-0" title="L14-15-1">
             <g>
-                <polyline points="-9.14,-14.07 -7.78,-13.97"/>
-                <g class="nad-edge-infos" transform="translate(-8.84,-14.05)">
+                <polyline points="-9.44,-14.09 -7.78,-13.97"/>
+                <g class="nad-edge-infos" transform="translate(-9.14,-14.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(94.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1634,8 +1634,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.41,-13.87 -7.78,-13.97"/>
-                <g class="nad-edge-infos" transform="translate(-6.71,-13.89)">
+                <polyline points="-6.11,-13.85 -7.78,-13.97"/>
+                <g class="nad-edge-infos" transform="translate(-6.41,-13.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-85.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1655,8 +1655,8 @@
         </g>
         <g id="148" title="T14-46-1">
             <g class="nad-vl0to30-0">
-                <polyline points="-10.26,-13.97 -12.65,-13.35"/>
-                <g class="nad-edge-infos" transform="translate(-10.55,-13.89)">
+                <polyline points="-9.97,-14.04 -12.65,-13.35"/>
+                <g class="nad-edge-infos" transform="translate(-10.26,-13.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1675,8 +1675,8 @@
                 <circle cx="-12.55" cy="-13.38" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-15.04,-12.74 -12.65,-13.35"/>
-                <g class="nad-edge-infos" transform="translate(-14.75,-12.81)">
+                <polyline points="-15.33,-12.66 -12.65,-13.35"/>
+                <g class="nad-edge-infos" transform="translate(-15.04,-12.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1697,8 +1697,8 @@
         </g>
         <g id="149" title="T15-45-1">
             <g class="nad-vl0to30-0">
-                <polyline points="-6.29,-13.48 -8.20,-11.99"/>
-                <g class="nad-edge-infos" transform="translate(-6.53,-13.29)">
+                <polyline points="-6.06,-13.66 -8.20,-11.99"/>
+                <g class="nad-edge-infos" transform="translate(-6.29,-13.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-127.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1717,8 +1717,8 @@
                 <circle cx="-8.12" cy="-12.05" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-10.11,-10.50 -8.20,-11.99"/>
-                <g class="nad-edge-infos" transform="translate(-9.88,-10.68)">
+                <polyline points="-10.35,-10.31 -8.20,-11.99"/>
+                <g class="nad-edge-infos" transform="translate(-10.11,-10.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1739,8 +1739,8 @@
         </g>
         <g id="150" class="nad-vl0to30-1" title="L18-19-1">
             <g>
-                <polyline points="8.33,2.48 8.46,4.14"/>
-                <g class="nad-edge-infos" transform="translate(8.36,2.78)">
+                <polyline points="8.31,2.18 8.46,4.14"/>
+                <g class="nad-edge-infos" transform="translate(8.33,2.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1758,8 +1758,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="8.60,5.80 8.46,4.14"/>
-                <g class="nad-edge-infos" transform="translate(8.57,5.50)">
+                <polyline points="8.62,6.10 8.46,4.14"/>
+                <g class="nad-edge-infos" transform="translate(8.60,5.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1779,8 +1779,8 @@
         </g>
         <g id="151" class="nad-vl0to30-1" title="L19-20-1">
             <g>
-                <polyline points="8.26,6.79 7.28,7.86"/>
-                <g class="nad-edge-infos" transform="translate(8.06,7.01)">
+                <polyline points="8.46,6.57 7.28,7.86"/>
+                <g class="nad-edge-infos" transform="translate(8.26,6.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1798,8 +1798,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.30,8.94 7.28,7.86"/>
-                <g class="nad-edge-infos" transform="translate(6.50,8.71)">
+                <polyline points="6.10,9.16 7.28,7.86"/>
+                <g class="nad-edge-infos" transform="translate(6.30,8.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1819,8 +1819,8 @@
         </g>
         <g id="152" title="T21-20-1">
             <g class="nad-vl0to30-2">
-                <polyline points="2.18,9.75 3.76,9.58"/>
-                <g class="nad-edge-infos" transform="translate(2.47,9.71)">
+                <polyline points="1.88,9.78 3.76,9.58"/>
+                <g class="nad-edge-infos" transform="translate(2.18,9.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1839,8 +1839,8 @@
                 <circle cx="3.66" cy="9.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="5.35,9.42 3.76,9.58"/>
-                <g class="nad-edge-infos" transform="translate(5.05,9.45)">
+                <polyline points="5.65,9.38 3.76,9.58"/>
+                <g class="nad-edge-infos" transform="translate(5.35,9.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1861,8 +1861,8 @@
         </g>
         <g id="153" class="nad-vl0to30-2" title="L21-22-1">
             <g>
-                <polyline points="1.05,9.71 -0.62,9.45"/>
-                <g class="nad-edge-infos" transform="translate(0.75,9.67)">
+                <polyline points="1.34,9.76 -0.62,9.45"/>
+                <g class="nad-edge-infos" transform="translate(1.05,9.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1880,8 +1880,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.29,9.18 -0.62,9.45"/>
-                <g class="nad-edge-infos" transform="translate(-1.99,9.22)">
+                <polyline points="-2.59,9.13 -0.62,9.45"/>
+                <g class="nad-edge-infos" transform="translate(-2.29,9.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1901,8 +1901,8 @@
         </g>
         <g id="154" class="nad-vl0to30-2" title="L22-23-1">
             <g>
-                <polyline points="-2.49,9.52 -0.55,11.84"/>
-                <g class="nad-edge-infos" transform="translate(-2.29,9.75)">
+                <polyline points="-2.68,9.29 -0.55,11.84"/>
+                <g class="nad-edge-infos" transform="translate(-2.49,9.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1920,8 +1920,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.38,14.16 -0.55,11.84"/>
-                <g class="nad-edge-infos" transform="translate(1.19,13.93)">
+                <polyline points="1.57,14.39 -0.55,11.84"/>
+                <g class="nad-edge-infos" transform="translate(1.38,14.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1941,8 +1941,8 @@
         </g>
         <g id="155" class="nad-vl0to30-2" title="L22-38-1">
             <g>
-                <polyline points="-3.25,8.68 -6.91,4.89"/>
-                <g class="nad-edge-infos" transform="translate(-3.46,8.46)">
+                <polyline points="-3.04,8.89 -6.91,4.89"/>
+                <g class="nad-edge-infos" transform="translate(-3.25,8.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1960,8 +1960,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.57,1.10 -6.91,4.89"/>
-                <g class="nad-edge-infos" transform="translate(-10.36,1.32)">
+                <polyline points="-10.78,0.88 -6.91,4.89"/>
+                <g class="nad-edge-infos" transform="translate(-10.57,1.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -1981,8 +1981,8 @@
         </g>
         <g id="156" class="nad-vl0to30-2" title="L23-24-1">
             <g>
-                <polyline points="2.24,14.87 4.36,16.05"/>
-                <g class="nad-edge-infos" transform="translate(2.51,15.02)">
+                <polyline points="1.98,14.73 4.36,16.05"/>
+                <g class="nad-edge-infos" transform="translate(2.24,14.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2000,8 +2000,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="6.48,17.22 4.36,16.05"/>
-                <g class="nad-edge-infos" transform="translate(6.22,17.08)">
+                <polyline points="6.74,17.37 4.36,16.05"/>
+                <g class="nad-edge-infos" transform="translate(6.48,17.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2021,7 +2021,7 @@
         </g>
         <g id="157" title="T24-25-1">
             <g class="nad-vl0to30-2">
-                <polyline points="6.49,17.79 6.29,17.91 5.44,19.42"/>
+                <polyline points="6.75,17.64 6.29,17.91 5.44,19.42"/>
                 <g class="nad-edge-infos" transform="translate(6.14,18.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.72)">
@@ -2041,7 +2041,7 @@
                 <circle cx="5.49" cy="19.33" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="4.60,21.16 4.59,20.93 5.44,19.42"/>
+                <polyline points="4.60,21.46 4.59,20.93 5.44,19.42"/>
                 <g class="nad-edge-infos" transform="translate(4.74,20.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.28)">
@@ -2063,7 +2063,7 @@
         </g>
         <g id="158" title="T24-25-2">
             <g class="nad-vl0to30-2">
-                <polyline points="6.99,18.07 6.99,18.30 6.14,19.81"/>
+                <polyline points="6.98,17.77 6.99,18.30 6.14,19.81"/>
                 <g class="nad-edge-infos" transform="translate(6.84,18.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.72)">
@@ -2083,7 +2083,7 @@
                 <circle cx="6.19" cy="19.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="5.09,21.44 5.29,21.32 6.14,19.81"/>
+                <polyline points="4.84,21.60 5.29,21.32 6.14,19.81"/>
                 <g class="nad-edge-infos" transform="translate(5.44,21.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.28)">
@@ -2105,8 +2105,8 @@
         </g>
         <g id="159" title="T24-26-1">
             <g class="nad-vl0to30-2">
-                <polyline points="7.51,17.29 9.82,16.40"/>
-                <g class="nad-edge-infos" transform="translate(7.79,17.18)">
+                <polyline points="7.23,17.40 9.82,16.40"/>
+                <g class="nad-edge-infos" transform="translate(7.51,17.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2125,8 +2125,8 @@
                 <circle cx="9.72" cy="16.44" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="12.13,15.51 9.82,16.40"/>
-                <g class="nad-edge-infos" transform="translate(11.85,15.62)">
+                <polyline points="12.41,15.40 9.82,16.40"/>
+                <g class="nad-edge-infos" transform="translate(12.13,15.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2147,8 +2147,8 @@
         </g>
         <g id="160" class="nad-vl0to30-3" title="L25-30-1">
             <g>
-                <polyline points="4.10,21.99 2.53,22.80"/>
-                <g class="nad-edge-infos" transform="translate(3.83,22.13)">
+                <polyline points="4.36,21.86 2.53,22.80"/>
+                <g class="nad-edge-infos" transform="translate(4.10,21.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2166,8 +2166,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.96,23.60 2.53,22.80"/>
-                <g class="nad-edge-infos" transform="translate(1.23,23.47)">
+                <polyline points="0.69,23.74 2.53,22.80"/>
+                <g class="nad-edge-infos" transform="translate(0.96,23.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2187,8 +2187,8 @@
         </g>
         <g id="161" class="nad-vl0to30-4" title="L26-27-1">
             <g>
-                <polyline points="13.07,14.92 14.75,13.34"/>
-                <g class="nad-edge-infos" transform="translate(13.29,14.71)">
+                <polyline points="12.85,15.12 14.75,13.34"/>
+                <g class="nad-edge-infos" transform="translate(13.07,14.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2206,8 +2206,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="16.43,11.77 14.75,13.34"/>
-                <g class="nad-edge-infos" transform="translate(16.21,11.97)">
+                <polyline points="16.65,11.56 14.75,13.34"/>
+                <g class="nad-edge-infos" transform="translate(16.43,11.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2227,8 +2227,8 @@
         </g>
         <g id="162" class="nad-vl0to30-4" title="L27-28-1">
             <g>
-                <polyline points="17.09,10.86 18.08,8.76"/>
-                <g class="nad-edge-infos" transform="translate(17.22,10.59)">
+                <polyline points="16.96,11.14 18.08,8.76"/>
+                <g class="nad-edge-infos" transform="translate(17.09,10.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2246,8 +2246,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="19.08,6.67 18.08,8.76"/>
-                <g class="nad-edge-infos" transform="translate(18.95,6.94)">
+                <polyline points="19.21,6.39 18.08,8.76"/>
+                <g class="nad-edge-infos" transform="translate(19.08,6.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2267,8 +2267,8 @@
         </g>
         <g id="163" class="nad-vl0to30-4" title="L28-29-1">
             <g>
-                <polyline points="19.38,5.58 19.64,3.04"/>
-                <g class="nad-edge-infos" transform="translate(19.41,5.28)">
+                <polyline points="19.35,5.88 19.64,3.04"/>
+                <g class="nad-edge-infos" transform="translate(19.38,5.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2286,8 +2286,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="19.89,0.50 19.64,3.04"/>
-                <g class="nad-edge-infos" transform="translate(19.86,0.80)">
+                <polyline points="19.92,0.21 19.64,3.04"/>
+                <g class="nad-edge-infos" transform="translate(19.89,0.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2307,8 +2307,8 @@
         </g>
         <g id="164" class="nad-vl0to30-4" title="L29-52-1">
             <g>
-                <polyline points="20.22,-0.56 21.18,-2.30"/>
-                <g class="nad-edge-infos" transform="translate(20.37,-0.83)">
+                <polyline points="20.08,-0.30 21.18,-2.30"/>
+                <g class="nad-edge-infos" transform="translate(20.22,-0.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2326,8 +2326,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="22.13,-4.03 21.18,-2.30"/>
-                <g class="nad-edge-infos" transform="translate(21.98,-3.77)">
+                <polyline points="22.27,-4.30 21.18,-2.30"/>
+                <g class="nad-edge-infos" transform="translate(22.13,-4.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2347,8 +2347,8 @@
         </g>
         <g id="165" class="nad-vl0to30-3" title="L30-31-1">
             <g>
-                <polyline points="-0.12,23.87 -1.92,23.90"/>
-                <g class="nad-edge-infos" transform="translate(-0.42,23.88)">
+                <polyline points="0.18,23.87 -1.92,23.90"/>
+                <g class="nad-edge-infos" transform="translate(-0.12,23.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2366,8 +2366,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.73,23.92 -1.92,23.90"/>
-                <g class="nad-edge-infos" transform="translate(-3.43,23.92)">
+                <polyline points="-4.03,23.93 -1.92,23.90"/>
+                <g class="nad-edge-infos" transform="translate(-3.73,23.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2387,8 +2387,8 @@
         </g>
         <g id="166" class="nad-vl0to30-3" title="L31-32-1">
             <g>
-                <polyline points="-4.86,23.81 -6.78,23.37"/>
-                <g class="nad-edge-infos" transform="translate(-5.15,23.74)">
+                <polyline points="-4.56,23.87 -6.78,23.37"/>
+                <g class="nad-edge-infos" transform="translate(-4.86,23.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2406,8 +2406,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-8.70,22.94 -6.78,23.37"/>
-                <g class="nad-edge-infos" transform="translate(-8.41,23.01)">
+                <polyline points="-8.99,22.88 -6.78,23.37"/>
+                <g class="nad-edge-infos" transform="translate(-8.70,22.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2427,8 +2427,8 @@
         </g>
         <g id="167" class="nad-vl0to30-3" title="L32-33-1">
             <g>
-                <polyline points="-9.56,23.30 -10.28,24.47"/>
-                <g class="nad-edge-infos" transform="translate(-9.72,23.56)">
+                <polyline points="-9.40,23.05 -10.28,24.47"/>
+                <g class="nad-edge-infos" transform="translate(-9.56,23.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2446,8 +2446,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.01,25.63 -10.28,24.47"/>
-                <g class="nad-edge-infos" transform="translate(-10.85,25.38)">
+                <polyline points="-11.17,25.89 -10.28,24.47"/>
+                <g class="nad-edge-infos" transform="translate(-11.01,25.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2467,8 +2467,8 @@
         </g>
         <g id="168" title="T34-32-1">
             <g class="nad-vl0to30-2">
-                <polyline points="-12.59,19.75 -11.13,21.09"/>
-                <g class="nad-edge-infos" transform="translate(-12.37,19.96)">
+                <polyline points="-12.81,19.55 -11.13,21.09"/>
+                <g class="nad-edge-infos" transform="translate(-12.59,19.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2487,8 +2487,8 @@
                 <circle cx="-11.21" cy="21.02" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="-9.68,22.43 -11.13,21.09"/>
-                <g class="nad-edge-infos" transform="translate(-9.90,22.23)">
+                <polyline points="-9.46,22.64 -11.13,21.09"/>
+                <g class="nad-edge-infos" transform="translate(-9.68,22.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2509,8 +2509,8 @@
         </g>
         <g id="169" class="nad-vl0to30-2" title="L34-35-1">
             <g>
-                <polyline points="-13.32,18.89 -14.34,17.29"/>
-                <g class="nad-edge-infos" transform="translate(-13.48,18.63)">
+                <polyline points="-13.15,19.14 -14.34,17.29"/>
+                <g class="nad-edge-infos" transform="translate(-13.32,18.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2528,8 +2528,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-15.36,15.70 -14.34,17.29"/>
-                <g class="nad-edge-infos" transform="translate(-15.20,15.95)">
+                <polyline points="-15.53,15.45 -14.34,17.29"/>
+                <g class="nad-edge-infos" transform="translate(-15.36,15.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2549,8 +2549,8 @@
         </g>
         <g id="170" class="nad-vl0to30-2" title="L35-36-1">
             <g>
-                <polyline points="-15.69,14.65 -15.74,12.54"/>
-                <g class="nad-edge-infos" transform="translate(-15.69,14.35)">
+                <polyline points="-15.68,14.95 -15.74,12.54"/>
+                <g class="nad-edge-infos" transform="translate(-15.69,14.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2568,8 +2568,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-15.79,10.43 -15.74,12.54"/>
-                <g class="nad-edge-infos" transform="translate(-15.79,10.73)">
+                <polyline points="-15.80,10.13 -15.74,12.54"/>
+                <g class="nad-edge-infos" transform="translate(-15.79,10.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2589,8 +2589,8 @@
         </g>
         <g id="171" class="nad-vl0to30-2" title="L36-37-1">
             <g>
-                <polyline points="-15.68,9.30 -15.34,7.85"/>
-                <g class="nad-edge-infos" transform="translate(-15.61,9.01)">
+                <polyline points="-15.75,9.59 -15.34,7.85"/>
+                <g class="nad-edge-infos" transform="translate(-15.68,9.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2608,8 +2608,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-15.01,6.39 -15.34,7.85"/>
-                <g class="nad-edge-infos" transform="translate(-15.07,6.68)">
+                <polyline points="-14.94,6.10 -15.34,7.85"/>
+                <g class="nad-edge-infos" transform="translate(-15.01,6.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-167.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2629,8 +2629,8 @@
         </g>
         <g id="172" class="nad-vl0to30-2" title="L36-40-1">
             <g>
-                <polyline points="-15.36,9.50 -13.53,8.03"/>
-                <g class="nad-edge-infos" transform="translate(-15.13,9.31)">
+                <polyline points="-15.60,9.69 -13.53,8.03"/>
+                <g class="nad-edge-infos" transform="translate(-15.36,9.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2648,8 +2648,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.69,6.55 -13.53,8.03"/>
-                <g class="nad-edge-infos" transform="translate(-11.92,6.74)">
+                <polyline points="-11.45,6.36 -13.53,8.03"/>
+                <g class="nad-edge-infos" transform="translate(-11.69,6.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2669,8 +2669,8 @@
         </g>
         <g id="173" class="nad-vl0to30-2" title="L37-38-1">
             <g>
-                <polyline points="-14.53,5.38 -12.92,3.26"/>
-                <g class="nad-edge-infos" transform="translate(-14.35,5.14)">
+                <polyline points="-14.71,5.62 -12.92,3.26"/>
+                <g class="nad-edge-infos" transform="translate(-14.53,5.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2688,8 +2688,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-11.31,1.14 -12.92,3.26"/>
-                <g class="nad-edge-infos" transform="translate(-11.49,1.38)">
+                <polyline points="-11.13,0.90 -12.92,3.26"/>
+                <g class="nad-edge-infos" transform="translate(-11.31,1.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2709,8 +2709,8 @@
         </g>
         <g id="174" class="nad-vl0to30-2" title="L37-39-1">
             <g>
-                <polyline points="-14.54,6.29 -13.37,7.83"/>
-                <g class="nad-edge-infos" transform="translate(-14.36,6.53)">
+                <polyline points="-14.72,6.05 -13.37,7.83"/>
+                <g class="nad-edge-infos" transform="translate(-14.54,6.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2728,8 +2728,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.21,9.38 -13.37,7.83"/>
-                <g class="nad-edge-infos" transform="translate(-12.39,9.14)">
+                <polyline points="-12.03,9.62 -13.37,7.83"/>
+                <g class="nad-edge-infos" transform="translate(-12.21,9.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2749,8 +2749,8 @@
         </g>
         <g id="175" class="nad-vl0to30-2" title="L38-44-1">
             <g>
-                <polyline points="-11.09,0.13 -11.69,-2.41"/>
-                <g class="nad-edge-infos" transform="translate(-11.16,-0.16)">
+                <polyline points="-11.03,0.43 -11.69,-2.41"/>
+                <g class="nad-edge-infos" transform="translate(-11.09,0.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-13.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2768,8 +2768,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-12.29,-4.96 -11.69,-2.41"/>
-                <g class="nad-edge-infos" transform="translate(-12.22,-4.67)">
+                <polyline points="-12.36,-5.26 -11.69,-2.41"/>
+                <g class="nad-edge-infos" transform="translate(-12.29,-4.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(166.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2789,8 +2789,8 @@
         </g>
         <g id="176" class="nad-vl0to30-2" title="L38-49-1">
             <g>
-                <polyline points="-10.75,0.16 -9.90,-1.91"/>
-                <g class="nad-edge-infos" transform="translate(-10.64,-0.12)">
+                <polyline points="-10.86,0.44 -9.90,-1.91"/>
+                <g class="nad-edge-infos" transform="translate(-10.75,0.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2808,8 +2808,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.06,-3.98 -9.90,-1.91"/>
-                <g class="nad-edge-infos" transform="translate(-9.17,-3.70)">
+                <polyline points="-8.95,-4.26 -9.90,-1.91"/>
+                <g class="nad-edge-infos" transform="translate(-9.06,-3.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2829,8 +2829,8 @@
         </g>
         <g id="177" class="nad-vl0to30-2" title="L38-48-1">
             <g>
-                <polyline points="-11.36,0.28 -12.80,-1.17"/>
-                <g class="nad-edge-infos" transform="translate(-11.57,0.07)">
+                <polyline points="-11.15,0.50 -12.80,-1.17"/>
+                <g class="nad-edge-infos" transform="translate(-11.36,0.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2848,8 +2848,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-14.23,-2.63 -12.80,-1.17"/>
-                <g class="nad-edge-infos" transform="translate(-14.02,-2.42)">
+                <polyline points="-14.44,-2.84 -12.80,-1.17"/>
+                <g class="nad-edge-infos" transform="translate(-14.23,-2.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2869,8 +2869,8 @@
         </g>
         <g id="178" title="T39-57-1">
             <g class="nad-vl0to30-2">
-                <polyline points="-11.32,9.69 -9.91,9.35"/>
-                <g class="nad-edge-infos" transform="translate(-11.02,9.62)">
+                <polyline points="-11.61,9.77 -9.91,9.35"/>
+                <g class="nad-edge-infos" transform="translate(-11.32,9.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2889,8 +2889,8 @@
                 <circle cx="-10.01" cy="9.37" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-8.51,9.00 -9.91,9.35"/>
-                <g class="nad-edge-infos" transform="translate(-8.80,9.07)">
+                <polyline points="-8.22,8.93 -9.91,9.35"/>
+                <g class="nad-edge-infos" transform="translate(-8.51,9.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2911,8 +2911,8 @@
         </g>
         <g id="179" title="T40-56-1">
             <g class="nad-vl0to30-2">
-                <polyline points="-10.70,6.01 -8.70,5.34"/>
-                <g class="nad-edge-infos" transform="translate(-10.42,5.92)">
+                <polyline points="-10.99,6.11 -8.70,5.34"/>
+                <g class="nad-edge-infos" transform="translate(-10.70,6.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2931,8 +2931,8 @@
                 <circle cx="-8.79" cy="5.37" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-6.69,4.67 -8.70,5.34"/>
-                <g class="nad-edge-infos" transform="translate(-6.98,4.77)">
+                <polyline points="-6.41,4.58 -8.70,5.34"/>
+                <g class="nad-edge-infos" transform="translate(-6.69,4.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2953,8 +2953,8 @@
         </g>
         <g id="180" class="nad-vl0to30-5" title="L41-42-1">
             <g>
-                <polyline points="-1.80,0.43 -2.13,1.62"/>
-                <g class="nad-edge-infos" transform="translate(-1.88,0.72)">
+                <polyline points="-1.73,0.14 -2.13,1.62"/>
+                <g class="nad-edge-infos" transform="translate(-1.80,0.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2972,8 +2972,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.45,2.80 -2.13,1.62"/>
-                <g class="nad-edge-infos" transform="translate(-2.37,2.51)">
+                <polyline points="-2.52,3.09 -2.13,1.62"/>
+                <g class="nad-edge-infos" transform="translate(-2.45,2.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -2993,8 +2993,8 @@
         </g>
         <g id="181" class="nad-vl0to30-5" title="L41-43-1">
             <g>
-                <polyline points="-1.17,-0.42 -0.09,-1.11"/>
-                <g class="nad-edge-infos" transform="translate(-0.92,-0.58)">
+                <polyline points="-1.43,-0.26 -0.09,-1.11"/>
+                <g class="nad-edge-infos" transform="translate(-1.17,-0.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(57.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3012,8 +3012,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="0.99,-1.79 -0.09,-1.11"/>
-                <g class="nad-edge-infos" transform="translate(0.73,-1.63)">
+                <polyline points="1.24,-1.95 -0.09,-1.11"/>
+                <g class="nad-edge-infos" transform="translate(0.99,-1.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-122.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3033,8 +3033,8 @@
         </g>
         <g id="182" class="nad-vl0to30-5" title="L56-41-1">
             <g>
-                <polyline points="-5.76,4.08 -3.91,2.19"/>
-                <g class="nad-edge-infos" transform="translate(-5.55,3.87)">
+                <polyline points="-5.97,4.30 -3.91,2.19"/>
+                <g class="nad-edge-infos" transform="translate(-5.76,4.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3052,8 +3052,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.05,0.29 -3.91,2.19"/>
-                <g class="nad-edge-infos" transform="translate(-2.26,0.50)">
+                <polyline points="-1.84,0.07 -3.91,2.19"/>
+                <g class="nad-edge-infos" transform="translate(-2.05,0.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3073,8 +3073,8 @@
         </g>
         <g id="183" class="nad-vl0to30-5" title="L56-42-1">
             <g>
-                <polyline points="-5.61,4.32 -4.37,3.92"/>
-                <g class="nad-edge-infos" transform="translate(-5.33,4.23)">
+                <polyline points="-5.90,4.41 -4.37,3.92"/>
+                <g class="nad-edge-infos" transform="translate(-5.61,4.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(72.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3092,8 +3092,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.14,3.53 -4.37,3.92"/>
-                <g class="nad-edge-infos" transform="translate(-3.42,3.62)">
+                <polyline points="-2.85,3.43 -4.37,3.92"/>
+                <g class="nad-edge-infos" transform="translate(-3.14,3.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-107.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3113,8 +3113,8 @@
         </g>
         <g id="184" class="nad-vl0to30-2" title="L44-45-1">
             <g>
-                <polyline points="-12.21,-6.05 -11.49,-7.83"/>
-                <g class="nad-edge-infos" transform="translate(-12.09,-6.33)">
+                <polyline points="-12.32,-5.77 -11.49,-7.83"/>
+                <g class="nad-edge-infos" transform="translate(-12.21,-6.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3132,8 +3132,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-10.77,-9.62 -11.49,-7.83"/>
-                <g class="nad-edge-infos" transform="translate(-10.89,-9.34)">
+                <polyline points="-10.66,-9.90 -11.49,-7.83"/>
+                <g class="nad-edge-infos" transform="translate(-10.77,-9.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3153,8 +3153,8 @@
         </g>
         <g id="185" class="nad-vl0to30-2" title="L46-47-1">
             <g>
-                <polyline points="-15.83,-12.07 -16.64,-10.25"/>
-                <g class="nad-edge-infos" transform="translate(-15.95,-11.80)">
+                <polyline points="-15.70,-12.35 -16.64,-10.25"/>
+                <g class="nad-edge-infos" transform="translate(-15.83,-12.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3172,8 +3172,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-17.46,-8.43 -16.64,-10.25"/>
-                <g class="nad-edge-infos" transform="translate(-17.34,-8.71)">
+                <polyline points="-17.58,-8.16 -16.64,-10.25"/>
+                <g class="nad-edge-infos" transform="translate(-17.46,-8.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3193,8 +3193,8 @@
         </g>
         <g id="186" class="nad-vl0to30-2" title="L47-48-1">
             <g>
-                <polyline points="-17.39,-7.43 -16.16,-5.47"/>
-                <g class="nad-edge-infos" transform="translate(-17.23,-7.18)">
+                <polyline points="-17.55,-7.68 -16.16,-5.47"/>
+                <g class="nad-edge-infos" transform="translate(-17.39,-7.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3212,8 +3212,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-14.94,-3.52 -16.16,-5.47"/>
-                <g class="nad-edge-infos" transform="translate(-15.10,-3.77)">
+                <polyline points="-14.78,-3.26 -16.16,-5.47"/>
+                <g class="nad-edge-infos" transform="translate(-14.94,-3.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3233,8 +3233,8 @@
         </g>
         <g id="187" class="nad-vl0to30-2" title="L48-49-1">
             <g>
-                <polyline points="-14.08,-3.18 -11.74,-3.77"/>
-                <g class="nad-edge-infos" transform="translate(-13.79,-3.25)">
+                <polyline points="-14.37,-3.10 -11.74,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-14.08,-3.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3252,8 +3252,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-9.40,-4.37 -11.74,-3.77"/>
-                <g class="nad-edge-infos" transform="translate(-9.69,-4.29)">
+                <polyline points="-9.11,-4.44 -11.74,-3.77"/>
+                <g class="nad-edge-infos" transform="translate(-9.40,-4.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3273,8 +3273,8 @@
         </g>
         <g id="188" class="nad-vl0to30-2" title="L49-50-1">
             <g>
-                <polyline points="-8.32,-4.72 -7.17,-5.18"/>
-                <g class="nad-edge-infos" transform="translate(-8.04,-4.83)">
+                <polyline points="-8.59,-4.61 -7.17,-5.18"/>
+                <g class="nad-edge-infos" transform="translate(-8.32,-4.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3292,8 +3292,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.02,-5.64 -7.17,-5.18"/>
-                <g class="nad-edge-infos" transform="translate(-6.30,-5.53)">
+                <polyline points="-5.74,-5.75 -7.17,-5.18"/>
+                <g class="nad-edge-infos" transform="translate(-6.02,-5.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3313,8 +3313,8 @@
         </g>
         <g id="189" class="nad-vl0to30-2" title="L50-51-1">
             <g>
-                <polyline points="-5.01,-6.15 -3.64,-6.99"/>
-                <g class="nad-edge-infos" transform="translate(-4.75,-6.31)">
+                <polyline points="-5.26,-5.99 -3.64,-6.99"/>
+                <g class="nad-edge-infos" transform="translate(-5.01,-6.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3332,8 +3332,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-2.28,-7.83 -3.64,-6.99"/>
-                <g class="nad-edge-infos" transform="translate(-2.53,-7.68)">
+                <polyline points="-2.02,-7.99 -3.64,-6.99"/>
+                <g class="nad-edge-infos" transform="translate(-2.28,-7.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3353,8 +3353,8 @@
         </g>
         <g id="190" class="nad-vl0to30-4" title="L52-53-1">
             <g>
-                <polyline points="22.29,-5.09 21.90,-7.01"/>
-                <g class="nad-edge-infos" transform="translate(22.23,-5.39)">
+                <polyline points="22.35,-4.80 21.90,-7.01"/>
+                <g class="nad-edge-infos" transform="translate(22.29,-5.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3372,8 +3372,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="21.51,-8.93 21.90,-7.01"/>
-                <g class="nad-edge-infos" transform="translate(21.57,-8.63)">
+                <polyline points="21.45,-9.22 21.90,-7.01"/>
+                <g class="nad-edge-infos" transform="translate(21.51,-8.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3393,8 +3393,8 @@
         </g>
         <g id="191" class="nad-vl0to30-4" title="L53-54-1">
             <g>
-                <polyline points="20.98,-9.88 19.52,-11.25"/>
-                <g class="nad-edge-infos" transform="translate(20.76,-10.08)">
+                <polyline points="21.20,-9.67 19.52,-11.25"/>
+                <g class="nad-edge-infos" transform="translate(20.98,-9.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3412,8 +3412,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="18.06,-12.63 19.52,-11.25"/>
-                <g class="nad-edge-infos" transform="translate(18.28,-12.43)">
+                <polyline points="17.84,-12.84 19.52,-11.25"/>
+                <g class="nad-edge-infos" transform="translate(18.06,-12.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3433,8 +3433,8 @@
         </g>
         <g id="192" class="nad-vl0to30-4" title="L54-55-1">
             <g>
-                <polyline points="17.08,-13.11 14.90,-13.46"/>
-                <g class="nad-edge-infos" transform="translate(16.79,-13.16)">
+                <polyline points="17.38,-13.07 14.90,-13.46"/>
+                <g class="nad-edge-infos" transform="translate(17.08,-13.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3452,8 +3452,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="12.71,-13.80 14.90,-13.46"/>
-                <g class="nad-edge-infos" transform="translate(13.01,-13.76)">
+                <polyline points="12.41,-13.85 14.90,-13.46"/>
+                <g class="nad-edge-infos" transform="translate(12.71,-13.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3473,8 +3473,8 @@
         </g>
         <g id="193" class="nad-vl0to30-5" title="L57-56-1">
             <g>
-                <polyline points="-7.74,8.34 -7.06,6.68"/>
-                <g class="nad-edge-infos" transform="translate(-7.63,8.06)">
+                <polyline points="-7.86,8.62 -7.06,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-7.74,8.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3492,8 +3492,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-6.37,5.02 -7.06,6.68"/>
-                <g class="nad-edge-infos" transform="translate(-6.49,5.30)">
+                <polyline points="-6.26,4.74 -7.06,6.68"/>
+                <g class="nad-edge-infos" transform="translate(-6.37,5.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -3513,63 +3513,63 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-2.59,-19.24 -2.19,-19.24"/>
-        <polyline id="2_text_edge" points="-1.37,-15.97 -0.97,-15.97"/>
-        <polyline id="4_text_edge" points="1.11,-11.05 1.51,-11.05"/>
-        <polyline id="6_text_edge" points="7.99,-4.16 8.39,-4.16"/>
-        <polyline id="8_text_edge" points="11.34,-1.87 11.74,-1.87"/>
-        <polyline id="10_text_edge" points="12.75,-4.80 13.15,-4.80"/>
-        <polyline id="12_text_edge" points="16.65,-4.19 17.05,-4.19"/>
-        <polyline id="14_text_edge" points="12.27,-8.29 12.67,-8.29"/>
-        <polyline id="16_text_edge" points="6.16,-11.43 6.56,-11.43"/>
-        <polyline id="18_text_edge" points="3.53,-13.06 3.93,-13.06"/>
-        <polyline id="20_text_edge" points="1.90,-6.08 2.30,-6.08"/>
-        <polyline id="22_text_edge" points="2.53,-16.51 2.93,-16.51"/>
-        <polyline id="24_text_edge" points="-2.47,-11.25 -2.07,-11.25"/>
-        <polyline id="26_text_edge" points="-9.11,-14.11 -8.71,-14.11"/>
-        <polyline id="28_text_edge" points="-5.24,-13.83 -4.84,-13.83"/>
-        <polyline id="30_text_edge" points="-0.57,-22.02 -0.17,-22.02"/>
-        <polyline id="32_text_edge" points="2.53,-20.57 2.93,-20.57"/>
-        <polyline id="34_text_edge" points="8.89,1.91 9.29,1.91"/>
-        <polyline id="36_text_edge" points="9.24,6.37 9.64,6.37"/>
-        <polyline id="38_text_edge" points="6.52,9.36 6.92,9.36"/>
-        <polyline id="40_text_edge" points="2.21,9.80 2.61,9.80"/>
-        <polyline id="42_text_edge" points="-2.25,9.09 -1.85,9.09"/>
-        <polyline id="44_text_edge" points="2.35,14.60 2.75,14.60"/>
-        <polyline id="46_text_edge" points="7.58,17.50 7.98,17.50"/>
-        <polyline id="48_text_edge" points="5.20,21.73 5.60,21.73"/>
-        <polyline id="50_text_edge" points="13.26,15.31 13.66,15.31"/>
-        <polyline id="52_text_edge" points="17.45,11.38 17.85,11.38"/>
-        <polyline id="54_text_edge" points="19.92,6.15 20.32,6.15"/>
-        <polyline id="56_text_edge" points="20.55,-0.06 20.95,-0.06"/>
-        <polyline id="58_text_edge" points="1.05,23.86 1.45,23.86"/>
-        <polyline id="60_text_edge" points="-3.70,23.93 -3.30,23.93"/>
-        <polyline id="62_text_edge" points="-8.66,22.82 -8.26,22.82"/>
-        <polyline id="64_text_edge" points="-10.71,26.12 -10.31,26.12"/>
-        <polyline id="66_text_edge" points="-12.41,19.37 -12.01,19.37"/>
-        <polyline id="68_text_edge" points="-15.07,15.22 -14.67,15.22"/>
-        <polyline id="70_text_edge" points="-15.21,9.86 -14.81,9.86"/>
-        <polyline id="72_text_edge" points="-14.28,5.83 -13.88,5.83"/>
-        <polyline id="74_text_edge" points="-10.36,0.69 -9.96,0.69"/>
-        <polyline id="76_text_edge" points="-11.27,9.83 -10.87,9.83"/>
-        <polyline id="78_text_edge" points="-10.64,6.19 -10.24,6.19"/>
-        <polyline id="80_text_edge" points="-1.06,-0.12 -0.66,-0.12"/>
-        <polyline id="82_text_edge" points="-1.99,3.35 -1.59,3.35"/>
-        <polyline id="84_text_edge" points="2.07,-2.09 2.47,-2.09"/>
-        <polyline id="86_text_edge" points="-11.82,-5.52 -11.42,-5.52"/>
-        <polyline id="88_text_edge" points="-9.96,-10.15 -9.56,-10.15"/>
-        <polyline id="90_text_edge" points="-14.99,-12.59 -14.59,-12.59"/>
-        <polyline id="92_text_edge" points="-17.09,-7.91 -16.69,-7.91"/>
-        <polyline id="94_text_edge" points="-14.03,-3.04 -13.63,-3.04"/>
-        <polyline id="96_text_edge" points="-8.24,-4.51 -7.84,-4.51"/>
-        <polyline id="98_text_edge" points="-4.89,-5.85 -4.49,-5.85"/>
-        <polyline id="100_text_edge" points="-1.19,-8.13 -0.79,-8.13"/>
-        <polyline id="102_text_edge" points="23.00,-4.53 23.40,-4.53"/>
-        <polyline id="104_text_edge" points="21.99,-9.49 22.39,-9.49"/>
-        <polyline id="106_text_edge" points="18.25,-13.02 18.65,-13.02"/>
-        <polyline id="108_text_edge" points="12.75,-13.89 13.15,-13.89"/>
-        <polyline id="110_text_edge" points="-5.55,4.49 -5.15,4.49"/>
-        <polyline id="112_text_edge" points="-7.36,8.86 -6.96,8.86"/>
+        <polyline id="0_text_edge" points="-2.89,-19.24 -2.19,-19.24"/>
+        <polyline id="2_text_edge" points="-1.67,-15.97 -0.97,-15.97"/>
+        <polyline id="4_text_edge" points="0.81,-11.05 1.51,-11.05"/>
+        <polyline id="6_text_edge" points="7.69,-4.16 8.39,-4.16"/>
+        <polyline id="8_text_edge" points="11.04,-1.87 11.74,-1.87"/>
+        <polyline id="10_text_edge" points="12.45,-4.80 13.15,-4.80"/>
+        <polyline id="12_text_edge" points="16.35,-4.19 17.05,-4.19"/>
+        <polyline id="14_text_edge" points="11.97,-8.29 12.67,-8.29"/>
+        <polyline id="16_text_edge" points="5.86,-11.43 6.56,-11.43"/>
+        <polyline id="18_text_edge" points="3.23,-13.06 3.93,-13.06"/>
+        <polyline id="20_text_edge" points="1.60,-6.08 2.30,-6.08"/>
+        <polyline id="22_text_edge" points="2.23,-16.51 2.93,-16.51"/>
+        <polyline id="24_text_edge" points="-2.77,-11.25 -2.07,-11.25"/>
+        <polyline id="26_text_edge" points="-9.41,-14.11 -8.71,-14.11"/>
+        <polyline id="28_text_edge" points="-5.54,-13.83 -4.84,-13.83"/>
+        <polyline id="30_text_edge" points="-0.87,-22.02 -0.17,-22.02"/>
+        <polyline id="32_text_edge" points="2.23,-20.57 2.93,-20.57"/>
+        <polyline id="34_text_edge" points="8.59,1.91 9.29,1.91"/>
+        <polyline id="36_text_edge" points="8.94,6.37 9.64,6.37"/>
+        <polyline id="38_text_edge" points="6.22,9.36 6.92,9.36"/>
+        <polyline id="40_text_edge" points="1.91,9.80 2.61,9.80"/>
+        <polyline id="42_text_edge" points="-2.55,9.09 -1.85,9.09"/>
+        <polyline id="44_text_edge" points="2.05,14.60 2.75,14.60"/>
+        <polyline id="46_text_edge" points="7.28,17.50 7.98,17.50"/>
+        <polyline id="48_text_edge" points="4.90,21.73 5.60,21.73"/>
+        <polyline id="50_text_edge" points="12.96,15.31 13.66,15.31"/>
+        <polyline id="52_text_edge" points="17.15,11.38 17.85,11.38"/>
+        <polyline id="54_text_edge" points="19.62,6.15 20.32,6.15"/>
+        <polyline id="56_text_edge" points="20.25,-0.06 20.95,-0.06"/>
+        <polyline id="58_text_edge" points="0.75,23.86 1.45,23.86"/>
+        <polyline id="60_text_edge" points="-4.00,23.93 -3.30,23.93"/>
+        <polyline id="62_text_edge" points="-8.96,22.82 -8.26,22.82"/>
+        <polyline id="64_text_edge" points="-11.01,26.12 -10.31,26.12"/>
+        <polyline id="66_text_edge" points="-12.71,19.37 -12.01,19.37"/>
+        <polyline id="68_text_edge" points="-15.37,15.22 -14.67,15.22"/>
+        <polyline id="70_text_edge" points="-15.51,9.86 -14.81,9.86"/>
+        <polyline id="72_text_edge" points="-14.58,5.83 -13.88,5.83"/>
+        <polyline id="74_text_edge" points="-10.66,0.69 -9.96,0.69"/>
+        <polyline id="76_text_edge" points="-11.57,9.83 -10.87,9.83"/>
+        <polyline id="78_text_edge" points="-10.94,6.19 -10.24,6.19"/>
+        <polyline id="80_text_edge" points="-1.36,-0.12 -0.66,-0.12"/>
+        <polyline id="82_text_edge" points="-2.29,3.35 -1.59,3.35"/>
+        <polyline id="84_text_edge" points="1.77,-2.09 2.47,-2.09"/>
+        <polyline id="86_text_edge" points="-12.12,-5.52 -11.42,-5.52"/>
+        <polyline id="88_text_edge" points="-10.26,-10.15 -9.56,-10.15"/>
+        <polyline id="90_text_edge" points="-15.29,-12.59 -14.59,-12.59"/>
+        <polyline id="92_text_edge" points="-17.39,-7.91 -16.69,-7.91"/>
+        <polyline id="94_text_edge" points="-14.33,-3.04 -13.63,-3.04"/>
+        <polyline id="96_text_edge" points="-8.54,-4.51 -7.84,-4.51"/>
+        <polyline id="98_text_edge" points="-5.19,-5.85 -4.49,-5.85"/>
+        <polyline id="100_text_edge" points="-1.49,-8.13 -0.79,-8.13"/>
+        <polyline id="102_text_edge" points="22.70,-4.53 23.40,-4.53"/>
+        <polyline id="104_text_edge" points="21.69,-9.49 22.39,-9.49"/>
+        <polyline id="106_text_edge" points="17.95,-13.02 18.65,-13.02"/>
+        <polyline id="108_text_edge" points="12.45,-13.89 13.15,-13.89"/>
+        <polyline id="110_text_edge" points="-5.85,4.49 -5.15,4.49"/>
+        <polyline id="112_text_edge" points="-7.66,8.86 -6.96,8.86"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-2.19" y="-19.24" style="dominant-baseline:middle">VL1</text>

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -40,26 +40,26 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-5.73,0.61)" id="0" class="nad-vl180to300" title="S1VL1">
-            <circle r="0.60" id="1"/>
+            <circle r="0.30" id="1"/>
         </g>
         <g transform="translate(-1.69,0.46)" id="2" class="nad-vl300to500" title="S1VL2">
-            <circle r="0.60" id="3"/>
+            <circle r="0.30" id="3"/>
         </g>
         <g transform="translate(0.73,-2.20)" id="4" class="nad-vl300to500" title="S2VL1">
-            <circle r="0.60" id="5"/>
+            <circle r="0.30" id="5"/>
         </g>
         <g transform="translate(2.50,0.94)" id="6" class="nad-vl300to500" title="S3VL1">
-            <circle r="0.60" id="7"/>
+            <circle r="0.30" id="7"/>
         </g>
         <g transform="translate(6.34,2.21)" id="8" class="nad-vl300to500" title="S4VL1">
-            <circle r="0.60" id="9"/>
+            <circle r="0.30" id="9"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="10" title="TWT">
             <g class="nad-vl180to300">
-                <polyline points="-5.16,0.59 -3.71,0.53"/>
-                <g class="nad-edge-infos" transform="translate(-4.86,0.58)">
+                <polyline points="-5.46,0.60 -3.71,0.53"/>
+                <g class="nad-edge-infos" transform="translate(-5.16,0.59)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(87.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -78,8 +78,8 @@
                 <circle cx="-3.81" cy="0.54" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-2.26,0.48 -3.71,0.53"/>
-                <g class="nad-edge-infos" transform="translate(-2.56,0.49)">
+                <polyline points="-1.96,0.47 -3.71,0.53"/>
+                <g class="nad-edge-infos" transform="translate(-2.26,0.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -100,8 +100,8 @@
         </g>
         <g id="11" class="nad-hvdc-edge" title="HVDC1">
             <g class="nad-vl300to500">
-                <polyline points="-1.30,0.04 -0.48,-0.87"/>
-                <g class="nad-edge-infos" transform="translate(-1.10,-0.18)">
+                <polyline points="-1.51,0.26 -0.48,-0.87"/>
+                <g class="nad-edge-infos" transform="translate(-1.30,0.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -119,8 +119,8 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="0.35,-1.78 -0.48,-0.87"/>
-                <g class="nad-edge-infos" transform="translate(0.15,-1.55)">
+                <polyline points="0.55,-2.00 -0.48,-0.87"/>
+                <g class="nad-edge-infos" transform="translate(0.35,-1.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-137.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -141,8 +141,8 @@
         </g>
         <g id="12" class="nad-hvdc-edge" title="HVDC2">
             <g class="nad-vl300to500">
-                <polyline points="-1.12,0.52 0.41,0.70"/>
-                <g class="nad-edge-infos" transform="translate(-0.82,0.56)">
+                <polyline points="-1.42,0.49 0.41,0.70"/>
+                <g class="nad-edge-infos" transform="translate(-1.12,0.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -160,8 +160,8 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="1.94,0.87 0.41,0.70"/>
-                <g class="nad-edge-infos" transform="translate(1.64,0.84)">
+                <polyline points="2.24,0.91 0.41,0.70"/>
+                <g class="nad-edge-infos" transform="translate(1.94,0.87)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-83.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -182,8 +182,8 @@
         </g>
         <g id="13" class="nad-vl300to500" title="LINE_S2S3">
             <g>
-                <polyline points="1.01,-1.70 1.62,-0.63"/>
-                <g class="nad-edge-infos" transform="translate(1.16,-1.44)">
+                <polyline points="0.87,-1.96 1.62,-0.63"/>
+                <g class="nad-edge-infos" transform="translate(1.01,-1.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -201,8 +201,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.22,0.44 1.62,-0.63"/>
-                <g class="nad-edge-infos" transform="translate(2.08,0.18)">
+                <polyline points="2.37,0.70 1.62,-0.63"/>
+                <g class="nad-edge-infos" transform="translate(2.22,0.44)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-29.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -222,8 +222,8 @@
         </g>
         <g id="14" class="nad-vl300to500" title="LINE_S3S4">
             <g>
-                <polyline points="3.05,1.12 4.42,1.58"/>
-                <g class="nad-edge-infos" transform="translate(3.33,1.21)">
+                <polyline points="2.76,1.02 4.42,1.58"/>
+                <g class="nad-edge-infos" transform="translate(3.05,1.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -241,8 +241,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="5.80,2.03 4.42,1.58"/>
-                <g class="nad-edge-infos" transform="translate(5.51,1.94)">
+                <polyline points="6.08,2.13 4.42,1.58"/>
+                <g class="nad-edge-infos" transform="translate(5.80,2.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-71.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -262,11 +262,11 @@
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-5.13,0.61 -4.73,0.61"/>
-        <polyline id="2_text_edge" points="-1.09,0.46 -0.69,0.46"/>
-        <polyline id="4_text_edge" points="1.33,-2.20 1.73,-2.20"/>
-        <polyline id="6_text_edge" points="3.10,0.94 3.50,0.94"/>
-        <polyline id="8_text_edge" points="6.94,2.21 7.34,2.21"/>
+        <polyline id="0_text_edge" points="-5.43,0.61 -4.73,0.61"/>
+        <polyline id="2_text_edge" points="-1.39,0.46 -0.69,0.46"/>
+        <polyline id="4_text_edge" points="1.03,-2.20 1.73,-2.20"/>
+        <polyline id="6_text_edge" points="2.80,0.94 3.50,0.94"/>
+        <polyline id="8_text_edge" points="6.64,2.21 7.34,2.21"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-4.73" y="0.61" style="dominant-baseline:middle">S1VL1</text>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -44,32 +44,32 @@
             <path d="M-0.077,0.595 A0.600,0.600 28.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -18.646 0 0 -0.063,0.293 Z M-0.425,0.424 A0.600,0.600 32.706 0 1 -0.586,0.127 L-0.287,0.088 A0.300,0.300 -23.157 0 0 -0.229,0.193 Z M-0.599,0.028 A0.600,0.600 270.451 1 1 0.023,0.600 L0.037,0.298 A0.300,0.300 -260.901 1 0 -0.300,-0.011 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
-            <circle r="0.60" id="4"/>
+            <circle r="0.30" id="4"/>
         </g>
         <g transform="translate(7.06,2.74)" id="5" class="nad-vl300to500" title="DDE1AA1">
-            <circle r="0.60" id="6"/>
+            <circle r="0.30" id="6"/>
         </g>
         <g transform="translate(4.50,0.01)" id="7" class="nad-vl300to500" title="DDE2AA1">
-            <circle r="0.60" id="8"/>
+            <circle r="0.30" id="8"/>
         </g>
         <g transform="translate(3.75,4.37)" id="9" class="nad-vl300to500" title="DDE3AA1">
-            <circle r="0.60" id="10"/>
+            <circle r="0.30" id="10"/>
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
             <path d="M-0.392,-0.455 A0.600,0.600 57.675 0 1 0.175,-0.574 L0.063,-0.293 A0.300,0.300 -48.126 0 0 -0.176,-0.243 Z M0.268,-0.537 A0.600,0.600 70.451 0 1 0.596,0.073 L0.300,0.011 A0.300,0.300 -60.901 0 0 0.156,-0.256 Z M0.575,0.170 A0.600,0.600 203.226 1 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -193.677 1 0 0.280,0.109 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(1.23,-8.03)" id="16" class="nad-vl300to500" title="NNL1AA1">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-1.50,-5.35)" id="18" class="nad-vl300to500" title="NNL2AA1">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(2.52,-4.42)" id="20" class="nad-vl300to500" title="NNL3AA1">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
@@ -94,7 +94,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.73,1.78 -5.81,1.56 -5.53,0.04"/>
+                <polyline points="-5.63,2.06 -5.81,1.56 -5.53,0.04"/>
                 <g class="nad-edge-infos" transform="translate(-5.76,1.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -197,7 +197,7 @@
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-5.17,1.88 -5.02,1.70 -4.75,0.19"/>
+                <polyline points="-5.37,2.11 -5.02,1.70 -4.75,0.19"/>
                 <g class="nad-edge-infos" transform="translate(-4.97,1.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -237,8 +237,8 @@
         </g>
         <g id="26" class="nad-vl300to500" title="NNL2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-1.90,-4.94 -3.12,-3.71"/>
-                <g class="nad-edge-infos" transform="translate(-2.11,-4.73)">
+                <polyline points="-1.69,-5.16 -3.01,-3.82"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,-4.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -256,7 +256,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.34,-2.48 -3.12,-3.71"/>
+                <polyline points="-4.34,-2.48 -3.01,-3.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.13,-2.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -277,8 +277,8 @@
         </g>
         <g id="27" class="nad-vl300to500" title="BBE2AA1  FFR3AA1  1">
             <g>
-                <polyline points="-5.30,2.83 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-5.18,3.10)">
+                <polyline points="-5.43,2.56 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-5.30,2.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -296,8 +296,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.96,5.74 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-4.09,5.47)">
+                <polyline points="-3.83,6.02 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-3.96,5.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -317,8 +317,8 @@
         </g>
         <g id="28" class="nad-vl300to500" title="DDE1AA1  DDE2AA1  1">
             <g>
-                <polyline points="6.67,2.33 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(6.46,2.11)">
+                <polyline points="6.87,2.54 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(6.67,2.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -336,8 +336,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.89,0.42 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(5.10,0.64)">
+                <polyline points="4.69,0.20 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(4.89,0.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -357,8 +357,8 @@
         </g>
         <g id="29" class="nad-vl300to500" title="DDE1AA1  DDE3AA1  1">
             <g>
-                <polyline points="6.54,2.99 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(6.28,3.13)">
+                <polyline points="6.81,2.86 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(6.54,2.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -376,8 +376,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.26,4.12 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(4.53,3.98)">
+                <polyline points="3.99,4.25 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(4.26,4.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -397,8 +397,8 @@
         </g>
         <g id="30" class="nad-vl300to500" title="DDE2AA1  DDE3AA1  1">
             <g>
-                <polyline points="4.40,0.57 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(4.35,0.86)">
+                <polyline points="4.46,0.27 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(4.40,0.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -416,8 +416,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.85,3.81 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(3.90,3.51)">
+                <polyline points="3.79,4.10 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(3.85,3.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -437,8 +437,8 @@
         </g>
         <g id="31" class="nad-vl300to500" title="DDE2AA1  NNL3AA1  1">
             <g>
-                <polyline points="4.27,-0.51 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(4.15,-0.79)">
+                <polyline points="4.39,-0.24 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(4.27,-0.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -456,8 +456,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.75,-3.90 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(2.88,-3.63)">
+                <polyline points="2.63,-4.18 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(2.75,-3.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -477,7 +477,7 @@
         </g>
         <g id="32" class="nad-vl300to500" title="FFR2AA1  DDE3AA1  1">
             <g>
-                <polyline points="0.79,6.94 2.06,5.84"/>
+                <polyline points="0.79,6.94 2.17,5.74"/>
                 <g class="nad-edge-infos" transform="translate(1.02,6.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -496,8 +496,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.32,4.74 2.06,5.84"/>
-                <g class="nad-edge-infos" transform="translate(3.09,4.94)">
+                <polyline points="3.55,4.55 2.17,5.74"/>
+                <g class="nad-edge-infos" transform="translate(3.32,4.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -576,7 +576,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.17,6.11 -2.95,6.05 -1.58,6.40"/>
+                <polyline points="-3.46,6.19 -2.95,6.05 -1.58,6.40"/>
                 <g class="nad-edge-infos" transform="translate(-2.66,6.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -658,7 +658,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.31,6.66 -3.15,6.82 -1.78,7.18"/>
+                <polyline points="-3.53,6.45 -3.15,6.82 -1.78,7.18"/>
                 <g class="nad-edge-infos" transform="translate(-2.86,6.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -679,8 +679,8 @@
         </g>
         <g id="37" class="nad-vl300to500" title="NNL1AA1  NNL2AA1  1">
             <g>
-                <polyline points="0.82,-7.63 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(0.61,-7.42)">
+                <polyline points="1.04,-7.85 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(0.82,-7.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -698,8 +698,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.09,-5.75 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(-0.88,-5.96)">
+                <polyline points="-1.30,-5.54 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.09,-5.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -719,8 +719,8 @@
         </g>
         <g id="38" class="nad-vl300to500" title="NNL1AA1  NNL3AA1  1">
             <g>
-                <polyline points="1.42,-7.50 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(1.52,-7.22)">
+                <polyline points="1.32,-7.78 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(1.42,-7.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -738,8 +738,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.33,-4.96 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(2.23,-5.24)">
+                <polyline points="2.43,-4.68 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(2.33,-4.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -759,8 +759,8 @@
         </g>
         <g id="39" class="nad-vl300to500" title="NNL2AA1  NNL3AA1  1">
             <g>
-                <polyline points="-0.94,-5.22 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(-0.65,-5.15)">
+                <polyline points="-1.23,-5.29 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-5.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -778,8 +778,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.96,-4.55 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(1.67,-4.62)">
+                <polyline points="2.26,-4.48 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(1.96,-4.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -800,15 +800,15 @@
     </g>
     <g class="nad-text-edges">
         <polyline id="0_text_edge" points="-4.14,-2.08 -3.74,-2.08"/>
-        <polyline id="3_text_edge" points="-4.94,2.31 -4.54,2.31"/>
-        <polyline id="5_text_edge" points="7.66,2.74 8.06,2.74"/>
-        <polyline id="7_text_edge" points="5.10,0.01 5.50,0.01"/>
-        <polyline id="9_text_edge" points="4.35,4.37 4.75,4.37"/>
+        <polyline id="3_text_edge" points="-5.24,2.31 -4.54,2.31"/>
+        <polyline id="5_text_edge" points="7.36,2.74 8.06,2.74"/>
+        <polyline id="7_text_edge" points="4.80,0.01 5.50,0.01"/>
+        <polyline id="9_text_edge" points="4.05,4.37 4.75,4.37"/>
         <polyline id="11_text_edge" points="0.96,7.32 1.36,7.32"/>
-        <polyline id="14_text_edge" points="-3.12,6.26 -2.72,6.26"/>
-        <polyline id="16_text_edge" points="1.83,-8.03 2.23,-8.03"/>
-        <polyline id="18_text_edge" points="-0.90,-5.35 -0.50,-5.35"/>
-        <polyline id="20_text_edge" points="3.12,-4.42 3.52,-4.42"/>
+        <polyline id="14_text_edge" points="-3.42,6.26 -2.72,6.26"/>
+        <polyline id="16_text_edge" points="1.53,-8.03 2.23,-8.03"/>
+        <polyline id="18_text_edge" points="-1.20,-5.35 -0.50,-5.35"/>
+        <polyline id="20_text_edge" points="2.82,-4.42 3.52,-4.42"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-3.74" y="-2.08" style="dominant-baseline:middle">BBE1AA1</text>

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -44,32 +44,32 @@
             <path d="M-0.028,-0.599 A0.600,0.600 60.451 0 1 0.508,-0.320 L0.240,-0.181 A0.300,0.300 -50.901 0 0 0.011,-0.300 Z M0.554,-0.231 A0.600,0.600 148.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -138.646 0 0 0.285,-0.092 Z M-0.425,0.424 A0.600,0.600 122.706 0 1 -0.127,-0.586 L-0.088,-0.287 A0.300,0.300 -113.157 0 0 -0.229,0.193 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
-            <circle r="0.60" id="4"/>
+            <circle r="0.30" id="4"/>
         </g>
         <g transform="translate(7.06,2.74)" id="5" class="nad-vl300to500" title="DDE1AA1">
-            <circle r="0.60" id="6"/>
+            <circle r="0.30" id="6"/>
         </g>
         <g transform="translate(4.50,0.01)" id="7" class="nad-vl300to500" title="DDE2AA1">
-            <circle r="0.60" id="8"/>
+            <circle r="0.30" id="8"/>
         </g>
         <g transform="translate(3.75,4.37)" id="9" class="nad-vl300to500" title="DDE3AA1">
-            <circle r="0.60" id="10"/>
+            <circle r="0.30" id="10"/>
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
             <path d="M-0.392,-0.455 A0.600,0.600 100.084 0 1 0.516,-0.306 L0.244,-0.174 A0.300,0.300 -90.534 0 0 -0.176,-0.243 Z M0.560,-0.216 A0.600,0.600 165.634 0 1 -0.489,0.348 L-0.229,0.194 A0.300,0.300 -156.085 0 0 0.288,-0.084 Z M-0.540,0.262 A0.600,0.600 65.634 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -56.085 0 0 -0.280,0.108 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(1.23,-8.03)" id="16" class="nad-vl300to500" title="NNL1AA1">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-1.50,-5.35)" id="18" class="nad-vl300to500" title="NNL2AA1">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(2.52,-4.42)" id="20" class="nad-vl300to500" title="NNL3AA1">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
@@ -94,7 +94,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.73,1.78 -5.81,1.56 -5.53,0.04"/>
+                <polyline points="-5.63,2.06 -5.81,1.56 -5.53,0.04"/>
                 <g class="nad-edge-infos" transform="translate(-5.76,1.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -197,7 +197,7 @@
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-5.17,1.88 -5.02,1.70 -4.75,0.19"/>
+                <polyline points="-5.37,2.11 -5.02,1.70 -4.75,0.19"/>
                 <g class="nad-edge-infos" transform="translate(-4.97,1.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -237,8 +237,8 @@
         </g>
         <g id="26" class="nad-vl300to500" title="NNL2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-1.90,-4.94 -3.12,-3.71"/>
-                <g class="nad-edge-infos" transform="translate(-2.11,-4.73)">
+                <polyline points="-1.69,-5.16 -3.01,-3.82"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,-4.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -256,7 +256,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.34,-2.48 -3.12,-3.71"/>
+                <polyline points="-4.34,-2.48 -3.01,-3.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.13,-2.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -277,8 +277,8 @@
         </g>
         <g id="27" class="nad-vl300to500" title="BBE2AA1  FFR3AA1  1">
             <g>
-                <polyline points="-5.30,2.83 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-5.18,3.10)">
+                <polyline points="-5.43,2.56 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-5.30,2.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -296,8 +296,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.96,5.74 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-4.09,5.47)">
+                <polyline points="-3.83,6.02 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-3.96,5.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -317,8 +317,8 @@
         </g>
         <g id="28" class="nad-vl300to500" title="DDE1AA1  DDE2AA1  1">
             <g>
-                <polyline points="6.67,2.33 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(6.46,2.11)">
+                <polyline points="6.87,2.54 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(6.67,2.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -336,8 +336,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.89,0.42 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(5.10,0.64)">
+                <polyline points="4.69,0.20 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(4.89,0.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -357,8 +357,8 @@
         </g>
         <g id="29" class="nad-vl300to500" title="DDE1AA1  DDE3AA1  1">
             <g>
-                <polyline points="6.54,2.99 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(6.28,3.13)">
+                <polyline points="6.81,2.86 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(6.54,2.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -376,8 +376,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.26,4.12 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(4.53,3.98)">
+                <polyline points="3.99,4.25 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(4.26,4.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -397,8 +397,8 @@
         </g>
         <g id="30" class="nad-vl300to500" title="DDE2AA1  DDE3AA1  1">
             <g>
-                <polyline points="4.40,0.57 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(4.35,0.86)">
+                <polyline points="4.46,0.27 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(4.40,0.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -416,8 +416,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.85,3.81 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(3.90,3.51)">
+                <polyline points="3.79,4.10 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(3.85,3.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -437,8 +437,8 @@
         </g>
         <g id="31" class="nad-vl300to500" title="DDE2AA1  NNL3AA1  1">
             <g>
-                <polyline points="4.27,-0.51 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(4.15,-0.79)">
+                <polyline points="4.39,-0.24 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(4.27,-0.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -456,8 +456,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.75,-3.90 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(2.88,-3.63)">
+                <polyline points="2.63,-4.18 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(2.75,-3.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -477,7 +477,7 @@
         </g>
         <g id="32" class="nad-vl300to500" title="FFR2AA1  DDE3AA1  1">
             <g>
-                <polyline points="0.79,6.94 2.06,5.84"/>
+                <polyline points="0.79,6.94 2.17,5.74"/>
                 <g class="nad-edge-infos" transform="translate(1.02,6.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -496,8 +496,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.32,4.74 2.06,5.84"/>
-                <g class="nad-edge-infos" transform="translate(3.09,4.94)">
+                <polyline points="3.55,4.55 2.17,5.74"/>
+                <g class="nad-edge-infos" transform="translate(3.32,4.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -576,7 +576,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.17,6.11 -2.95,6.05 -1.58,6.40"/>
+                <polyline points="-3.46,6.19 -2.95,6.05 -1.58,6.40"/>
                 <g class="nad-edge-infos" transform="translate(-2.66,6.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -658,7 +658,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.31,6.66 -3.15,6.82 -1.78,7.18"/>
+                <polyline points="-3.53,6.45 -3.15,6.82 -1.78,7.18"/>
                 <g class="nad-edge-infos" transform="translate(-2.86,6.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -679,8 +679,8 @@
         </g>
         <g id="37" class="nad-vl300to500" title="NNL1AA1  NNL2AA1  1">
             <g>
-                <polyline points="0.82,-7.63 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(0.61,-7.42)">
+                <polyline points="1.04,-7.85 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(0.82,-7.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -698,8 +698,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.09,-5.75 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(-0.88,-5.96)">
+                <polyline points="-1.30,-5.54 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.09,-5.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -719,8 +719,8 @@
         </g>
         <g id="38" class="nad-vl300to500" title="NNL1AA1  NNL3AA1  1">
             <g>
-                <polyline points="1.42,-7.50 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(1.52,-7.22)">
+                <polyline points="1.32,-7.78 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(1.42,-7.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -738,8 +738,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.33,-4.96 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(2.23,-5.24)">
+                <polyline points="2.43,-4.68 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(2.33,-4.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -759,8 +759,8 @@
         </g>
         <g id="39" class="nad-vl300to500" title="NNL2AA1  NNL3AA1  1">
             <g>
-                <polyline points="-0.94,-5.22 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(-0.65,-5.15)">
+                <polyline points="-1.23,-5.29 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-5.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -778,8 +778,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.96,-4.55 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(1.67,-4.62)">
+                <polyline points="2.26,-4.48 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(1.96,-4.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -800,15 +800,15 @@
     </g>
     <g class="nad-text-edges">
         <polyline id="0_text_edge" points="-4.14,-2.08 -3.74,-2.08"/>
-        <polyline id="3_text_edge" points="-4.94,2.31 -4.54,2.31"/>
-        <polyline id="5_text_edge" points="7.66,2.74 8.06,2.74"/>
-        <polyline id="7_text_edge" points="5.10,0.01 5.50,0.01"/>
-        <polyline id="9_text_edge" points="4.35,4.37 4.75,4.37"/>
+        <polyline id="3_text_edge" points="-5.24,2.31 -4.54,2.31"/>
+        <polyline id="5_text_edge" points="7.36,2.74 8.06,2.74"/>
+        <polyline id="7_text_edge" points="4.80,0.01 5.50,0.01"/>
+        <polyline id="9_text_edge" points="4.05,4.37 4.75,4.37"/>
         <polyline id="11_text_edge" points="0.96,7.32 1.36,7.32"/>
-        <polyline id="14_text_edge" points="-3.12,6.26 -2.72,6.26"/>
-        <polyline id="16_text_edge" points="1.83,-8.03 2.23,-8.03"/>
-        <polyline id="18_text_edge" points="-0.90,-5.35 -0.50,-5.35"/>
-        <polyline id="20_text_edge" points="3.12,-4.42 3.52,-4.42"/>
+        <polyline id="14_text_edge" points="-3.42,6.26 -2.72,6.26"/>
+        <polyline id="16_text_edge" points="1.53,-8.03 2.23,-8.03"/>
+        <polyline id="18_text_edge" points="-1.20,-5.35 -0.50,-5.35"/>
+        <polyline id="20_text_edge" points="2.82,-4.42 3.52,-4.42"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-3.74" y="-2.08" style="dominant-baseline:middle">BBE1AA1</text>

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -44,32 +44,32 @@
             <path d="M-0.132,-0.585 A0.600,0.600 80.451 0 1 0.555,-0.227 L0.267,-0.136 A0.300,0.300 -70.901 0 0 -0.041,-0.297 Z M0.585,-0.132 A0.600,0.600 138.195 0 1 -0.349,0.488 L-0.153,0.258 A0.300,0.300 -128.646 0 0 0.297,-0.041 Z M-0.425,0.424 A0.600,0.600 112.706 0 1 -0.227,-0.555 L-0.136,-0.267 A0.300,0.300 -103.157 0 0 -0.229,0.193 Z " id="2"/>
         </g>
         <g transform="translate(-5.54,2.31)" id="3" class="nad-vl300to500" title="BBE2AA1">
-            <circle r="0.60" id="4"/>
+            <circle r="0.30" id="4"/>
         </g>
         <g transform="translate(7.06,2.74)" id="5" class="nad-vl300to500" title="DDE1AA1">
-            <circle r="0.60" id="6"/>
+            <circle r="0.30" id="6"/>
         </g>
         <g transform="translate(4.50,0.01)" id="7" class="nad-vl300to500" title="DDE2AA1">
-            <circle r="0.60" id="8"/>
+            <circle r="0.30" id="8"/>
         </g>
         <g transform="translate(3.75,4.37)" id="9" class="nad-vl300to500" title="DDE3AA1">
-            <circle r="0.60" id="10"/>
+            <circle r="0.30" id="10"/>
         </g>
         <g transform="translate(0.36,7.32)" id="11" class="nad-vl300to500" title="FFR1AA1">
             <circle r="0.30" id="12"/>
             <path d="M-0.239,-0.550 A0.600,0.600 200.451 1 1 0.032,0.599 L0.041,0.297 A0.300,0.300 -190.901 1 0 -0.096,-0.284 Z M-0.068,0.596 A0.600,0.600 123.226 0 1 -0.462,-0.383 L-0.246,-0.172 A0.300,0.300 -113.677 0 0 -0.059,0.294 Z " id="13"/>
         </g>
         <g transform="translate(-3.72,6.26)" id="14" class="nad-vl300to500" title="FFR3AA1">
-            <circle r="0.60" id="15"/>
+            <circle r="0.30" id="15"/>
         </g>
         <g transform="translate(1.23,-8.03)" id="16" class="nad-vl300to500" title="NNL1AA1">
-            <circle r="0.60" id="17"/>
+            <circle r="0.30" id="17"/>
         </g>
         <g transform="translate(-1.50,-5.35)" id="18" class="nad-vl300to500" title="NNL2AA1">
-            <circle r="0.60" id="19"/>
+            <circle r="0.30" id="19"/>
         </g>
         <g transform="translate(2.52,-4.42)" id="20" class="nad-vl300to500" title="NNL3AA1">
-            <circle r="0.60" id="21"/>
+            <circle r="0.30" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
@@ -94,7 +94,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-5.73,1.78 -5.81,1.56 -5.53,0.04"/>
+                <polyline points="-5.63,2.06 -5.81,1.56 -5.53,0.04"/>
                 <g class="nad-edge-infos" transform="translate(-5.76,1.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -197,7 +197,7 @@
         </g>
         <g id="25" class="nad-vl300to500" title="BBE2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-5.17,1.88 -5.02,1.70 -4.75,0.19"/>
+                <polyline points="-5.37,2.11 -5.02,1.70 -4.75,0.19"/>
                 <g class="nad-edge-infos" transform="translate(-4.97,1.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -237,8 +237,8 @@
         </g>
         <g id="26" class="nad-vl300to500" title="NNL2AA1  BBE3AA1  1">
             <g>
-                <polyline points="-1.90,-4.94 -3.12,-3.71"/>
-                <g class="nad-edge-infos" transform="translate(-2.11,-4.73)">
+                <polyline points="-1.69,-5.16 -3.01,-3.82"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,-4.94)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -256,7 +256,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-4.34,-2.48 -3.12,-3.71"/>
+                <polyline points="-4.34,-2.48 -3.01,-3.82"/>
                 <g class="nad-edge-infos" transform="translate(-4.13,-2.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -277,8 +277,8 @@
         </g>
         <g id="27" class="nad-vl300to500" title="BBE2AA1  FFR3AA1  1">
             <g>
-                <polyline points="-5.30,2.83 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-5.18,3.10)">
+                <polyline points="-5.43,2.56 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-5.30,2.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -296,8 +296,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.96,5.74 -4.63,4.29"/>
-                <g class="nad-edge-infos" transform="translate(-4.09,5.47)">
+                <polyline points="-3.83,6.02 -4.63,4.29"/>
+                <g class="nad-edge-infos" transform="translate(-3.96,5.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -317,8 +317,8 @@
         </g>
         <g id="28" class="nad-vl300to500" title="DDE1AA1  DDE2AA1  1">
             <g>
-                <polyline points="6.67,2.33 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(6.46,2.11)">
+                <polyline points="6.87,2.54 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(6.67,2.33)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -336,8 +336,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.89,0.42 5.78,1.37"/>
-                <g class="nad-edge-infos" transform="translate(5.10,0.64)">
+                <polyline points="4.69,0.20 5.78,1.37"/>
+                <g class="nad-edge-infos" transform="translate(4.89,0.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -357,8 +357,8 @@
         </g>
         <g id="29" class="nad-vl300to500" title="DDE1AA1  DDE3AA1  1">
             <g>
-                <polyline points="6.54,2.99 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(6.28,3.13)">
+                <polyline points="6.81,2.86 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(6.54,2.99)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -376,8 +376,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="4.26,4.12 5.40,3.55"/>
-                <g class="nad-edge-infos" transform="translate(4.53,3.98)">
+                <polyline points="3.99,4.25 5.40,3.55"/>
+                <g class="nad-edge-infos" transform="translate(4.26,4.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -397,8 +397,8 @@
         </g>
         <g id="30" class="nad-vl300to500" title="DDE2AA1  DDE3AA1  1">
             <g>
-                <polyline points="4.40,0.57 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(4.35,0.86)">
+                <polyline points="4.46,0.27 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(4.40,0.57)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -416,8 +416,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.85,3.81 4.13,2.19"/>
-                <g class="nad-edge-infos" transform="translate(3.90,3.51)">
+                <polyline points="3.79,4.10 4.13,2.19"/>
+                <g class="nad-edge-infos" transform="translate(3.85,3.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -437,8 +437,8 @@
         </g>
         <g id="31" class="nad-vl300to500" title="DDE2AA1  NNL3AA1  1">
             <g>
-                <polyline points="4.27,-0.51 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(4.15,-0.79)">
+                <polyline points="4.39,-0.24 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(4.27,-0.51)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -456,8 +456,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.75,-3.90 3.51,-2.21"/>
-                <g class="nad-edge-infos" transform="translate(2.88,-3.63)">
+                <polyline points="2.63,-4.18 3.51,-2.21"/>
+                <g class="nad-edge-infos" transform="translate(2.75,-3.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -477,7 +477,7 @@
         </g>
         <g id="32" class="nad-vl300to500" title="FFR2AA1  DDE3AA1  1">
             <g>
-                <polyline points="0.79,6.94 2.06,5.84"/>
+                <polyline points="0.79,6.94 2.17,5.74"/>
                 <g class="nad-edge-infos" transform="translate(1.02,6.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -496,8 +496,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="3.32,4.74 2.06,5.84"/>
-                <g class="nad-edge-infos" transform="translate(3.09,4.94)">
+                <polyline points="3.55,4.55 2.17,5.74"/>
+                <g class="nad-edge-infos" transform="translate(3.32,4.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -576,7 +576,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.17,6.11 -2.95,6.05 -1.58,6.40"/>
+                <polyline points="-3.46,6.19 -2.95,6.05 -1.58,6.40"/>
                 <g class="nad-edge-infos" transform="translate(-2.66,6.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -658,7 +658,7 @@
                 </g>
             </g>
             <g>
-                <polyline points="-3.31,6.66 -3.15,6.82 -1.78,7.18"/>
+                <polyline points="-3.53,6.45 -3.15,6.82 -1.78,7.18"/>
                 <g class="nad-edge-infos" transform="translate(-2.86,6.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -679,8 +679,8 @@
         </g>
         <g id="37" class="nad-vl300to500" title="NNL1AA1  NNL2AA1  1">
             <g>
-                <polyline points="0.82,-7.63 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(0.61,-7.42)">
+                <polyline points="1.04,-7.85 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(0.82,-7.63)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -698,8 +698,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="-1.09,-5.75 -0.13,-6.69"/>
-                <g class="nad-edge-infos" transform="translate(-0.88,-5.96)">
+                <polyline points="-1.30,-5.54 -0.13,-6.69"/>
+                <g class="nad-edge-infos" transform="translate(-1.09,-5.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -719,8 +719,8 @@
         </g>
         <g id="38" class="nad-vl300to500" title="NNL1AA1  NNL3AA1  1">
             <g>
-                <polyline points="1.42,-7.50 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(1.52,-7.22)">
+                <polyline points="1.32,-7.78 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(1.42,-7.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -738,8 +738,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="2.33,-4.96 1.88,-6.23"/>
-                <g class="nad-edge-infos" transform="translate(2.23,-5.24)">
+                <polyline points="2.43,-4.68 1.88,-6.23"/>
+                <g class="nad-edge-infos" transform="translate(2.33,-4.96)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -759,8 +759,8 @@
         </g>
         <g id="39" class="nad-vl300to500" title="NNL2AA1  NNL3AA1  1">
             <g>
-                <polyline points="-0.94,-5.22 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(-0.65,-5.15)">
+                <polyline points="-1.23,-5.29 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(-0.94,-5.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -778,8 +778,8 @@
                 </g>
             </g>
             <g>
-                <polyline points="1.96,-4.55 0.51,-4.88"/>
-                <g class="nad-edge-infos" transform="translate(1.67,-4.62)">
+                <polyline points="2.26,-4.48 0.51,-4.88"/>
+                <g class="nad-edge-infos" transform="translate(1.96,-4.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
@@ -800,15 +800,15 @@
     </g>
     <g class="nad-text-edges">
         <polyline id="0_text_edge" points="-4.14,-2.08 -3.74,-2.08"/>
-        <polyline id="3_text_edge" points="-4.94,2.31 -4.54,2.31"/>
-        <polyline id="5_text_edge" points="7.66,2.74 8.06,2.74"/>
-        <polyline id="7_text_edge" points="5.10,0.01 5.50,0.01"/>
-        <polyline id="9_text_edge" points="4.35,4.37 4.75,4.37"/>
+        <polyline id="3_text_edge" points="-5.24,2.31 -4.54,2.31"/>
+        <polyline id="5_text_edge" points="7.36,2.74 8.06,2.74"/>
+        <polyline id="7_text_edge" points="4.80,0.01 5.50,0.01"/>
+        <polyline id="9_text_edge" points="4.05,4.37 4.75,4.37"/>
         <polyline id="11_text_edge" points="0.96,7.32 1.36,7.32"/>
-        <polyline id="14_text_edge" points="-3.12,6.26 -2.72,6.26"/>
-        <polyline id="16_text_edge" points="1.83,-8.03 2.23,-8.03"/>
-        <polyline id="18_text_edge" points="-0.90,-5.35 -0.50,-5.35"/>
-        <polyline id="20_text_edge" points="3.12,-4.42 3.52,-4.42"/>
+        <polyline id="14_text_edge" points="-3.42,6.26 -2.72,6.26"/>
+        <polyline id="16_text_edge" points="1.53,-8.03 2.23,-8.03"/>
+        <polyline id="18_text_edge" points="-1.20,-5.35 -0.50,-5.35"/>
+        <polyline id="20_text_edge" points="2.82,-4.42 3.52,-4.42"/>
     </g>
     <g class="nad-text-nodes">
         <text filter="url(#textBgFilter)" x="-3.74" y="-2.08" style="dominant-baseline:middle">BBE1AA1</text>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
Voltage levels are all of the same size (except fictitious ones)


**What is the new behavior (if this is a feature change)?**
Voltage levels are bigger if more than one bus

![screenshot](https://user-images.githubusercontent.com/66690739/154529636-948a3ff3-b454-4013-9998-d0c2a6ed4fd2.png)


**Does this PR introduce a breaking change or deprecate an API?** 
No


**Other information**:
One could think of a radius proportional to the number of buses, nonetheless this requires more code changes (expecially the forking edges)
