### PR TITLE
Edge info labels on the edge

### DIFF
--- a/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
+++ b/src/main/java/com/powsybl/nad/svg/EdgeInfo.java
@@ -17,14 +17,14 @@ public class EdgeInfo {
 
     private final String infoType;
     private final Direction arrowDirection;
-    private final String leftLabel;
-    private final String rightLabel;
+    private final String internalLabel;
+    private final String externalLabel;
 
-    public EdgeInfo(String infoType, Direction arrowDirection, String leftLabel, String rightLabel) {
+    public EdgeInfo(String infoType, Direction arrowDirection, String internalLabel, String externalLabel) {
         this.infoType = infoType;
         this.arrowDirection = arrowDirection;
-        this.leftLabel = leftLabel;
-        this.rightLabel = rightLabel;
+        this.internalLabel = internalLabel;
+        this.externalLabel = externalLabel;
     }
 
     public EdgeInfo(String infoType, double value) {
@@ -39,12 +39,12 @@ public class EdgeInfo {
         return Optional.ofNullable(arrowDirection);
     }
 
-    public Optional<String> getLeftLabel() {
-        return Optional.ofNullable(leftLabel);
+    public Optional<String> getInternalLabel() {
+        return Optional.ofNullable(internalLabel);
     }
 
-    public Optional<String> getRightLabel() {
-        return Optional.ofNullable(rightLabel);
+    public Optional<String> getExternalLabel() {
+        return Optional.ofNullable(externalLabel);
     }
 
     public enum Direction {

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -21,7 +21,7 @@ public class SvgParameters {
     private int fixedWidth = -1;
     private int fixedHeight = -1;
     private double arrowShift = 0.3;
-    private double arrowLabelShift = 0.12;
+    private double arrowLabelShift = 0.23;
     private double converterStationWidth = 0.6;
     private double voltageLevelCircleRadius = 0.3;
     private double fictitiousVoltageLevelCircleRadius = 0.15;

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -21,7 +21,7 @@ public class SvgParameters {
     private int fixedWidth = -1;
     private int fixedHeight = -1;
     private double arrowShift = 0.3;
-    private double arrowLabelShift = 0.23;
+    private double arrowLabelShift = 0.19;
     private double converterStationWidth = 0.6;
     private double voltageLevelCircleRadius = 0.3;
     private double fictitiousVoltageLevelCircleRadius = 0.15;
@@ -35,6 +35,7 @@ public class SvgParameters {
     private double loopEdgesAperture = Math.toRadians(60);
     private double loopControlDistance = 0.4;
     private boolean textNodeBackground = true;
+    private boolean edgeInfoAlongEdge = true;
 
     public enum CssLocation {
         INSERTED_IN_SVG, EXTERNAL_IMPORTED, EXTERNAL_NO_IMPORT
@@ -241,6 +242,15 @@ public class SvgParameters {
 
     public SvgParameters setTextNodeBackground(boolean textNodeBackground) {
         this.textNodeBackground = textNodeBackground;
+        return this;
+    }
+
+    public boolean isEdgeInfoAlongEdge() {
+        return edgeInfoAlongEdge;
+    }
+
+    public SvgParameters setEdgeInfoAlongEdge(boolean edgeInfoAlongEdge) {
+        this.edgeInfoAlongEdge = edgeInfoAlongEdge;
         return this;
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -347,8 +347,9 @@ public class SvgWriter {
     private void drawLabelPerpendicularToEdge(XMLStreamWriter writer, String label, double edgeAngle, boolean externalLabel) throws XMLStreamException {
         boolean textFlipped = Math.sin(edgeAngle) > 0;
         double textAngle = textFlipped ? -Math.PI / 2 + edgeAngle : Math.PI / 2 + edgeAngle;
-        double shift = svgParameters.getArrowLabelShift() * (externalLabel ? 1 : -1);
-        drawLabel(writer, label, textFlipped ? shift * 1.15 : -shift, "text-anchor:middle", textAngle, Y_ATTRIBUTE);
+        double shift = svgParameters.getArrowLabelShift();
+        double shiftAdjusted = externalLabel == textFlipped ? shift * 1.15 : -shift; // to have a nice compact rendering, shift needs to be adjusted, because of dominant-baseline:middle (text is expected to be a number, hence not below the line)
+        drawLabel(writer, label, shiftAdjusted, "text-anchor:middle", textAngle, Y_ATTRIBUTE);
     }
 
     private void drawLabel(XMLStreamWriter writer, String label, double shift, String style, double textAngle, String shiftAxis) throws XMLStreamException {

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -333,7 +333,7 @@ public class SvgWriter {
     private void drawLabel(XMLStreamWriter writer, String label, double labelShiftY, double angle, boolean textFlipped, String style) throws XMLStreamException {
         writer.writeStartElement(TEXT_ELEMENT_NAME);
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getRotateString(angle));
-        writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textFlipped ? labelShiftY : -labelShiftY));
+        writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textFlipped ? labelShiftY * 1.15 : -labelShiftY));
         if (style != null) {
             writer.writeAttribute(STYLE_ELEMENT_NAME, style);
         }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -298,18 +298,19 @@ public class SvgWriter {
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.EDGE_INFOS_CLASS);
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getTranslateString(infoCenter));
-        double textAngle = Math.sin(edgeAngle) > 0 ? -Math.PI / 2 + edgeAngle : Math.PI / 2 + edgeAngle;
+        boolean textFlipped = Math.sin(edgeAngle) > 0;
+        double textAngle = textFlipped ? -Math.PI / 2 + edgeAngle : Math.PI / 2 + edgeAngle;
         for (EdgeInfo info : edgeInfos) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
             addStylesIfAny(writer, styleProvider.getEdgeInfoStyles(info));
             drawInAndOutArrows(writer, edgeAngle);
-            Optional<String> rightLabel = info.getRightLabel();
+            Optional<String> rightLabel = info.getExternalLabel();
             if (rightLabel.isPresent()) {
-                drawLabel(writer, rightLabel.get(), svgParameters.getArrowLabelShift(), textAngle, "dominant-baseline:middle");
+                drawLabel(writer, rightLabel.get(), svgParameters.getArrowLabelShift(), textAngle, textFlipped, "text-anchor:middle");
             }
-            Optional<String> leftLabel = info.getLeftLabel();
+            Optional<String> leftLabel = info.getInternalLabel();
             if (leftLabel.isPresent()) {
-                drawLabel(writer, leftLabel.get(), -svgParameters.getArrowLabelShift(), textAngle, "dominant-baseline:middle; text-anchor:end");
+                drawLabel(writer, leftLabel.get(), -svgParameters.getArrowLabelShift(), textAngle, textFlipped, "text-anchor:middle");
             }
             writer.writeEndElement();
         }
@@ -329,11 +330,13 @@ public class SvgWriter {
         writer.writeEndElement();
     }
 
-    private void drawLabel(XMLStreamWriter writer, String label, double labelShiftX, double angle, String style) throws XMLStreamException {
+    private void drawLabel(XMLStreamWriter writer, String label, double labelShiftY, double angle, boolean textFlipped, String style) throws XMLStreamException {
         writer.writeStartElement(TEXT_ELEMENT_NAME);
         writer.writeAttribute(TRANSFORM_ATTRIBUTE, getRotateString(angle));
-        writer.writeAttribute(X_ATTRIBUTE, getFormattedValue(labelShiftX));
-        writer.writeAttribute(STYLE_ELEMENT_NAME, style);
+        writer.writeAttribute(Y_ATTRIBUTE, getFormattedValue(textFlipped ? labelShiftY : -labelShiftY));
+        if (style != null) {
+            writer.writeAttribute(STYLE_ELEMENT_NAME, style);
+        }
         writer.writeCharacters(label);
         writer.writeEndElement();
     }

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -2,7 +2,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -17,9 +17,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -2,7 +2,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-branch-edges .nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -91,4 +91,3 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-

--- a/src/test/java/com/powsybl/nad/AbstractTest.java
+++ b/src/test/java/com/powsybl/nad/AbstractTest.java
@@ -32,9 +32,9 @@ public abstract class AbstractTest {
     protected boolean debugSvg = false;
     protected boolean overrideTestReferences = false;
 
-    protected abstract LayoutParameters getLayoutParameters();
+    private SvgParameters svgParameters;
 
-    protected abstract SvgParameters getSvgParameters();
+    private LayoutParameters layoutParameters;
 
     protected abstract StyleProvider getStyleProvider(Network network);
 
@@ -91,5 +91,21 @@ public abstract class AbstractTest {
     private static String normalizeLineSeparator(String str) {
         return str.replace("\r\n", "\n")
                 .replace("\r", "\n");
+    }
+
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
+    protected SvgParameters getSvgParameters() {
+        return svgParameters;
+    }
+
+    protected void setLayoutParameters(LayoutParameters layoutParameters) {
+        this.layoutParameters = layoutParameters;
+    }
+
+    protected void setSvgParameters(SvgParameters svgParameters) {
+        this.svgParameters = svgParameters;
     }
 }

--- a/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
+++ b/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
@@ -27,6 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class EdgeInfoTest extends AbstractTest {
 
+    private String internalLabel;
+    private String externalLabel;
+
     @BeforeEach
     public void setup() {
         setLayoutParameters(new LayoutParameters());
@@ -45,12 +48,12 @@ class EdgeInfoTest extends AbstractTest {
         return new LabelProvider() {
             @Override
             public List<EdgeInfo> getEdgeInfos(Graph graph, BranchEdge edge, BranchEdge.Side side) {
-                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.OUT, "int.", "ext."));
+                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.OUT, internalLabel, externalLabel));
             }
 
             @Override
             public List<EdgeInfo> getEdgeInfos(Graph graph, ThreeWtEdge edge) {
-                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.IN, "int.", "ext."));
+                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.IN, internalLabel, externalLabel));
             }
 
             @Override
@@ -66,19 +69,30 @@ class EdgeInfoTest extends AbstractTest {
     }
 
     @Test
-    public void testPerpendicularLabels() {
+    void testMissingLabels() {
         Network network = NetworkTestFactory.createTwoVoltageLevels();
-        getSvgParameters().setEdgeInfoAlongEdge(false)
-                .setArrowShift(0.5)
-                .setArrowLabelShift(0.25);
-        assertEquals(toString("/perpendicular_labels.svg"), generateSvgString(network, "/perpendicular_labels.svg"));
+        getSvgParameters().setArrowShift(0.1);
+        assertEquals(toString("/edge_info_missing_label.svg"), generateSvgString(network, "/edge_info_missing_label.svg"));
     }
 
     @Test
-    public void testParallelLabels() {
+    void testPerpendicularLabels() {
+        Network network = NetworkTestFactory.createTwoVoltageLevels();
+        internalLabel = "int";
+        externalLabel = "ext";
+        getSvgParameters().setEdgeInfoAlongEdge(false)
+                .setArrowShift(0.5)
+                .setArrowLabelShift(0.25);
+        assertEquals(toString("/edge_info_perpendicular_label.svg"), generateSvgString(network, "/edge_info_perpendicular_label.svg"));
+    }
+
+    @Test
+    void testParallelLabels() {
         Network network = ThreeWindingsTransformerNetworkFactory.create();
+        internalLabel = "243";
+        externalLabel = "145";
         getSvgParameters().setArrowShift(0.6)
                 .setArrowLabelShift(0.2);
-        assertEquals(toString("/double_labels.svg"), generateSvgString(network, "/double_labels.svg"));
+        assertEquals(toString("/edge_info_double_labels.svg"), generateSvgString(network, "/edge_info_double_labels.svg"));
     }
 }

--- a/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
+++ b/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
@@ -27,26 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class EdgeInfoTest extends AbstractTest {
 
-    private SvgParameters svgParameters;
-
-    private LayoutParameters layoutParameters;
-
     @BeforeEach
     public void setup() {
-        this.layoutParameters = new LayoutParameters();
-        this.svgParameters = new SvgParameters()
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
                 .setSvgWidthAndHeightAdded(true)
-                .setFixedWidth(800);
-    }
-
-    @Override
-    protected LayoutParameters getLayoutParameters() {
-        return layoutParameters;
-    }
-
-    @Override
-    protected SvgParameters getSvgParameters() {
-        return svgParameters;
+                .setFixedWidth(800));
     }
 
     @Override

--- a/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
+++ b/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
@@ -68,17 +68,16 @@ class EdgeInfoTest extends AbstractTest {
             }
 
             @Override
-            public String getArrowPathDIn() {
+            public String getArrowPathDIn() { // larger arrow
                 return "M-0.2 -0.1 H0.2 L0 0.1z";
             }
 
             @Override
-            public String getArrowPathDOut() {
+            public String getArrowPathDOut() { // thinner arrow
                 return "M-0.05 0.1 H0.05 L0 -0.1z";
             }
         };
     }
-
 
     @Test
     public void testPerpendicularLabels() {

--- a/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
+++ b/src/test/java/com/powsybl/nad/svg/EdgeInfoTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.model.BranchEdge;
+import com.powsybl.nad.model.Graph;
+import com.powsybl.nad.model.ThreeWtEdge;
+import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+class EdgeInfoTest extends AbstractTest {
+
+    private SvgParameters svgParameters;
+
+    private LayoutParameters layoutParameters;
+
+    @BeforeEach
+    public void setup() {
+        this.layoutParameters = new LayoutParameters();
+        this.svgParameters = new SvgParameters()
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800);
+    }
+
+    @Override
+    protected LayoutParameters getLayoutParameters() {
+        return layoutParameters;
+    }
+
+    @Override
+    protected SvgParameters getSvgParameters() {
+        return svgParameters;
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new NominalVoltageStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new LabelProvider() {
+            @Override
+            public List<EdgeInfo> getEdgeInfos(Graph graph, BranchEdge edge, BranchEdge.Side side) {
+                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.OUT, "int.", "ext."));
+            }
+
+            @Override
+            public List<EdgeInfo> getEdgeInfos(Graph graph, ThreeWtEdge edge) {
+                return Collections.singletonList(new EdgeInfo("test", EdgeInfo.Direction.IN, "int.", "ext."));
+            }
+
+            @Override
+            public String getArrowPathDIn() {
+                return "M-0.2 -0.1 H0.2 L0 0.1z";
+            }
+
+            @Override
+            public String getArrowPathDOut() {
+                return "M-0.05 0.1 H0.05 L0 -0.1z";
+            }
+        };
+    }
+
+
+    @Test
+    public void testPerpendicularLabels() {
+        Network network = NetworkTestFactory.createTwoVoltageLevels();
+        getSvgParameters().setEdgeInfoAlongEdge(false)
+                .setArrowShift(0.5)
+                .setArrowLabelShift(0.25);
+        assertEquals(toString("/perpendicular_labels.svg"), generateSvgString(network, "/perpendicular_labels.svg"));
+    }
+
+    @Test
+    public void testParallelLabels() {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        getSvgParameters().setArrowShift(0.6)
+                .setArrowLabelShift(0.2);
+        assertEquals(toString("/double_labels.svg"), generateSvgString(network, "/double_labels.svg"));
+    }
+}

--- a/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
+++ b/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
@@ -14,7 +14,10 @@ import com.powsybl.iidm.network.VoltageLevel;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class NetworkTestFactory {
+public final class NetworkTestFactory {
+
+    private NetworkTestFactory() {
+    }
 
     /**
      *  g1     dl1

--- a/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
+++ b/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Substation;
+import com.powsybl.iidm.network.TopologyKind;
+import com.powsybl.iidm.network.VoltageLevel;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class NetworkTestFactory {
+
+    /**
+     *  g1     dl1
+     *  |       |
+     *  b1 ---- b2
+     *      l1
+     */
+    public static Network createTwoVoltageLevels() {
+        Network network = Network.create("dl", "test");
+        Substation s = network.newSubstation().setId("S1").add();
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setConnectableBus("b1")
+                .setBus("b1")
+                .setTargetP(101.3664)
+                .setTargetV(390)
+                .setMinP(0)
+                .setMaxP(150)
+                .setVoltageRegulatorOn(true)
+                .add();
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newDanglingLine()
+                .setId("dl1")
+                .setConnectableBus("b2")
+                .setBus("b2")
+                .setR(0.7)
+                .setX(1)
+                .setG(1e-6)
+                .setB(3e-6)
+                .setP0(101)
+                .setQ0(150)
+                .newGeneration()
+                .setTargetP(0)
+                .setTargetQ(0)
+                .setTargetV(390)
+                .setVoltageRegulationOn(false)
+                .add()
+                .add();
+        network.newLine()
+                .setId("l1")
+                .setVoltageLevel1("vl1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setR(1)
+                .setX(3)
+                .setG1(0)
+                .setG2(0)
+                .setB1(0)
+                .setB2(0)
+                .add();
+        return network;
+    }
+}

--- a/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -33,27 +33,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class NominalVoltageStyleTest extends AbstractTest {
 
-    private SvgParameters svgParameters;
-
-    private LayoutParameters layoutParameters;
-
     @BeforeEach
     public void setup() {
-        this.layoutParameters = new LayoutParameters();
-        this.svgParameters = new SvgParameters()
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
                 .setInsertName(true)
                 .setSvgWidthAndHeightAdded(true)
-                .setFixedWidth(800);
-    }
-
-    @Override
-    protected LayoutParameters getLayoutParameters() {
-        return layoutParameters;
-    }
-
-    @Override
-    protected SvgParameters getSvgParameters() {
-        return svgParameters;
+                .setFixedWidth(800));
     }
 
     @Override
@@ -121,14 +107,14 @@ class NominalVoltageStyleTest extends AbstractTest {
     @Test
     void testEuropeLoopAperture80() {
         Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
-        svgParameters.setLoopEdgesAperture(80);
+        getSvgParameters().setLoopEdgesAperture(80);
         assertEquals(toString("/simple-eu-loop80.svg"), generateSvgString(network, "/simple-eu-loop80.svg"));
     }
 
     @Test
     void testEuropeLoopAperture100() {
         Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
-        svgParameters.setLoopEdgesAperture(100);
+        getSvgParameters().setLoopEdgesAperture(100);
         assertEquals(toString("/simple-eu-loop100.svg"), generateSvgString(network, "/simple-eu-loop100.svg"));
     }
 

--- a/src/test/java/com/powsybl/nad/svg/TopologicalStyleTest.java
+++ b/src/test/java/com/powsybl/nad/svg/TopologicalStyleTest.java
@@ -25,24 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 class TopologicalStyleTest extends AbstractTest {
 
-    private LayoutParameters layoutParameters;
-
     @BeforeEach
     public void setup() {
-        this.layoutParameters = new LayoutParameters();
-    }
-
-    @Override
-    protected LayoutParameters getLayoutParameters() {
-        return layoutParameters;
-    }
-
-    @Override
-    protected SvgParameters getSvgParameters() {
-        return new SvgParameters()
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
                 .setInsertName(true)
                 .setSvgWidthAndHeightAdded(true)
-                .setFixedWidth(800);
+                .setFixedWidth(800));
     }
 
     @Override

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -59,14 +59,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-44.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(45.46)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(135.46)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-44.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(45.46)" x="0.19">0</text>
                 </g>
             </g>
         </g>
@@ -78,14 +78,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(39.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-50.46)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(39.54)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(39.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-50.46)" x="0.19">0</text>
                 </g>
             </g>
         </g>
@@ -97,14 +97,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(72.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-17.23)" x="-0.19" style="text-anchor:end">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(72.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-17.23)" x="-0.19" style="text-anchor:end">0</text>
                 </g>
             </g>
         </g>

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/3wt_disconnected.svg
+++ b/src/test/resources/3wt_disconnected.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,7 +20,7 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
 .nad-edge-infos .nad-state-in {fill: #b71c1c}
 .nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
@@ -59,14 +59,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-44.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(45.46)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(135.46)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-44.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(45.46)" x="0.19">0</text>
                 </g>
             </g>
         </g>
@@ -78,14 +78,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(39.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-50.46)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(39.54)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(39.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-50.46)" x="0.19">0</text>
                 </g>
             </g>
         </g>
@@ -97,14 +97,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(72.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-17.23)" x="-0.19" style="text-anchor:end">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(-107.23)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(72.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-17.23)" x="-0.19" style="text-anchor:end">0</text>
                 </g>
             </g>
         </g>

--- a/src/test/resources/3wt_disconnected.svg
+++ b/src/test/resources/3wt_disconnected.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -53,14 +53,14 @@
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(74.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-15.41)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
                     <g transform="rotate(74.59)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(74.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                    <text transform="rotate(-15.41)" x="0.19">0</text>
                 </g>
             </g>
         </g>

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-branch-edges .nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}
@@ -94,7 +94,6 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-
 ]]></style>
     <metadata></metadata>
     <defs>
@@ -469,14 +468,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-72.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(17.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(107.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-72.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(17.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -488,14 +487,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-72.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-342.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-72.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-72.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-342.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -509,14 +508,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(69.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.61)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -528,14 +527,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-110.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -549,14 +548,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.57)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(90.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.57)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -568,14 +567,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-89.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -589,14 +588,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-31.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-301.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-31.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-31.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-301.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -608,14 +607,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-31.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(58.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(148.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-31.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(58.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -629,14 +628,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(116.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -648,14 +647,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-63.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -669,14 +668,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-168.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -688,14 +687,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.22)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(11.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.22)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -709,14 +708,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-30.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.99)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(149.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-30.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(59.99)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -728,14 +727,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-30.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-300.01)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-30.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-30.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-300.01)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -749,14 +748,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(66.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -768,14 +767,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-113.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -789,14 +788,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.70)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="17.25" cy="-20.63" r="0.20"/>
@@ -809,14 +808,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="17.40" cy="-20.77" r="0.20"/>
@@ -831,14 +830,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.39)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(111.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.39)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -850,14 +849,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-68.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -871,14 +870,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.10)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -890,14 +889,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -911,14 +910,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(17.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-72.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-162.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(17.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-72.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -930,14 +929,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(17.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-72.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(17.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(17.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-72.61)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -951,14 +950,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-41.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -970,14 +969,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(138.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.94)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -991,14 +990,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(169.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1010,14 +1009,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-10.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1031,14 +1030,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1050,14 +1049,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.31)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1071,14 +1070,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(141.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.29)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1090,14 +1089,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-38.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1111,14 +1110,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(20.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-69.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-159.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(20.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-69.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1130,14 +1129,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(20.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-69.09)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(20.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(20.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-69.09)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1151,14 +1150,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-153.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1170,14 +1169,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(26.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1191,14 +1190,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.77)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(172.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.77)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1210,14 +1209,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1231,14 +1230,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.38)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(98.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.38)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1250,14 +1249,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-81.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1271,14 +1270,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1290,14 +1289,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1311,14 +1310,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-118.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1330,14 +1329,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.71)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(61.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.71)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1351,14 +1350,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.86)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(141.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.86)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1370,14 +1369,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-38.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1391,14 +1390,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1410,14 +1409,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1431,14 +1430,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-346.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-76.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-346.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1450,14 +1449,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(13.11)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(103.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(13.11)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1471,14 +1470,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-140.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1490,14 +1489,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.41)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(39.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.41)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1511,14 +1510,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-93.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1530,14 +1529,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.99)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(86.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.99)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1551,14 +1550,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(19.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(109.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(19.37)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="20.33" cy="-6.16" r="0.20"/>
@@ -1571,14 +1570,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-340.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-70.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-340.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="20.52" cy="-6.10" r="0.20"/>
@@ -1593,14 +1592,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(147.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1612,14 +1611,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-32.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1633,14 +1632,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(171.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1652,14 +1651,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-8.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1673,14 +1672,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-356.08)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-86.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-356.08)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1692,14 +1691,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(3.92)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(93.92)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.08)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(3.92)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1713,14 +1712,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(175.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1732,14 +1731,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-4.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1753,14 +1752,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-63.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1772,14 +1771,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(116.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1793,14 +1792,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.97)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(170.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.97)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1812,14 +1811,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-9.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1833,14 +1832,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(170.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1852,14 +1851,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-9.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1873,14 +1872,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-331.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-61.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-331.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1892,14 +1891,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(28.77)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(118.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(28.77)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1913,14 +1912,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-95.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1932,14 +1931,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(84.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1953,14 +1952,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(66.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1972,14 +1971,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-113.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1993,14 +1992,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(74.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2012,14 +2011,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-105.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2033,14 +2032,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-65.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-335.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-65.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-65.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-335.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2052,14 +2051,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-65.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(24.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(114.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-65.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(24.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2073,14 +2072,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-100.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2092,14 +2091,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(80.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2113,14 +2112,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(171.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.79)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="20.38" cy="3.47" r="0.20"/>
@@ -2133,14 +2132,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-8.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="20.41" cy="3.66" r="0.20"/>
@@ -2155,14 +2154,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(111.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(21.51)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2174,14 +2173,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-68.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2195,14 +2194,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-22.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2214,14 +2213,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(157.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2235,14 +2234,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(77.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2254,14 +2253,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-102.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2275,14 +2274,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.98)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.98)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2294,14 +2293,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2315,14 +2314,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2334,14 +2333,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2355,14 +2354,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(7.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2374,14 +2373,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-172.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2395,14 +2394,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-58.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2414,14 +2413,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.73)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.73)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2435,14 +2434,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-115.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2454,14 +2453,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(64.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.88)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2475,14 +2474,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-141.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2494,14 +2493,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.75)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(38.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.75)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2515,14 +2514,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(5.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2534,14 +2533,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-174.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2555,14 +2554,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.86)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(172.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.86)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2574,14 +2573,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2595,14 +2594,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-123.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2614,14 +2613,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(56.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2635,14 +2634,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-32.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2654,14 +2653,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(147.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2675,14 +2674,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(22.76)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(112.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(22.76)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2694,14 +2693,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-337.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-67.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-337.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2715,14 +2714,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-129.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2734,14 +2733,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(50.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2755,14 +2754,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-88.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2774,14 +2773,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(91.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2795,14 +2794,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(68.11)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(158.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(68.11)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2814,14 +2813,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-291.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-21.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-291.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2835,14 +2834,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(25.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.37)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="8.49" cy="-5.36" r="0.20"/>
@@ -2855,14 +2854,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="8.58" cy="-5.54" r="0.20"/>
@@ -2877,14 +2876,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2896,14 +2895,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2917,14 +2916,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(175.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2936,14 +2935,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-4.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2957,14 +2956,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-141.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2976,14 +2975,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(38.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2997,14 +2996,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-172.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3016,14 +3015,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(7.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.51)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3037,14 +3036,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(177.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3056,14 +3055,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-2.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3077,14 +3076,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-166.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3096,14 +3095,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(13.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3117,14 +3116,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-149.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3136,14 +3135,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(30.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3157,14 +3156,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-149.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3176,14 +3175,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(30.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3197,14 +3196,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-149.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3216,14 +3215,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(30.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3237,14 +3236,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-178.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3256,14 +3255,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(1.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3277,14 +3276,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.68)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(166.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.68)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3296,14 +3295,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-13.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3317,14 +3316,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(61.32)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(151.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(61.32)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3336,14 +3335,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-298.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-28.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-298.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3357,14 +3356,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-176.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3376,14 +3375,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(3.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3397,14 +3396,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-80.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3416,14 +3415,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(99.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3437,14 +3436,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(62.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(152.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(62.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3456,14 +3455,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-297.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-27.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-297.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3477,14 +3476,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.83)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(157.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.83)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3496,14 +3495,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-22.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3517,14 +3516,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-58.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3536,14 +3535,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3557,14 +3556,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-2.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-92.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-2.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3576,14 +3575,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-2.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(87.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-2.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3597,14 +3596,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3616,14 +3615,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3637,14 +3636,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3656,14 +3655,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3677,14 +3676,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-179.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3696,14 +3695,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(0.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3717,14 +3716,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-179.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3736,14 +3735,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(0.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.07)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3757,14 +3756,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3776,14 +3775,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3797,14 +3796,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3816,14 +3815,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3837,14 +3836,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3856,14 +3855,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.79)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3877,14 +3876,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(166.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.88)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3896,14 +3895,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-13.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3917,14 +3916,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-56.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(33.56)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(123.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-56.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(33.56)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3936,14 +3935,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-56.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-326.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-56.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-56.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-326.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3957,14 +3956,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-168.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3976,14 +3975,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.82)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(11.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.82)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3997,14 +3996,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-117.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4016,14 +4015,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.51)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4037,14 +4036,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-80.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4056,14 +4055,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(99.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4077,14 +4076,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-163.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4096,14 +4095,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.71)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(16.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.71)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4117,14 +4116,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.41)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(162.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.41)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4136,14 +4135,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-287.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-17.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-287.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4157,14 +4156,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-121.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4176,14 +4175,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.57)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(58.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.57)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4197,14 +4196,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.47)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(51.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.47)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4216,14 +4215,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-128.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4237,14 +4236,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4256,14 +4255,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4277,14 +4276,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.60)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(21.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.60)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4296,14 +4295,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-158.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4317,14 +4316,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(97.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4336,14 +4335,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4357,14 +4356,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4376,14 +4375,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.13)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(97.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.13)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4397,14 +4396,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4416,14 +4415,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.13)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(97.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.13)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4437,14 +4436,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4456,14 +4455,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(97.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.29)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4477,14 +4476,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-318.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-48.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-318.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4496,14 +4495,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(41.65)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(131.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(41.65)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4517,14 +4516,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(84.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.10)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-1.60" cy="25.91" r="0.20"/>
@@ -4537,14 +4536,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-95.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-1.40" cy="25.89" r="0.20"/>
@@ -4559,14 +4558,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.60)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.60)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4578,14 +4577,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4599,14 +4598,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4618,14 +4617,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(178.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.52)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4639,14 +4638,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-321.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-51.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-321.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4658,14 +4657,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(38.48)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(128.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(38.48)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4679,14 +4678,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(23.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-66.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-156.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(23.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-66.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-2.66" cy="20.56" r="0.20"/>
@@ -4699,14 +4698,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(23.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-66.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(23.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(23.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-66.63)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-2.74" cy="20.74" r="0.20"/>
@@ -4721,14 +4720,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.67)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(34.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.67)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4740,14 +4739,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-145.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4761,14 +4760,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-11.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4780,14 +4779,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.20)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(168.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.20)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4801,14 +4800,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(8.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4820,14 +4819,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-171.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4841,14 +4840,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4860,14 +4859,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4881,14 +4880,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-166.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-1.44" cy="10.81" r="0.20"/>
@@ -4901,14 +4900,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.41)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(13.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.41)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-1.49" cy="11.00" r="0.20"/>
@@ -4923,14 +4922,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-22.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4942,14 +4941,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(157.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -4963,14 +4962,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-118.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -4982,14 +4981,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.89)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(61.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.89)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5003,14 +5002,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(4.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-85.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-175.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(4.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-85.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-3.56" cy="2.50" r="0.20"/>
@@ -5023,14 +5022,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(4.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-85.05)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(4.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(4.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-85.05)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-3.57" cy="2.70" r="0.20"/>
@@ -5045,14 +5044,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-32.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5064,14 +5063,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(147.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5085,14 +5084,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.89)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(15.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.89)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5104,14 +5103,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-164.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5125,14 +5124,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-137.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5144,14 +5143,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(42.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5165,14 +5164,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-344.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-74.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-344.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5184,14 +5183,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(15.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(105.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(15.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5205,14 +5204,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5224,14 +5223,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5245,14 +5244,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-140.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5264,14 +5263,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(39.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(39.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-50.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5285,14 +5284,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-344.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-74.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-344.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5304,14 +5303,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(15.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(105.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(15.51)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5325,14 +5324,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-26.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5344,14 +5343,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(153.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5365,14 +5364,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(90.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5384,14 +5383,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-89.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5405,14 +5404,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.79)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-123.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.79)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5424,14 +5423,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(56.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.79)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5445,14 +5444,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(22.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5464,14 +5463,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-157.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5485,14 +5484,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5504,14 +5503,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5525,14 +5524,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-87.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5544,14 +5543,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(92.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.37)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5565,14 +5564,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.76)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(41.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.76)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5584,14 +5583,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-138.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5605,14 +5604,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-179.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5624,14 +5623,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(0.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.37)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5645,14 +5644,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(27.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5664,14 +5663,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-152.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5685,14 +5684,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5704,14 +5703,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.38)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.38)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5725,14 +5724,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5744,14 +5743,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.38)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.62)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.38)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5765,14 +5764,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-327.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-57.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-327.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5784,14 +5783,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(33.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(123.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(33.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5805,14 +5804,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5824,14 +5823,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(172.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5845,14 +5844,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-133.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5864,14 +5863,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.16)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(46.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.16)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5885,14 +5884,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-54.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.49)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-9.41" cy="-6.78" r="0.20"/>
@@ -5905,14 +5904,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(125.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.51)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-9.58" cy="-6.90" r="0.20"/>
@@ -5927,14 +5926,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-41.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5946,14 +5945,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(138.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -5967,14 +5966,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -5986,14 +5985,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.98)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(178.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.98)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6007,14 +6006,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-130.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6026,14 +6025,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.48)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(49.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.48)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6047,14 +6046,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-112.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6066,14 +6065,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(67.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6087,14 +6086,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-90.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6106,14 +6105,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(89.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.23)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6127,14 +6126,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(36.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.23)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6146,14 +6145,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-143.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6167,14 +6166,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-112.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6186,14 +6185,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(67.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(67.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-22.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6207,14 +6206,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-69.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6226,14 +6225,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.55)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(110.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.45)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.55)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6247,14 +6246,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-290.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-20.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-290.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6266,14 +6265,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.98)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(159.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.98)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6287,14 +6286,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-128.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6306,14 +6305,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(51.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.28)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6327,14 +6326,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6346,14 +6345,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.71)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.71)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6367,14 +6366,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(30.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6386,14 +6385,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-149.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6407,14 +6406,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-146.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6426,14 +6425,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(33.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6447,14 +6446,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(80.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6466,14 +6465,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-99.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6487,14 +6486,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6506,14 +6505,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6527,14 +6526,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6546,14 +6545,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6567,14 +6566,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6586,14 +6585,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6607,14 +6606,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6626,14 +6625,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6647,14 +6646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(98.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6666,14 +6665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-81.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6687,14 +6686,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.89)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.89)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6706,14 +6705,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.11)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.11)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6727,14 +6726,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(38.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6746,14 +6745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-141.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6767,14 +6766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.09)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.09)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6786,14 +6785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6807,14 +6806,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(73.46)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(163.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(73.46)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6826,14 +6825,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-286.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-16.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-286.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6847,14 +6846,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-178.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6866,14 +6865,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.77)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(1.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.77)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6887,14 +6886,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-25.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(154.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-25.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(64.44)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6906,14 +6905,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-25.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-295.56)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-25.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-25.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-295.56)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6927,14 +6926,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(41.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6946,14 +6945,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-138.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -6967,14 +6966,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.16)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.16)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -6986,14 +6985,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7007,14 +7006,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-168.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7026,14 +7025,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(11.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7047,14 +7046,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.79)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7066,14 +7065,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7087,14 +7086,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(71.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7106,14 +7105,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-108.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7127,14 +7126,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-88.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7146,14 +7145,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.42)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(91.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.42)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7167,14 +7166,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(65.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-114.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(65.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7186,14 +7185,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(65.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(65.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(65.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-24.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7207,14 +7206,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-58.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7226,14 +7225,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7247,14 +7246,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-172.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7266,14 +7265,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(7.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.98)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7287,14 +7286,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-168.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7306,14 +7305,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.04)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(11.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.04)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7327,14 +7326,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7346,14 +7345,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.80)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.80)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7367,14 +7366,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(0.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7386,14 +7385,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-179.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7407,14 +7406,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.65)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(1.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.65)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7426,14 +7425,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-178.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-88.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7447,14 +7446,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7466,14 +7465,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.85)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.85)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7487,14 +7486,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-171.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7506,14 +7505,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.07)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(8.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(8.93)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-81.07)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7527,14 +7526,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-129.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7546,14 +7545,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(50.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7567,14 +7566,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7586,14 +7585,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.20)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(178.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.20)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7607,14 +7606,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-334.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-64.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-334.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7626,14 +7625,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(25.20)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(115.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(25.20)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7647,14 +7646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-152.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7666,14 +7665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(27.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.10)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7687,14 +7686,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-129.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7706,14 +7705,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(50.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-39.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7727,14 +7726,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.09)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(169.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.09)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7746,14 +7745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-10.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.91)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7767,14 +7766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.20)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(90.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(0.20)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7786,14 +7785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-89.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-89.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-359.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7807,14 +7806,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.68)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(143.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.68)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7826,14 +7825,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-36.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7847,14 +7846,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(19.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-70.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-160.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(19.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-70.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -7866,14 +7865,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(19.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-70.68)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(19.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(19.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-70.68)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7887,14 +7886,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(110.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -7906,14 +7905,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-69.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-branch-edges .nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}
@@ -94,7 +94,6 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-
 ]]></style>
     <metadata></metadata>
     <defs>
@@ -175,14 +174,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -196,14 +195,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-66.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -217,14 +216,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.39)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(110.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.39)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -236,14 +235,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-69.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -257,14 +256,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.39)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(110.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.39)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -276,14 +275,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-69.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.61)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -297,14 +296,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(18.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.79)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -318,14 +317,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -339,14 +338,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-58.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -358,14 +357,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.98)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.98)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -379,14 +378,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.45)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(99.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.45)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -400,14 +399,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.48)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(18.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.48)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -419,14 +418,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-161.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(18.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-71.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -440,14 +439,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -459,14 +458,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.47)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.53)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.47)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -480,14 +479,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(73.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-16.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-106.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(73.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-16.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -501,14 +500,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -520,14 +519,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.98)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.98)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -541,14 +540,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(89.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -560,14 +559,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-90.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -581,14 +580,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(46.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.23)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -600,14 +599,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-133.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -621,14 +620,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -640,14 +639,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -661,14 +660,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -680,14 +679,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -701,14 +700,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -720,14 +719,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -741,14 +740,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -760,14 +759,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -781,14 +780,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-166.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -800,14 +799,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.89)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(13.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-76.89)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -821,14 +820,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.83)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(29.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.83)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -840,14 +839,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-150.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -861,14 +860,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(30.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -880,14 +879,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-149.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(30.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-59.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -901,14 +900,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.97)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.97)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -920,14 +919,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-124.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -941,14 +940,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.66)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-60.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.66)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -960,14 +959,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.34)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(119.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.34)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -981,14 +980,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-133.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1000,14 +999,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.42)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(46.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.42)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1021,14 +1020,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.83)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(6.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.83)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1040,14 +1039,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(6.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1061,14 +1060,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.73)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(81.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.73)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1080,14 +1079,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-98.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1101,14 +1100,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1120,14 +1119,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.17)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.17)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1141,14 +1140,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(47.42)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(137.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(47.42)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1160,14 +1159,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-312.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-42.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-312.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1181,14 +1180,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-87.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1200,14 +1199,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.71)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(92.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(2.71)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1221,14 +1220,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.23)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1240,14 +1239,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1261,14 +1260,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.22)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(106.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.22)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1280,14 +1279,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-73.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1301,14 +1300,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-63.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1320,14 +1319,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(116.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1341,14 +1340,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-63.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-333.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1360,14 +1359,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(116.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-63.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(26.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1381,14 +1380,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-108.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1400,14 +1399,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(71.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1421,14 +1420,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-348.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-78.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-348.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1440,14 +1439,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(11.35)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(101.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.65)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(11.35)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1461,14 +1460,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.58)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-1.27" cy="-11.30" r="0.20"/>
@@ -1481,14 +1480,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-1.21" cy="-11.11" r="0.20"/>
@@ -1503,14 +1502,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-26.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1522,14 +1521,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(153.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1543,14 +1542,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-125.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1564,14 +1563,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-158.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1588,14 +1587,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(0.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(0.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-89.88)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-6.09" cy="-11.94" r="0.20"/>
@@ -1610,14 +1609,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.60)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1631,14 +1630,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-0.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1655,14 +1654,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(35.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-54.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-144.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(35.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-54.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-9.34" cy="4.99" r="0.20"/>
@@ -1677,14 +1676,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-90.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1701,14 +1700,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(119.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.78)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="1.43" cy="14.36" r="0.20"/>
@@ -1723,14 +1722,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(35.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-54.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-144.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(35.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-54.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1744,14 +1743,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-93.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(86.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-3.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1765,14 +1764,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(77.62)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(167.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(77.62)" x="0.19">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-branch-edges .nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}
@@ -94,7 +94,6 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-
 ]]></style>
     <metadata></metadata>
     <defs>
@@ -145,14 +144,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(162.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(72.28)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -166,14 +165,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(89.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.43)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -187,14 +186,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -208,14 +207,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-23.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-293.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-23.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-23.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-293.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -227,14 +226,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-23.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(66.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(156.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-23.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(66.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -248,14 +247,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(47.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(137.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-42.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(47.29)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -269,14 +268,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-139.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.61)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -290,14 +289,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -309,14 +308,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -330,14 +329,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -351,14 +350,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(79.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(79.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-10.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-0.36" cy="-5.81" r="0.20"/>
@@ -376,14 +375,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-297.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-27.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-27.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-297.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -397,14 +396,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.41)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(33.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.41)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -418,14 +417,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(37.46)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(127.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(37.46)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -437,14 +436,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-322.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-52.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-52.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-322.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -458,14 +457,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(3.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(93.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-86.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(3.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -479,14 +478,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -500,14 +499,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-164.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -519,14 +518,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(15.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -540,14 +539,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -559,14 +558,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-117.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -580,14 +579,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-69.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-339.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -599,14 +598,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.77)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(110.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-69.23)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(20.77)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -620,14 +619,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.11)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -641,14 +640,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-5.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(84.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(174.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-5.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(84.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -662,14 +661,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-68.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-68.59)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-338.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -683,14 +682,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.22)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(169.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(79.22)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="8.65" cy="1.59" r="0.20"/>
@@ -703,14 +702,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-10.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-280.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="8.69" cy="1.79" r="0.20"/>
@@ -725,14 +724,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.34)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.34)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -746,14 +745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(32.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(122.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-57.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(32.10)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -767,14 +766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(53.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-36.30)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(53.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(53.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-36.30)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -786,14 +785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(53.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-36.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-126.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(53.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-36.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -807,14 +806,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.27)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.27)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -828,14 +827,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-282.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-12.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-282.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="12.28" cy="-7.58" r="0.20"/>
@@ -853,14 +852,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(125.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -874,14 +873,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.09)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(36.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.09)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -895,14 +894,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.08)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.08)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -92,14 +92,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">157</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">157</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">-20</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">-20</text>
                     </g>
                 </g>
             </g>
@@ -111,14 +111,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">-153</text>
+                        <text transform="rotate(-34.59)" x="0.19">-153</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">28</text>
+                        <text transform="rotate(-34.59)" x="0.19">28</text>
                     </g>
                 </g>
             </g>
@@ -132,14 +132,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">76</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">76</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -151,14 +151,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">-73</text>
+                        <text transform="rotate(-64.11)" x="0.19">-73</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-64.11)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -172,14 +172,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">73</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">73</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -191,14 +191,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">-71</text>
+                        <text transform="rotate(68.95)" x="0.19">-71</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(68.95)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -212,14 +212,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">56</text>
+                        <text transform="rotate(29.28)" x="0.19">56</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(29.28)" x="0.19">-2</text>
                     </g>
                 </g>
             </g>
@@ -231,14 +231,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">-54</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">-54</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">3</text>
                     </g>
                 </g>
             </g>
@@ -252,14 +252,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">42</text>
+                        <text transform="rotate(87.24)" x="0.19">42</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(87.24)" x="0.19">1</text>
                     </g>
                 </g>
             </g>
@@ -271,14 +271,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">-41</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">-41</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">-2</text>
                     </g>
                 </g>
             </g>
@@ -292,14 +292,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">-23</text>
+                        <text transform="rotate(46.70)" x="0.19">-23</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(46.70)" x="0.19">4</text>
                     </g>
                 </g>
             </g>
@@ -311,14 +311,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">24</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">24</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">-5</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">-5</text>
                     </g>
                 </g>
             </g>
@@ -332,14 +332,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">-61</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">-61</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">16</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">16</text>
                     </g>
                 </g>
             </g>
@@ -351,14 +351,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">62</text>
+                        <text transform="rotate(-25.82)" x="0.19">62</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">-14</text>
+                        <text transform="rotate(-25.82)" x="0.19">-14</text>
                     </g>
                 </g>
             </g>
@@ -372,14 +372,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">28</text>
+                        <text transform="rotate(16.67)" x="0.19">28</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">-10</text>
+                        <text transform="rotate(16.67)" x="0.19">-10</text>
                     </g>
                 </g>
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
@@ -392,14 +392,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">-28</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">-28</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">11</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">11</text>
                     </g>
                 </g>
                 <circle cx="4.19" cy="-2.66" r="0.20"/>
@@ -414,14 +414,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">16</text>
+                        <text transform="rotate(77.88)" x="0.19">16</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(77.88)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
@@ -434,14 +434,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">-16</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">-16</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">2</text>
                     </g>
                 </g>
                 <circle cx="2.34" cy="-1.03" r="0.20"/>
@@ -456,14 +456,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">44</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">44</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">12</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">12</text>
                     </g>
                 </g>
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
@@ -476,14 +476,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">-44</text>
+                        <text transform="rotate(-75.51)" x="0.19">-44</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">-8</text>
+                        <text transform="rotate(-75.51)" x="0.19">-8</text>
                     </g>
                 </g>
                 <circle cx="-2.23" cy="1.78" r="0.20"/>
@@ -498,14 +498,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">7</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">7</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -517,14 +517,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">-7</text>
+                        <text transform="rotate(25.50)" x="0.19">-7</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">-3</text>
+                        <text transform="rotate(25.50)" x="0.19">-3</text>
                     </g>
                 </g>
             </g>
@@ -538,14 +538,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">8</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">8</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">3</text>
                     </g>
                 </g>
             </g>
@@ -557,14 +557,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">-8</text>
+                        <text transform="rotate(-86.25)" x="0.19">-8</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(3.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-86.25)" x="0.19">-2</text>
                     </g>
                 </g>
             </g>
@@ -578,14 +578,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">18</text>
+                        <text transform="rotate(43.11)" x="0.19">18</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">7</text>
+                        <text transform="rotate(43.11)" x="0.19">7</text>
                     </g>
                 </g>
             </g>
@@ -597,14 +597,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">-18</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">-18</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">-7</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">-7</text>
                     </g>
                 </g>
             </g>
@@ -618,14 +618,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">-17</text>
+                        <text transform="rotate(-21.53)" x="0.19">-17</text>
                     </g>
                 </g>
             </g>
@@ -637,14 +637,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">18</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">18</text>
                     </g>
                 </g>
             </g>
@@ -658,14 +658,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">28</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">28</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">6</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">6</text>
                     </g>
                 </g>
             </g>
@@ -677,14 +677,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">-28</text>
+                        <text transform="rotate(-41.18)" x="0.19">-28</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">-5</text>
+                        <text transform="rotate(-41.18)" x="0.19">-5</text>
                     </g>
                 </g>
             </g>
@@ -698,14 +698,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">5</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">5</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -717,14 +717,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">-5</text>
+                        <text transform="rotate(-4.84)" x="0.19">-5</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">-4</text>
+                        <text transform="rotate(-4.84)" x="0.19">-4</text>
                     </g>
                 </g>
             </g>
@@ -738,14 +738,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(80.10)" x="0.19">9</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(80.10)" x="0.19">4</text>
                     </g>
                 </g>
             </g>
@@ -757,14 +757,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">-9</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">-9</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-9.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">-3</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">-3</text>
                     </g>
                 </g>
             </g>
@@ -778,14 +778,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">-4</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">-4</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">-2</text>
                     </g>
                 </g>
             </g>
@@ -797,14 +797,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-27.24)" x="0.19">4</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-27.24)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -818,14 +818,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-20.78)" x="0.19">2</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(69.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(-20.78)" x="0.19">1</text>
                     </g>
                 </g>
             </g>
@@ -837,14 +837,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">-2</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">-1</text>
                     </g>
                 </g>
             </g>
@@ -858,14 +858,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">6</text>
+                        <text transform="rotate(-33.52)" x="0.19">6</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-33.52)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -877,14 +877,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">-6</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">-6</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-123.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">-2</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -92,14 +92,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">152</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">152</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">-19</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">-19</text>
                     </g>
                 </g>
             </g>
@@ -111,14 +111,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">-148</text>
+                        <text transform="rotate(-34.59)" x="0.19">-148</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">26</text>
+                        <text transform="rotate(-34.59)" x="0.19">26</text>
                     </g>
                 </g>
             </g>
@@ -132,14 +132,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">64</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">64</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -151,14 +151,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">-62</text>
+                        <text transform="rotate(-64.11)" x="0.19">-62</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(-64.11)" x="0.19">-1</text>
                     </g>
                 </g>
             </g>
@@ -172,14 +172,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">98</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">98</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">2</text>
                     </g>
                 </g>
             </g>
@@ -191,14 +191,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">-94</text>
+                        <text transform="rotate(68.95)" x="0.19">-94</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">11</text>
+                        <text transform="rotate(68.95)" x="0.19">11</text>
                     </g>
                 </g>
             </g>
@@ -212,14 +212,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">38</text>
+                        <text transform="rotate(29.28)" x="0.19">38</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(29.28)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -231,14 +231,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">-38</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">-38</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">-3</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">-3</text>
                     </g>
                 </g>
             </g>
@@ -252,14 +252,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">30</text>
+                        <text transform="rotate(87.24)" x="0.19">30</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(87.24)" x="0.19">3</text>
                     </g>
                 </g>
             </g>
@@ -271,14 +271,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">-29</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">-29</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">-6</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">-6</text>
                     </g>
                 </g>
             </g>
@@ -292,14 +292,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -311,14 +311,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">-1</text>
                     </g>
                 </g>
             </g>
@@ -332,14 +332,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">-38</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">-38</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
             </g>
@@ -351,14 +351,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">38</text>
+                        <text transform="rotate(-25.82)" x="0.19">38</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">-8</text>
+                        <text transform="rotate(-25.82)" x="0.19">-8</text>
                     </g>
                 </g>
             </g>
@@ -372,14 +372,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.67)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.67)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
@@ -392,14 +392,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="4.19" cy="-2.66" r="0.20"/>
@@ -414,14 +414,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">27</text>
+                        <text transform="rotate(77.88)" x="0.19">27</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(77.88)" x="0.19">-1</text>
                     </g>
                 </g>
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
@@ -434,14 +434,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">-27</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">-27</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
                 <circle cx="2.34" cy="-1.03" r="0.20"/>
@@ -456,14 +456,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">46</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">46</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">13</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">13</text>
                     </g>
                 </g>
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
@@ -476,14 +476,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">-46</text>
+                        <text transform="rotate(-75.51)" x="0.19">-46</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">-9</text>
+                        <text transform="rotate(-75.51)" x="0.19">-9</text>
                     </g>
                 </g>
                 <circle cx="-2.23" cy="1.78" r="0.20"/>
@@ -498,14 +498,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">15</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">15</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">-1</text>
                     </g>
                 </g>
             </g>
@@ -517,14 +517,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">-15</text>
+                        <text transform="rotate(25.50)" x="0.19">-15</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(25.50)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -538,14 +538,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">7</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">7</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">2</text>
                     </g>
                 </g>
             </g>
@@ -557,14 +557,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">-7</text>
+                        <text transform="rotate(-86.25)" x="0.19">-7</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(3.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-86.25)" x="0.19">-2</text>
                     </g>
                 </g>
             </g>
@@ -578,14 +578,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">13</text>
+                        <text transform="rotate(43.11)" x="0.19">13</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">5</text>
+                        <text transform="rotate(43.11)" x="0.19">5</text>
                     </g>
                 </g>
             </g>
@@ -597,14 +597,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">-13</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">-13</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">-5</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">-5</text>
                     </g>
                 </g>
             </g>
@@ -618,14 +618,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">-9</text>
+                        <text transform="rotate(-21.53)" x="0.19">-9</text>
                     </g>
                 </g>
             </g>
@@ -637,14 +637,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
             </g>
@@ -658,14 +658,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
             </g>
@@ -677,14 +677,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">-9</text>
+                        <text transform="rotate(-41.18)" x="0.19">-9</text>
                     </g>
                 </g>
             </g>
@@ -698,14 +698,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">-2</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">-2</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">10</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">10</text>
                     </g>
                 </g>
             </g>
@@ -717,14 +717,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(-4.84)" x="0.19">2</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">-10</text>
+                        <text transform="rotate(-4.84)" x="0.19">-10</text>
                     </g>
                 </g>
             </g>
@@ -738,14 +738,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.10)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -757,14 +757,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-9.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -778,14 +778,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">-11</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">-11</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
             </g>
@@ -797,14 +797,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">11</text>
+                        <text transform="rotate(-27.24)" x="0.19">11</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">-4</text>
+                        <text transform="rotate(-27.24)" x="0.19">-4</text>
                     </g>
                 </g>
             </g>
@@ -818,14 +818,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(69.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(-20.78)" x="0.19">1</text>
                     </g>
                 </g>
             </g>
@@ -837,14 +837,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">-1</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">-1</text>
                     </g>
                 </g>
             </g>
@@ -858,14 +858,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -877,14 +877,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-123.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -92,14 +92,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-124.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -111,14 +111,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -132,14 +132,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.11)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -151,14 +151,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.11)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(25.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.11)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -172,14 +172,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-21.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-291.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -191,14 +191,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(68.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(158.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-21.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(68.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -212,14 +212,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(119.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.28)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -231,14 +231,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-60.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -252,14 +252,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.24)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(177.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.24)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -271,14 +271,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-2.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.76)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -292,14 +292,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -311,14 +311,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -332,14 +332,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-115.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -351,14 +351,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.82)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(64.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.82)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -372,14 +372,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.67)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(106.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.67)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
@@ -392,14 +392,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-73.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="4.19" cy="-2.66" r="0.20"/>
@@ -414,14 +414,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(77.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(167.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(77.88)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
@@ -434,14 +434,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-12.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-282.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="2.34" cy="-1.03" r="0.20"/>
@@ -456,14 +456,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-165.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
@@ -476,14 +476,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(14.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(14.49)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-75.51)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-2.23" cy="1.78" r="0.20"/>
@@ -498,14 +498,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-64.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-334.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -517,14 +517,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(25.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(115.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-64.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(25.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -538,14 +538,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-176.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -557,14 +557,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(3.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(3.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-86.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -578,14 +578,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.11)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.11)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -597,14 +597,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-46.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -618,14 +618,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(68.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -637,14 +637,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.53)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -658,14 +658,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -677,14 +677,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -698,14 +698,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-94.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-4.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -717,14 +717,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-4.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(85.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(85.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-4.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -738,14 +738,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(170.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(80.10)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -757,14 +757,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-9.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-9.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-279.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -778,14 +778,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-117.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -797,14 +797,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.24)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.24)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -818,14 +818,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(69.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -837,14 +837,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-110.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -858,14 +858,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(56.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -877,14 +877,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-123.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(56.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-33.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -86,14 +86,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-18.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-288.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-18.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-18.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-288.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -105,14 +105,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-18.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(71.01)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(161.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-18.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(71.01)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -126,14 +126,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -145,14 +145,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.32)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(68.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.32)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -166,14 +166,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(26.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.88)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -185,14 +185,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-153.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -206,14 +206,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(4.76)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(94.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(4.76)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -225,14 +225,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-355.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-85.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-355.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -246,14 +246,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-163.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -265,14 +265,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.82)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(16.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(16.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-73.82)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -286,14 +286,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -305,14 +305,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-41.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -326,14 +326,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-121.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -345,14 +345,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(58.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.37)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -366,14 +366,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(83.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-6.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(83.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(83.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-6.43)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="3.50" cy="-4.69" r="0.20"/>
@@ -386,14 +386,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(83.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-6.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-96.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(83.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-6.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="3.70" cy="-4.71" r="0.20"/>
@@ -408,14 +408,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-49.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(40.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(130.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-49.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(40.78)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="3.17" cy="-1.88" r="0.20"/>
@@ -428,14 +428,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-49.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-319.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-49.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-49.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-319.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="3.32" cy="-1.75" r="0.20"/>
@@ -450,14 +450,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(75.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(165.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(75.90)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-5.44" cy="3.58" r="0.20"/>
@@ -470,14 +470,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-284.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-14.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-284.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-5.39" cy="3.77" r="0.20"/>
@@ -492,14 +492,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.42)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(74.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.42)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -511,14 +511,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-105.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(74.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-15.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -532,14 +532,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-167.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -551,14 +551,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(12.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -572,14 +572,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(50.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(140.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(50.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -591,14 +591,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-309.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-39.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-309.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -612,14 +612,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(22.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.31)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -631,14 +631,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.31)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-157.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.31)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -652,14 +652,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-173.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -671,14 +671,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(7.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-83.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -692,14 +692,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(75.83)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(165.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(75.83)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -711,14 +711,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-284.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-14.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-14.17)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-284.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -732,14 +732,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-168.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -751,14 +751,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(11.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(11.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-78.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -772,14 +772,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-99.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.62)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -791,14 +791,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.62)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(80.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(80.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-9.62)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -812,14 +812,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.42)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(81.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.42)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -831,14 +831,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-98.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(81.58)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-8.42)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -852,14 +852,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(64.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.29)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -871,14 +871,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-115.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.29)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -122,14 +122,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-167.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -141,14 +141,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(12.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -162,14 +162,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(47.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-42.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-132.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(47.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-42.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -181,14 +181,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(47.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-42.57)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(47.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(47.43)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-42.57)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -202,14 +202,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(19.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(109.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(19.29)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -221,14 +221,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-340.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-70.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-70.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-340.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -242,14 +242,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(52.45)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(142.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(52.45)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -261,14 +261,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-307.55)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-37.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-307.55)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -282,14 +282,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.17)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.17)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -301,14 +301,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -322,14 +322,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.29)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(168.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.29)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="1.07" cy="-4.04" r="0.20"/>
@@ -342,14 +342,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-11.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.71)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="1.11" cy="-3.84" r="0.20"/>
@@ -364,14 +364,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.04)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(143.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.04)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -383,14 +383,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-36.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -404,14 +404,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(27.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(117.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(27.23)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -423,14 +423,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-332.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-62.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-332.77)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -444,14 +444,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.65)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.65)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -463,14 +463,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.65)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -484,14 +484,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.54)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.54)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="3.47" cy="4.58" r="0.20"/>
@@ -504,14 +504,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.46)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.46)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.46)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="3.60" cy="4.73" r="0.20"/>
@@ -526,14 +526,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-148.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="6.70" cy="2.56" r="0.20"/>
@@ -546,14 +546,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(31.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.81)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="6.59" cy="2.73" r="0.20"/>
@@ -568,14 +568,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(141.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.96)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="6.86" cy="5.62" r="0.20"/>
@@ -588,14 +588,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-38.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="6.98" cy="5.78" r="0.20"/>
@@ -610,14 +610,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -629,14 +629,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.61)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -650,14 +650,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-155.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="6.37" cy="3.70" r="0.20"/>
@@ -670,14 +670,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(24.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.03)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="6.28" cy="3.88" r="0.20"/>
@@ -692,14 +692,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.92)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.92)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.92)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="6.69" cy="6.87" r="0.20"/>
@@ -712,14 +712,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.08)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.08)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.92)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.08)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="6.50" cy="6.82" r="0.20"/>
@@ -734,14 +734,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-91.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.90)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -753,14 +753,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(88.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -774,14 +774,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-41.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-311.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -793,14 +793,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(138.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-41.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(48.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -814,14 +814,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(56.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(146.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(56.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -833,14 +833,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-303.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-33.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-303.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -854,14 +854,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-36.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.03)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -873,14 +873,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.97)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(143.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.03)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.97)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -894,14 +894,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(41.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.50)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -913,14 +913,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-138.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-48.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -934,14 +934,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-124.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -953,14 +953,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.82)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(55.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(55.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-34.82)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -974,14 +974,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -993,14 +993,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.67)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.33)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.67)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1014,14 +1014,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.30)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(49.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.30)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1033,14 +1033,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-130.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.70)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.30)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1054,14 +1054,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-88.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-358.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1073,14 +1073,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(91.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-88.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(1.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1094,14 +1094,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(15.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1113,14 +1113,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-164.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1134,14 +1134,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1153,14 +1153,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1174,14 +1174,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1193,14 +1193,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1214,14 +1214,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-318.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-48.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-318.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1233,14 +1233,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(41.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(131.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-48.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(41.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1254,14 +1254,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-158.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1273,14 +1273,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.80)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(21.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.80)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1294,14 +1294,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1313,14 +1313,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1334,14 +1334,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1353,14 +1353,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(178.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.43)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1374,14 +1374,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1393,14 +1393,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1414,14 +1414,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1433,14 +1433,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.27)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1454,14 +1454,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(157.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1473,14 +1473,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-22.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1494,14 +1494,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(157.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(67.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1513,14 +1513,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-22.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-292.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1534,14 +1534,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1553,14 +1553,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1574,14 +1574,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(95.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(5.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1593,14 +1593,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-84.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-84.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-354.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1614,14 +1614,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-320.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-50.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-320.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1633,14 +1633,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(39.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(129.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(39.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -140,14 +140,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.05)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(71.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.05)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -159,14 +159,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-108.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.95)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.05)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -180,14 +180,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(5.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -199,14 +199,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-174.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -220,14 +220,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.12)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -239,14 +239,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -260,14 +260,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.04)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(166.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.04)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -279,14 +279,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-13.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -300,14 +300,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(42.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.43)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -319,14 +319,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-137.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -340,14 +340,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.32)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(66.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.32)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -359,14 +359,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-113.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(66.68)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-23.32)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -380,14 +380,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.34)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(89.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.34)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -399,14 +399,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.34)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-90.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.66)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.34)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -420,14 +420,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.12)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.12)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-1.69" cy="1.35" r="0.20"/>
@@ -440,14 +440,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.88)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-1.54" cy="1.21" r="0.20"/>
@@ -462,14 +462,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.09)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(49.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.09)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -481,14 +481,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-130.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(49.91)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-40.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -502,14 +502,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(89.11)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(179.11)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(89.11)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -521,14 +521,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-0.89)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.89)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.89)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -542,14 +542,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(38.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(128.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(38.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -561,14 +561,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-321.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-51.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-321.16)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -582,14 +582,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-303.38)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-33.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-303.38)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-3.85" cy="0.93" r="0.20"/>
@@ -602,14 +602,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(56.62)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(146.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-33.38)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(56.62)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-3.96" cy="0.76" r="0.20"/>
@@ -624,14 +624,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-15.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-285.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-2.93" cy="-0.45" r="0.20"/>
@@ -644,14 +644,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(164.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-15.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(74.64)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-2.99" cy="-0.64" r="0.20"/>
@@ -666,14 +666,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.31)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -685,14 +685,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -706,14 +706,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(61.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -725,14 +725,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-118.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -746,14 +746,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-38.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-308.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -765,14 +765,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(141.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-38.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(51.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -786,14 +786,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.84)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(34.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.84)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -805,14 +805,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-145.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(34.16)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-55.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -826,14 +826,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-102.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -845,14 +845,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(77.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -866,14 +866,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.71)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(27.29)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.71)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -885,14 +885,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-152.71)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(27.29)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-62.71)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -906,14 +906,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-4.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -925,14 +925,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(175.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -946,14 +946,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(60.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-29.13)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(60.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(60.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-29.13)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -965,14 +965,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(60.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-29.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-119.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(60.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-29.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -986,14 +986,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-79.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(100.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-79.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(10.93)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1005,14 +1005,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-79.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-349.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-79.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-79.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-349.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1026,14 +1026,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(172.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1045,14 +1045,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1066,14 +1066,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(78.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-11.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-101.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(78.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-11.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1085,14 +1085,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(78.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-11.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(78.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(78.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-11.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1106,14 +1106,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(7.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1125,14 +1125,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-172.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(7.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-82.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1146,14 +1146,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-54.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1165,14 +1165,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(125.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1186,14 +1186,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-102.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1205,14 +1205,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(77.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(77.63)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-12.37)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1226,14 +1226,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(54.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.31)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1245,14 +1245,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.31)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-125.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(54.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-35.31)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1266,14 +1266,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-331.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-61.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-331.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1285,14 +1285,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(28.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(118.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-61.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(28.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1306,14 +1306,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-346.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-76.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-346.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1325,14 +1325,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(13.85)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(103.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-76.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(13.85)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1346,14 +1346,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(33.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.28)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1365,14 +1365,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-146.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(33.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-56.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1386,14 +1386,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.94)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(113.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.94)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1405,14 +1405,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-66.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1426,14 +1426,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.65)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(97.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(7.65)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1445,14 +1445,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-82.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-82.35)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-352.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1466,14 +1466,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(61.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1485,14 +1485,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-118.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(61.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-28.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1506,14 +1506,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.86)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(125.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(35.86)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1525,14 +1525,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-54.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-54.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-324.14)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1546,14 +1546,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.24)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(51.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.24)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1565,14 +1565,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-128.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1586,14 +1586,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.79)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-177.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.79)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1605,14 +1605,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.79)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(2.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.21)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.79)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1626,14 +1626,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(70.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(70.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(70.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.74)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="8.70" cy="4.83" r="0.20"/>
@@ -1646,14 +1646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(70.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-109.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(70.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-19.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="8.89" cy="4.76" r="0.20"/>
@@ -1668,14 +1668,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(106.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(16.52)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1687,14 +1687,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-73.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-73.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-343.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1708,14 +1708,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(60.78)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(150.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(60.78)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1727,14 +1727,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-299.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-29.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.22)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-299.22)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1748,14 +1748,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-142.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1767,14 +1767,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.86)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(37.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.86)" x="0.19">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-branch-edges .nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}
@@ -94,7 +94,6 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-
 ]]></style>
     <metadata></metadata>
     <defs>
@@ -286,14 +285,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(159.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.52)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -305,14 +304,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-290.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-20.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-290.48)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -326,14 +325,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-153.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -345,14 +344,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.94)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(26.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.94)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -366,14 +365,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.95)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(36.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.95)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -385,14 +384,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.95)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-143.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(36.05)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-53.95)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -406,14 +405,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -425,14 +424,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -446,14 +445,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.27)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(153.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(63.27)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -465,14 +464,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-26.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-26.73)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-296.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -486,14 +485,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.04)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.04)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -505,14 +504,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.96)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.96)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -526,14 +525,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-66.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -545,14 +544,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.60)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(113.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.60)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -566,14 +565,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-55.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(34.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(124.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-55.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(34.31)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -585,14 +584,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-55.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-325.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-55.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-55.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-325.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -606,14 +605,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(82.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -625,14 +624,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-97.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -646,14 +645,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(171.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.61)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="7.43" cy="-1.16" r="0.20"/>
@@ -666,14 +665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-8.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="7.46" cy="-0.96" r="0.20"/>
@@ -688,14 +687,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(171.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(81.61)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="8.22" cy="-1.28" r="0.20"/>
@@ -708,14 +707,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-8.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-8.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-278.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="8.25" cy="-1.08" r="0.20"/>
@@ -730,14 +729,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(25.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -749,14 +748,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -770,14 +769,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(98.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.88)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -789,14 +788,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-81.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.12)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -810,14 +809,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.83)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -829,14 +828,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.17)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(172.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(82.17)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -850,14 +849,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-46.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -869,14 +868,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.14)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.14)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -890,14 +889,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.61)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="17.93" cy="-2.20" r="0.20"/>
@@ -910,14 +909,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="18.07" cy="-2.05" r="0.20"/>
@@ -932,14 +931,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-332.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-62.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-332.82)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -951,14 +950,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(27.18)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(117.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-62.82)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(27.18)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -972,14 +971,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-58.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-328.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -991,14 +990,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.76)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.24)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(31.76)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1012,14 +1011,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-141.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1031,14 +1030,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(38.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(38.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-51.44)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1052,14 +1051,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-305.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-35.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-305.54)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1071,14 +1070,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(54.46)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(144.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(54.46)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1092,14 +1091,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.20)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-91.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.20)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1111,14 +1110,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.20)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(88.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(88.80)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-1.20)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1132,14 +1131,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.52)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(69.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.52)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="8.76" cy="-12.62" r="0.20"/>
@@ -1152,14 +1151,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-110.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(69.48)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-20.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="8.95" cy="-12.69" r="0.20"/>
@@ -1174,14 +1173,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-286.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-16.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-286.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1193,14 +1192,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(73.94)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(163.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-16.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(73.94)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1214,14 +1213,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-136.23)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.23)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="0.64" cy="-10.67" r="0.20"/>
@@ -1234,14 +1233,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.23)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(43.77)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.77)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.23)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="0.50" cy="-10.53" r="0.20"/>
@@ -1256,14 +1255,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-40.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-310.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1275,14 +1274,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(139.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-40.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(49.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1296,14 +1295,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-153.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.60)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-0.13" cy="-3.19" r="0.20"/>
@@ -1316,14 +1315,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.60)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(26.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(26.40)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-63.60)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-0.22" cy="-3.01" r="0.20"/>
@@ -1338,14 +1337,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.61)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(177.61)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(87.61)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="1.38" cy="-4.19" r="0.20"/>
@@ -1358,14 +1357,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-2.39)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-2.39)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-272.39)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="1.39" cy="-3.99" r="0.20"/>
@@ -1380,14 +1379,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-136.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1399,14 +1398,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(43.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-46.44)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1420,14 +1419,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-299.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-29.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-299.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1439,14 +1438,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(60.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(150.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(60.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1460,14 +1459,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-0.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-270.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1479,14 +1478,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(89.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(179.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-0.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(89.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1500,14 +1499,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-66.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-336.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1519,14 +1518,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(113.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-66.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(23.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1540,14 +1539,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1559,14 +1558,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1580,14 +1579,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-139.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.43)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-5.89" cy="-7.95" r="0.20"/>
@@ -1600,14 +1599,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(40.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(40.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-49.43)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-6.02" cy="-7.80" r="0.20"/>
@@ -1622,14 +1621,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(4.22)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(94.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(4.22)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1641,14 +1640,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-355.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-85.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-85.78)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-355.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1662,14 +1661,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.46)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.46)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.46)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-12.55" cy="-13.38" r="0.20"/>
@@ -1682,14 +1681,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.46)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.54)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.54)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.46)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-12.75" cy="-13.33" r="0.20"/>
@@ -1704,14 +1703,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(52.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-127.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(52.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.94)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-8.12" cy="-12.05" r="0.20"/>
@@ -1724,14 +1723,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(52.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.94)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(52.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(52.06)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-37.94)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-8.28" cy="-11.93" r="0.20"/>
@@ -1746,14 +1745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.45)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(175.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(85.45)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1765,14 +1764,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.55)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-4.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-4.55)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-274.55)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1786,14 +1785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.66)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-137.66)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.66)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1805,14 +1804,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.66)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(42.34)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.34)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-47.66)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1826,14 +1825,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.93)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(84.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.93)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="3.66" cy="9.59" r="0.20"/>
@@ -1846,14 +1845,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-95.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(84.07)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-5.93)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="3.86" cy="9.57" r="0.20"/>
@@ -1868,14 +1867,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-80.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-350.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1887,14 +1886,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.14)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(99.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-80.86)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(9.14)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1908,14 +1907,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(50.16)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(140.16)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(50.16)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1927,14 +1926,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-309.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-39.84)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-39.84)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-309.84)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1948,14 +1947,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.01)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.01)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -1967,14 +1966,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.99)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.01)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.99)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -1988,14 +1987,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.01)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(119.01)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(29.01)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2007,14 +2006,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-60.99)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-60.99)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-330.99)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2028,14 +2027,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-150.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="5.49" cy="19.33" r="0.20"/>
@@ -2048,14 +2047,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(29.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="5.39" cy="19.51" r="0.20"/>
@@ -2070,14 +2069,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-150.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="6.19" cy="19.72" r="0.20"/>
@@ -2090,14 +2089,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(29.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(29.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-60.72)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="6.09" cy="19.90" r="0.20"/>
@@ -2112,14 +2111,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.10)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(68.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.10)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="9.72" cy="16.44" r="0.20"/>
@@ -2132,14 +2131,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.90)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="9.91" cy="16.37" r="0.20"/>
@@ -2154,14 +2153,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-117.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.17)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2173,14 +2172,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.17)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.83)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.17)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2194,14 +2193,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(46.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2213,14 +2212,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-133.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-43.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2234,14 +2233,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(25.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2253,14 +2252,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-154.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-64.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2274,14 +2273,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(5.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2293,14 +2292,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-174.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-84.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2314,14 +2313,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(28.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-61.24)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(28.76)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(28.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-61.24)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2333,14 +2332,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(28.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-61.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-151.24)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(28.76)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-61.24)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2354,14 +2353,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-90.80)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.80)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2373,14 +2372,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.80)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(89.20)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(89.20)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-0.80)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2394,14 +2393,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.36)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2413,14 +2412,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.36)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2434,14 +2433,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-148.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.13)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2453,14 +2452,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.13)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(31.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-58.13)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2474,14 +2473,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(42.63)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-11.21" cy="21.02" r="0.20"/>
@@ -2494,14 +2493,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-47.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.37)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-317.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-11.06" cy="21.16" r="0.20"/>
@@ -2516,14 +2515,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-32.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.72)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2535,14 +2534,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(147.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.28)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2556,14 +2555,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-1.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-271.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2575,14 +2574,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.56)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(178.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-1.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(88.56)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2596,14 +2595,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.00)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(13.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.00)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2615,14 +2614,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-167.00)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(13.00)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-77.00)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2636,14 +2635,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.75)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(51.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.75)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2655,14 +2654,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-128.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(51.25)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-38.75)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2676,14 +2675,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.73)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(37.27)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.73)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2695,14 +2694,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-142.73)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(37.27)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-52.73)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2716,14 +2715,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.03)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(143.03)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(53.03)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2735,14 +2734,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-36.97)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-36.97)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-306.97)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2756,14 +2755,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-13.18)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-283.18)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2775,14 +2774,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.82)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(166.82)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-13.18)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(76.82)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2796,14 +2795,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.81)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(22.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.81)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2815,14 +2814,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-157.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.19)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.81)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2836,14 +2835,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-44.57)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-314.57)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2855,14 +2854,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.43)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(135.43)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-44.57)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(45.43)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -2876,14 +2875,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(76.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-13.88)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(76.12)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(76.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-13.88)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-10.01" cy="9.37" r="0.20"/>
@@ -2896,14 +2895,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(76.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-13.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-103.88)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(76.12)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-13.88)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-9.82" cy="9.32" r="0.20"/>
@@ -2918,14 +2917,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.50)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(71.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.50)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-8.79" cy="5.37" r="0.20"/>
@@ -2938,14 +2937,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-108.50)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(71.50)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-18.50)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-8.60" cy="5.31" r="0.20"/>
@@ -2960,14 +2959,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-164.87)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.87)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -2979,14 +2978,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(15.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(15.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-74.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3000,14 +2999,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(57.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-32.25)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(57.75)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(57.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-32.25)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3019,14 +3018,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(57.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-32.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-122.25)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(57.75)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-32.25)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3040,14 +3039,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3059,14 +3058,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3080,14 +3079,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.74)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(72.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.74)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3099,14 +3098,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-107.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.26)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-17.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3120,14 +3119,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.15)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(21.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.15)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3139,14 +3138,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-158.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.85)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.15)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3160,14 +3159,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-155.86)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.86)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3179,14 +3178,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.86)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(24.14)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(24.14)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-65.86)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3200,14 +3199,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.91)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(147.91)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(57.91)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3219,14 +3218,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-32.09)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-32.09)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-302.09)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3240,14 +3239,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.26)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(75.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.26)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3259,14 +3258,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-104.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-14.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3280,14 +3279,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.85)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(68.15)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.85)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3299,14 +3298,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-111.85)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(68.15)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-21.85)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3320,14 +3319,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.68)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(58.32)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.68)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3339,14 +3338,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-121.68)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(58.32)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-31.68)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3360,14 +3359,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-11.52)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-281.52)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3379,14 +3378,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.48)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(168.48)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-11.52)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(78.48)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3400,14 +3399,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-46.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-316.67)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3419,14 +3418,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(133.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-46.67)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(43.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3440,14 +3439,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-81.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-351.02)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -3459,14 +3458,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.98)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(98.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.02)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(8.98)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3480,14 +3479,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(22.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.59)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -3499,14 +3498,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-157.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(22.41)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-67.59)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-disconnected {--nad-vl-color: #808080}
 .nad-vl0to30-0 {--nad-vl-color: #afb42b}
 .nad-vl0to30-1 {--nad-vl-color: #e6ee9c}

--- a/src/test/resources/double_labels.svg
+++ b/src/test/resources/double_labels.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="680.96" viewBox="-3.99 -4.23 11.54 9.82" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
+.nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-bg circle {stroke: none; fill: white}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+]]></style>
+    <metadata></metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-1.99,-2.23)" id="0" class="nad-vl120to180">
+            <circle r="0.30" id="1"/>
+        </g>
+        <g transform="translate(-1.80,3.59)" id="2" class="nad-vl30to50">
+            <circle r="0.30" id="3"/>
+        </g>
+        <g transform="translate(4.55,-0.65)" id="4" class="nad-vl0to30">
+            <circle r="0.30" id="5"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges"></g>
+    <g class="nad-3wt-edges">
+        <g id="7" class="nad-vl120to180">
+            <polyline points="-1.80,-2.03 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(-1.38,-1.61)">
+                <g class="nad-state-in">
+                    <g transform="rotate(135.46)">
+                        <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                        <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                    </g>
+                    <text transform="rotate(45.46)" x="0.20">ext.</text>
+                    <text transform="rotate(45.46)" x="-0.20" style="text-anchor:end">int.</text>
+                </g>
+            </g>
+        </g>
+        <g id="8" class="nad-vl30to50">
+            <polyline points="-1.63,3.38 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(-1.25,2.92)">
+                <g class="nad-state-in">
+                    <g transform="rotate(39.54)">
+                        <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                        <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                    </g>
+                    <text transform="rotate(-50.46)" x="0.20">ext.</text>
+                    <text transform="rotate(-50.46)" x="-0.20" style="text-anchor:end">int.</text>
+                </g>
+            </g>
+        </g>
+        <g id="9" class="nad-vl0to30">
+            <polyline points="4.29,-0.57 0.73,0.53"/>
+            <g class="nad-edge-infos" transform="translate(3.72,-0.40)">
+                <g class="nad-state-in">
+                    <g transform="rotate(-107.23)">
+                        <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                        <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                    </g>
+                    <text transform="rotate(-17.23)" x="-0.20" style="text-anchor:end">ext.</text>
+                    <text transform="rotate(-17.23)" x="0.20">int.</text>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-3wt-nodes">
+        <g transform="translate(0.73,0.53)">
+            <g class="nad-3wt-bg">
+                <circle cx="0.00" cy="0.12" r="0.20"/>
+                <circle cx="-0.10" cy="-0.06" r="0.20"/>
+                <circle cx="0.10" cy="-0.06" r="0.20"/>
+            </g>
+            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
+            <circle class="nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
+            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_text_edge" points="-1.69,-2.23 -0.99,-2.23"/>
+        <polyline id="2_text_edge" points="-1.50,3.59 -0.80,3.59"/>
+        <polyline id="4_text_edge" points="4.85,-0.65 5.55,-0.65"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" x="-0.99" y="-2.23" style="dominant-baseline:middle">VL_132</text>
+        <text filter="url(#textBgFilter)" x="-0.80" y="3.59" style="dominant-baseline:middle">VL_33</text>
+        <text filter="url(#textBgFilter)" x="5.55" y="-0.65" style="dominant-baseline:middle">VL_11</text>
+    </g>
+</svg>

--- a/src/test/resources/edge_info_double_labels.svg
+++ b/src/test/resources/edge_info_double_labels.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -59,8 +59,8 @@
                         <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.20">ext.</text>
-                    <text transform="rotate(45.46)" x="-0.20" style="text-anchor:end">int.</text>
+                    <text transform="rotate(45.46)" x="0.20">145</text>
+                    <text transform="rotate(45.46)" x="-0.20" style="text-anchor:end">243</text>
                 </g>
             </g>
         </g>
@@ -72,8 +72,8 @@
                         <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.20">ext.</text>
-                    <text transform="rotate(-50.46)" x="-0.20" style="text-anchor:end">int.</text>
+                    <text transform="rotate(-50.46)" x="0.20">145</text>
+                    <text transform="rotate(-50.46)" x="-0.20" style="text-anchor:end">243</text>
                 </g>
             </g>
         </g>
@@ -85,8 +85,8 @@
                         <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-17.23)" x="-0.20" style="text-anchor:end">ext.</text>
-                    <text transform="rotate(-17.23)" x="0.20">int.</text>
+                    <text transform="rotate(-17.23)" x="-0.20" style="text-anchor:end">145</text>
+                    <text transform="rotate(-17.23)" x="0.20">243</text>
                 </g>
             </g>
         </g>

--- a/src/test/resources/edge_info_missing_label.svg
+++ b/src/test/resources/edge_info_missing_label.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="770.68" viewBox="-5.78 -4.98 10.39 10.01" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
@@ -39,48 +39,45 @@
         </filter>
     </defs>
     <g class="nad-vl-nodes">
-        <g transform="translate(-3.78,1.10)" id="0" class="nad-vl0to30" title="VL_11">
+        <g transform="translate(1.60,-0.89)" id="0" class="nad-vl300to500">
             <circle r="0.30" id="1"/>
         </g>
-    </g>
-    <g class="nad-branch-edges"></g>
-    <g class="nad-3wt-edges">
-        <g id="3" class="nad-vl0to30" title="3WT">
-            <polyline points="-3.52,1.03 0.06,0.04"/>
-            <g class="nad-edge-infos" transform="translate(-3.23,0.95)">
-                <g class="nad-active nad-state-out">
-                    <g transform="rotate(74.59)">
-                        <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                        <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                    </g>
-                    <text transform="rotate(-15.41)" x="0.19">0</text>
-                </g>
-                <g class="nad-reactive nad-state-out">
-                    <g transform="rotate(74.59)">
-                        <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                        <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                    </g>
-                    <text transform="rotate(-15.41)" x="0.19">0</text>
-                </g>
-            </g>
+        <g transform="translate(-0.85,1.68)" id="2" class="nad-vl300to500">
+            <circle r="0.30" id="3"/>
         </g>
     </g>
-    <g class="nad-3wt-nodes">
-        <g transform="translate(0.06,0.04)">
-            <g class="nad-3wt-bg">
-                <circle cx="0.00" cy="0.12" r="0.20"/>
-                <circle cx="-0.10" cy="-0.06" r="0.20"/>
-                <circle cx="0.10" cy="-0.06" r="0.20"/>
+    <g class="nad-branch-edges">
+        <g id="4">
+            <g class="nad-vl300to500">
+                <polyline points="1.41,-0.69 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(1.34,-0.62)">
+                    <g class="nad-state-out">
+                        <g transform="rotate(-136.40)">
+                            <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                        </g>
+                    </g>
+                </g>
             </g>
-            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
-            <circle class="nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
-            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+            <g class="nad-vl300to500">
+                <polyline points="-0.66,1.48 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(-0.59,1.41)">
+                    <g class="nad-state-out">
+                        <g transform="rotate(43.60)">
+                            <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_text_edge" points="-3.48,1.10 -2.78,1.10"/>
+        <polyline id="0_text_edge" points="1.90,-0.89 2.60,-0.89"/>
+        <polyline id="2_text_edge" points="-0.55,1.68 0.15,1.68"/>
     </g>
     <g class="nad-text-nodes">
-        <text filter="url(#textBgFilter)" x="-2.78" y="1.10" style="dominant-baseline:middle">VL_11</text>
+        <text filter="url(#textBgFilter)" x="2.60" y="-0.89" style="dominant-baseline:middle">vl1</text>
+        <text filter="url(#textBgFilter)" x="0.15" y="1.68" style="dominant-baseline:middle">vl2</text>
     </g>
 </svg>

--- a/src/test/resources/edge_info_perpendicular_label.svg
+++ b/src/test/resources/edge_info_perpendicular_label.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -56,8 +56,8 @@
                             <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.60)" y="0.29" style="text-anchor:middle">ext.</text>
-                        <text transform="rotate(43.60)" y="-0.29" style="text-anchor:middle">int.</text>
+                        <text transform="rotate(43.60)" y="0.29" style="text-anchor:middle">ext</text>
+                        <text transform="rotate(43.60)" y="-0.25" style="text-anchor:middle">int</text>
                     </g>
                 </g>
             </g>
@@ -69,8 +69,8 @@
                             <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(43.60)" y="-0.25" style="text-anchor:middle">ext.</text>
-                        <text transform="rotate(43.60)" y="0.25" style="text-anchor:middle">int.</text>
+                        <text transform="rotate(43.60)" y="-0.25" style="text-anchor:middle">ext</text>
+                        <text transform="rotate(43.60)" y="0.29" style="text-anchor:middle">int</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -65,14 +65,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.83)" x="0.12" style="dominant-baseline:middle">-80</text>
+                        <text transform="rotate(-2.17)" x="0.19">-80</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(87.83)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.83)" x="0.12" style="dominant-baseline:middle">-10</text>
+                        <text transform="rotate(-2.17)" x="0.19">-10</text>
                     </g>
                 </g>
                 <circle cx="-3.81" cy="0.54" r="0.20"/>
@@ -85,14 +85,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.83)" x="0.12" style="dominant-baseline:middle">80</text>
+                        <text transform="rotate(-2.17)" x="-0.19" style="text-anchor:end">80</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-92.17)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(87.83)" x="0.12" style="dominant-baseline:middle">5</text>
+                        <text transform="rotate(-2.17)" x="-0.19" style="text-anchor:end">5</text>
                     </g>
                 </g>
                 <circle cx="-3.61" cy="0.53" r="0.20"/>
@@ -107,14 +107,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.36)" x="0.12" style="dominant-baseline:middle">10</text>
+                        <text transform="rotate(-47.64)" x="0.19">10</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(42.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.36)" x="0.12" style="dominant-baseline:middle">-512</text>
+                        <text transform="rotate(-47.64)" x="0.19">-512</text>
                     </g>
                 </g>
             </g>
@@ -126,14 +126,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.36)" x="0.12" style="dominant-baseline:middle">-10</text>
+                        <text transform="rotate(-47.64)" x="-0.19" style="text-anchor:end">-10</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-137.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(42.36)" x="0.12" style="dominant-baseline:middle">-120</text>
+                        <text transform="rotate(-47.64)" x="-0.19" style="text-anchor:end">-120</text>
                     </g>
                 </g>
             </g>
@@ -148,14 +148,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-83.47)" x="0.12" style="dominant-baseline:middle">81</text>
+                        <text transform="rotate(6.53)" x="0.19">81</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(96.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-83.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(6.53)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -167,14 +167,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-83.47)" x="0.12" style="dominant-baseline:middle">-79</text>
+                        <text transform="rotate(-353.47)" x="-0.19" style="text-anchor:end">-79</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-83.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-83.47)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-353.47)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -189,14 +189,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.47)" x="0.12" style="dominant-baseline:middle">110</text>
+                        <text transform="rotate(60.53)" x="0.19">110</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(150.53)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.47)" x="0.12" style="dominant-baseline:middle">190</text>
+                        <text transform="rotate(60.53)" x="0.19">190</text>
                     </g>
                 </g>
             </g>
@@ -208,14 +208,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.47)" x="0.12" style="dominant-baseline:middle">-110</text>
+                        <text transform="rotate(-299.47)" x="-0.19" style="text-anchor:end">-110</text>
                     </g>
                     <g class="nad-reactive nad-state-in">
                         <g transform="rotate(-29.47)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-29.47)" x="0.12" style="dominant-baseline:middle">-185</text>
+                        <text transform="rotate(-299.47)" x="-0.19" style="text-anchor:end">-185</text>
                     </g>
                 </g>
             </g>
@@ -229,14 +229,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-71.59)" x="0.12" style="dominant-baseline:middle">240</text>
+                        <text transform="rotate(18.41)" x="0.19">240</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(108.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-71.59)" x="0.12" style="dominant-baseline:middle">2</text>
+                        <text transform="rotate(18.41)" x="0.19">2</text>
                     </g>
                 </g>
             </g>
@@ -248,14 +248,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-71.59)" x="0.12" style="dominant-baseline:middle">-240</text>
+                        <text transform="rotate(-341.59)" x="-0.19" style="text-anchor:end">-240</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-71.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-71.59)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(-341.59)" x="-0.19" style="text-anchor:end">3</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/perpendicular_labels.svg
+++ b/src/test/resources/perpendicular_labels.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
+.nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-bg circle {stroke: none; fill: white}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+]]></style>
+    <metadata></metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(1.60,-0.89)" id="0" class="nad-vl300to500">
+            <circle r="0.30" id="1"/>
+        </g>
+        <g transform="translate(-0.85,1.68)" id="2" class="nad-vl300to500">
+            <circle r="0.30" id="3"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="4">
+            <g class="nad-vl300to500">
+                <polyline points="1.41,-0.69 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(1.06,-0.33)">
+                    <g class="nad-state-out">
+                        <g transform="rotate(-136.40)">
+                            <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.60)" y="0.29" style="text-anchor:middle">ext.</text>
+                        <text transform="rotate(43.60)" y="-0.29" style="text-anchor:middle">int.</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl300to500">
+                <polyline points="-0.66,1.48 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(-0.32,1.12)">
+                    <g class="nad-state-out">
+                        <g transform="rotate(43.60)">
+                            <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(43.60)" y="-0.25" style="text-anchor:middle">ext.</text>
+                        <text transform="rotate(43.60)" y="0.25" style="text-anchor:middle">int.</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_text_edge" points="1.90,-0.89 2.60,-0.89"/>
+        <polyline id="2_text_edge" points="-0.55,1.68 0.15,1.68"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" x="2.60" y="-0.89" style="dominant-baseline:middle">vl1</text>
+        <text filter="url(#textBgFilter)" x="0.15" y="1.68" style="dominant-baseline:middle">vl2</text>
+    </g>
+</svg>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -82,14 +82,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -101,14 +101,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -122,14 +122,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-97.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -141,14 +141,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(2.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -162,14 +162,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(82.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(82.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-7.44)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-3.87" cy="-1.37" r="0.20"/>
@@ -182,14 +182,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-177.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(2.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-87.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-3.96" cy="-1.27" r="0.20"/>
@@ -204,14 +204,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -223,14 +223,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -244,14 +244,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -263,14 +263,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -284,14 +284,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.26)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.26)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -303,14 +303,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -324,14 +324,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -343,14 +343,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -364,14 +364,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -383,14 +383,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -404,14 +404,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -423,14 +423,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -444,14 +444,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -463,14 +463,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -484,14 +484,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -503,14 +503,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -524,14 +524,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(11.72)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(101.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(11.72)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -543,14 +543,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-158.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -564,14 +564,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -583,14 +583,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -604,14 +604,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-348.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-78.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.28)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-348.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-0.23" cy="6.36" r="0.20"/>
@@ -624,14 +624,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.28)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(21.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(21.72)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-68.28)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="-0.11" cy="6.29" r="0.20"/>
@@ -646,14 +646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -665,14 +665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -686,14 +686,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -705,14 +705,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -726,14 +726,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -745,14 +745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -766,14 +766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -785,14 +785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -82,14 +82,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -101,14 +101,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -122,14 +122,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.44)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(62.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(62.56)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-27.44)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -141,14 +141,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(52.56)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(142.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-37.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(52.56)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -162,14 +162,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-87.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-87.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-357.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-5.62" cy="-2.79" r="0.20"/>
@@ -182,14 +182,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-7.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-7.44)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-277.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-5.53" cy="-2.89" r="0.20"/>
@@ -204,14 +204,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -223,14 +223,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -244,14 +244,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -263,14 +263,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-45.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -284,14 +284,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.26)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.26)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -303,14 +303,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -324,14 +324,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -343,14 +343,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(46.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -364,14 +364,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -383,14 +383,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-26.19)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -404,14 +404,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -423,14 +423,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-80.21)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -444,14 +444,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -463,14 +463,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.90)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(65.90)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -484,14 +484,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -503,14 +503,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -524,14 +524,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.87)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(64.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(64.13)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-25.87)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -543,14 +543,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(54.13)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(144.13)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-35.87)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(54.13)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -564,14 +564,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -583,14 +583,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -604,14 +604,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.31)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(159.31)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-20.69)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(69.31)" x="0.19">0</text>
                     </g>
                 </g>
                 <circle cx="0.05" cy="8.40" r="0.20"/>
@@ -624,14 +624,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-30.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-120.69)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(59.31)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-30.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
                 <circle cx="-0.07" cy="8.36" r="0.20"/>
@@ -646,14 +646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -665,14 +665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(14.49)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -686,14 +686,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -705,14 +705,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -726,14 +726,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.36)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(70.36)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -745,14 +745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -766,14 +766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.96)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(12.96)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -785,14 +785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: white}
-.nad-edge-infos .nad-state-out {fill: white}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: #b71c1c}
+.nad-edge-infos .nad-state-out {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -5,7 +5,7 @@
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
-.nad-disconnected {stroke-dasharray: .1,.1}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
 .nad-vl-nodes circle {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
 .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round;}
@@ -20,9 +20,9 @@
 .nad-reactive path {stroke: none; fill: #0277bd}
 .nad-text-background {flood-color: #90a4aeaa}
 .nad-text-nodes {font: 0.25px "Verdana"; fill: black}
-.nad-edge-infos {font: 0.2px "Verdana"}
-.nad-edge-infos .nad-state-in {fill: #b71c1c}
-.nad-edge-infos .nad-state-out {fill: #2e7d32}
+.nad-edge-infos {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: var(--nad-vl-color, white); stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in {fill: white}
+.nad-edge-infos .nad-state-out {fill: white}
 .nad-vl0to30 {--nad-vl-color: #AFB42B}
 .nad-vl30to50 {--nad-vl-color: #EF9A9A}
 .nad-vl50to70 {--nad-vl-color: #9C27B0}
@@ -82,14 +82,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">-1150</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">-1150</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">41</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">41</text>
                     </g>
                 </g>
             </g>
@@ -101,14 +101,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">1150</text>
+                        <text transform="rotate(-79.70)" x="0.19">1150</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">41</text>
+                        <text transform="rotate(-79.70)" x="0.19">41</text>
                     </g>
                 </g>
             </g>
@@ -122,14 +122,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">-618</text>
+                        <text transform="rotate(-17.44)" x="0.19">-618</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(72.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.56)" x="0.12" style="dominant-baseline:middle">12</text>
+                        <text transform="rotate(-17.44)" x="0.19">12</text>
                     </g>
                 </g>
             </g>
@@ -141,14 +141,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">618</text>
+                        <text transform="rotate(42.56)" x="0.19">618</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(132.56)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-47.44)" x="0.12" style="dominant-baseline:middle">12</text>
+                        <text transform="rotate(42.56)" x="0.19">12</text>
                     </g>
                 </g>
             </g>
@@ -162,14 +162,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">-267</text>
+                        <text transform="rotate(-347.44)" x="-0.19" style="text-anchor:end">-267</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.44)" x="0.12" style="dominant-baseline:middle">8</text>
+                        <text transform="rotate(-347.44)" x="-0.19" style="text-anchor:end">8</text>
                     </g>
                 </g>
                 <circle cx="-5.61" cy="-2.79" r="0.20"/>
@@ -182,14 +182,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">267</text>
+                        <text transform="rotate(-287.44)" x="-0.19" style="text-anchor:end">267</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-17.44)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-17.44)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(-287.44)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
                 <circle cx="-5.53" cy="-2.88" r="0.20"/>
@@ -204,14 +204,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">533</text>
+                        <text transform="rotate(-79.70)" x="0.19">533</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(10.30)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-79.70)" x="0.19">9</text>
                     </g>
                 </g>
             </g>
@@ -223,14 +223,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">-533</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">-533</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-169.70)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(10.30)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-79.70)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
             </g>
@@ -244,14 +244,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">-1183</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">-1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-135.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">44</text>
+                        <text transform="rotate(-45.19)" x="-0.19" style="text-anchor:end">44</text>
                     </g>
                 </g>
             </g>
@@ -263,14 +263,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">1183</text>
+                        <text transform="rotate(-45.19)" x="0.19">1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(44.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(44.81)" x="0.12" style="dominant-baseline:middle">44</text>
+                        <text transform="rotate(-45.19)" x="0.19">44</text>
                     </g>
                 </g>
             </g>
@@ -284,14 +284,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">318</text>
+                        <text transform="rotate(65.26)" x="0.19">318</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(65.26)" x="0.19">3</text>
                     </g>
                 </g>
             </g>
@@ -303,14 +303,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">-318</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">-318</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.74)" x="0.12" style="dominant-baseline:middle">3</text>
+                        <text transform="rotate(-294.74)" x="-0.19" style="text-anchor:end">3</text>
                     </g>
                 </g>
             </g>
@@ -324,14 +324,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">-394</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">-394</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-43.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">5</text>
+                        <text transform="rotate(-313.04)" x="-0.19" style="text-anchor:end">5</text>
                     </g>
                 </g>
             </g>
@@ -343,14 +343,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">394</text>
+                        <text transform="rotate(46.96)" x="0.19">394</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(136.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-43.04)" x="0.12" style="dominant-baseline:middle">5</text>
+                        <text transform="rotate(46.96)" x="0.19">5</text>
                     </g>
                 </g>
             </g>
@@ -364,14 +364,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">-606</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">-606</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-116.19)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">11</text>
+                        <text transform="rotate(-26.19)" x="-0.19" style="text-anchor:end">11</text>
                     </g>
                 </g>
             </g>
@@ -383,14 +383,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">606</text>
+                        <text transform="rotate(-26.19)" x="0.19">606</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(63.81)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(63.81)" x="0.12" style="dominant-baseline:middle">11</text>
+                        <text transform="rotate(-26.19)" x="0.19">11</text>
                     </g>
                 </g>
             </g>
@@ -404,14 +404,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">-212</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">-212</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-170.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(-80.21)" x="-0.19" style="text-anchor:end">1</text>
                     </g>
                 </g>
             </g>
@@ -423,14 +423,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">212</text>
+                        <text transform="rotate(-80.21)" x="0.19">212</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(9.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(9.79)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(-80.21)" x="0.19">1</text>
                     </g>
                 </g>
             </g>
@@ -444,14 +444,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">-1183</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">-1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-24.10)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">44</text>
+                        <text transform="rotate(-294.10)" x="-0.19" style="text-anchor:end">44</text>
                     </g>
                 </g>
             </g>
@@ -463,14 +463,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">1183</text>
+                        <text transform="rotate(65.90)" x="0.19">1183</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(155.90)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-24.10)" x="0.12" style="dominant-baseline:middle">44</text>
+                        <text transform="rotate(65.90)" x="0.19">44</text>
                     </g>
                 </g>
             </g>
@@ -484,14 +484,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">1317</text>
+                        <text transform="rotate(-41.06)" x="0.19">1317</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(48.94)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">54</text>
+                        <text transform="rotate(-41.06)" x="0.19">54</text>
                     </g>
                 </g>
             </g>
@@ -503,14 +503,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">-1317</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">-1317</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-131.06)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(48.94)" x="0.12" style="dominant-baseline:middle">54</text>
+                        <text transform="rotate(-41.06)" x="-0.19" style="text-anchor:end">54</text>
                     </g>
                 </g>
             </g>
@@ -524,14 +524,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">1523</text>
+                        <text transform="rotate(-298.28)" x="-0.19" style="text-anchor:end">1523</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-28.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-28.28)" x="0.12" style="dominant-baseline:middle">73</text>
+                        <text transform="rotate(-298.28)" x="-0.19" style="text-anchor:end">73</text>
                     </g>
                 </g>
             </g>
@@ -543,14 +543,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">-1523</text>
+                        <text transform="rotate(-58.28)" x="0.19">-1523</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(31.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(31.72)" x="0.12" style="dominant-baseline:middle">73</text>
+                        <text transform="rotate(-58.28)" x="0.19">73</text>
                     </g>
                 </g>
             </g>
@@ -564,14 +564,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">-148</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">-148</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">1</text>
                     </g>
                 </g>
             </g>
@@ -583,14 +583,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">148</text>
+                        <text transform="rotate(14.49)" x="0.19">148</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1</text>
+                        <text transform="rotate(14.49)" x="0.19">1</text>
                     </g>
                 </g>
             </g>
@@ -604,14 +604,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">376</text>
+                        <text transform="rotate(31.72)" x="0.19">376</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(121.72)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-58.28)" x="0.12" style="dominant-baseline:middle">4</text>
+                        <text transform="rotate(31.72)" x="0.19">4</text>
                     </g>
                 </g>
                 <circle cx="0.95" cy="8.27" r="0.20"/>
@@ -624,14 +624,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">-376</text>
+                        <text transform="rotate(-88.28)" x="-0.19" style="text-anchor:end">-376</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-178.28)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.72)" x="0.12" style="dominant-baseline:middle">9</text>
+                        <text transform="rotate(-88.28)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
                 <circle cx="0.84" cy="8.33" r="0.20"/>
@@ -646,14 +646,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">-1670</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">-1670</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-75.51)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">87</text>
+                        <text transform="rotate(-345.51)" x="-0.19" style="text-anchor:end">87</text>
                     </g>
                 </g>
             </g>
@@ -665,14 +665,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">1670</text>
+                        <text transform="rotate(14.49)" x="0.19">1670</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(104.49)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-75.51)" x="0.12" style="dominant-baseline:middle">87</text>
+                        <text transform="rotate(14.49)" x="0.19">87</text>
                     </g>
                 </g>
             </g>
@@ -686,14 +686,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">-61</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">-61</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-134.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
@@ -705,14 +705,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">61</text>
+                        <text transform="rotate(-44.58)" x="0.19">61</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(45.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(45.42)" x="0.12" style="dominant-baseline:middle">0</text>
+                        <text transform="rotate(-44.58)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
@@ -726,14 +726,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">561</text>
+                        <text transform="rotate(70.36)" x="0.19">561</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(160.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">10</text>
+                        <text transform="rotate(70.36)" x="0.19">10</text>
                     </g>
                 </g>
             </g>
@@ -745,14 +745,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">-561</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">-561</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-19.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.64)" x="0.12" style="dominant-baseline:middle">10</text>
+                        <text transform="rotate(-289.64)" x="-0.19" style="text-anchor:end">10</text>
                     </g>
                 </g>
             </g>
@@ -766,14 +766,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">622</text>
+                        <text transform="rotate(12.96)" x="0.19">622</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(102.96)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">12</text>
+                        <text transform="rotate(12.96)" x="0.19">12</text>
                     </g>
                 </g>
             </g>
@@ -785,14 +785,14 @@
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">-622</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">-622</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
                         <g transform="rotate(-77.04)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-77.04)" x="0.12" style="dominant-baseline:middle">12</text>
+                        <text transform="rotate(-347.04)" x="-0.19" style="text-anchor:end">12</text>
                     </g>
                 </g>
             </g>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?**
No


**What kind of change does this PR introduce?**
Feature



**What is the current behavior?** *(You can also link to an open issue here)*
Edge info labels drawn next to the edge, leading to overlapping & confusion when many edges
![screenshot](https://user-images.githubusercontent.com/66690739/154567811-b05e6fad-897c-401c-951b-b245f27c4ee8.png)


**What is the new behavior (if this is a feature change)?**
Edge info labels drawn on the corresponding edge (either parallel or perpendicular to the edge) with a white-transparent background
![screenshot](https://user-images.githubusercontent.com/66690739/154569576-f93c47d0-ab8b-478a-8330-a944fb16d626.png)



**Does this PR introduce a breaking change or deprecate an API?**
No


**Other information** 
Changing the CSS to have the text background of the same colour than the edge itself instead of transparent white could also be an option:
![screenshot](https://user-images.githubusercontent.com/66690739/154568296-a0a7901d-6977-4264-8ef5-2da212b4c633.png)
