### PR TITLE
New cloning SvgParameters/LayoutParameters constructors

### DIFF
--- a/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -12,6 +12,13 @@ package com.powsybl.nad.layout;
 public class LayoutParameters {
     private boolean textNodesForceLayout = false;
 
+    public LayoutParameters() {
+    }
+
+    public LayoutParameters(LayoutParameters other) {
+        this.textNodesForceLayout = other.textNodesForceLayout;
+    }
+
     public boolean isTextNodesForceLayout() {
         return textNodesForceLayout;
     }

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -45,6 +45,14 @@ public class SvgParameters {
         NONE, FIXED_WIDTH, FIXED_HEIGHT
     }
 
+    public SvgParameters() {
+    }
+
+    public SvgParameters(SvgParameters other) {
+        diagramPadding = other.diagramPadding;
+        svgWidthAndHeightAdded = other.svgWidthAndHeightAdded;
+    }
+
     public Padding getDiagramPadding() {
         return diagramPadding;
     }

--- a/src/main/java/com/powsybl/nad/svg/SvgParameters.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgParameters.java
@@ -49,8 +49,29 @@ public class SvgParameters {
     }
 
     public SvgParameters(SvgParameters other) {
-        diagramPadding = other.diagramPadding;
-        svgWidthAndHeightAdded = other.svgWidthAndHeightAdded;
+        this.diagramPadding = other.diagramPadding;
+        this.insertName = other.insertName;
+        this.svgWidthAndHeightAdded = other.svgWidthAndHeightAdded;
+        this.cssLocation = other.cssLocation;
+        this.sizeConstraint = other.sizeConstraint;
+        this.fixedWidth = other.fixedWidth;
+        this.fixedHeight = other.fixedHeight;
+        this.arrowShift = other.arrowShift;
+        this.arrowLabelShift = other.arrowLabelShift;
+        this.converterStationWidth = other.converterStationWidth;
+        this.voltageLevelCircleRadius = other.voltageLevelCircleRadius;
+        this.fictitiousVoltageLevelCircleRadius = other.fictitiousVoltageLevelCircleRadius;
+        this.transformerCircleRadius = other.transformerCircleRadius;
+        this.nodeHollowWidth = other.nodeHollowWidth;
+        this.edgesForkLength = other.edgesForkLength;
+        this.edgesForkAperture = other.edgesForkAperture;
+        this.edgeStartShift = other.edgeStartShift;
+        this.unknownBusNodeExtraRadius = other.unknownBusNodeExtraRadius;
+        this.loopDistance = other.loopDistance;
+        this.loopEdgesAperture = other.loopEdgesAperture;
+        this.loopControlDistance = other.loopControlDistance;
+        this.textNodeBackground = other.textNodeBackground;
+        this.edgeInfoAlongEdge = other.edgeInfoAlongEdge;
     }
 
     public Padding getDiagramPadding() {

--- a/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
+++ b/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
@@ -13,10 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class LayoutParametersTest {
+class LayoutParametersTest {
 
     @Test
-    public void test() {
+    void test() {
         LayoutParameters layoutParameters0 = new LayoutParameters()
                 .setTextNodesForceLayout(true);
 

--- a/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
+++ b/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.layout;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class LayoutParametersTest {
+
+    @Test
+    public void test() {
+        LayoutParameters layoutParameters0 = new LayoutParameters()
+                .setTextNodesForceLayout(true);
+
+        LayoutParameters layoutParameters1 = new LayoutParameters(layoutParameters0);
+
+        assertEquals(layoutParameters0.isTextNodesForceLayout(), layoutParameters1.isTextNodesForceLayout());
+    }
+}

--- a/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
+++ b/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
@@ -13,10 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
  */
-public class SvgParametersTest {
+class SvgParametersTest {
 
     @Test
-    public void test() {
+    void test() {
         SvgParameters svgParameters0 = new SvgParameters()
                 .setDiagramPadding(new Padding(5))
                 .setInsertName(false)

--- a/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
+++ b/src/test/java/com/powsybl/nad/svg/SvgParametersTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+public class SvgParametersTest {
+
+    @Test
+    public void test() {
+        SvgParameters svgParameters0 = new SvgParameters()
+                .setDiagramPadding(new Padding(5))
+                .setInsertName(false)
+                .setSvgWidthAndHeightAdded(true)
+                .setCssLocation(SvgParameters.CssLocation.EXTERNAL_NO_IMPORT)
+                .setFixedWidth(300)
+                .setFixedHeight(500)
+                .setSizeConstraint(SvgParameters.SizeConstraint.NONE)
+                .setArrowShift(1.)
+                .setArrowLabelShift(0.5)
+                .setConverterStationWidth(2.)
+                .setVoltageLevelCircleRadius(3.)
+                .setFictitiousVoltageLevelCircleRadius(2.)
+                .setTransformerCircleRadius(1.2)
+                .setNodeHollowWidth(0.8)
+                .setEdgesForkLength(4.)
+                .setEdgesForkAperture(10.)
+                .setEdgeStartShift(0.)
+                .setUnknownBusNodeExtraRadius(10.)
+                .setLoopDistance(8.)
+                .setLoopEdgesAperture(10.)
+                .setLoopControlDistance(1.)
+                .setTextNodeBackground(false)
+                .setEdgeInfoAlongEdge(false);
+
+        SvgParameters svgParameters1 = new SvgParameters(svgParameters0);
+
+        assertEquals(svgParameters0.getDiagramPadding().getLeft(), svgParameters1.getDiagramPadding().getLeft());
+        assertEquals(svgParameters0.getDiagramPadding().getTop(), svgParameters1.getDiagramPadding().getTop());
+        assertEquals(svgParameters0.getDiagramPadding().getRight(), svgParameters1.getDiagramPadding().getRight());
+        assertEquals(svgParameters0.getDiagramPadding().getBottom(), svgParameters1.getDiagramPadding().getBottom());
+        assertEquals(svgParameters0.isInsertName(), svgParameters1.isInsertName());
+        assertEquals(svgParameters0.isSvgWidthAndHeightAdded(), svgParameters1.isSvgWidthAndHeightAdded());
+        assertEquals(svgParameters0.getCssLocation(), svgParameters1.getCssLocation());
+        assertEquals(svgParameters0.getFixedWidth(), svgParameters1.getFixedWidth());
+        assertEquals(svgParameters0.getFixedHeight(), svgParameters1.getFixedHeight());
+        assertEquals(svgParameters0.getSizeConstraint(), svgParameters1.getSizeConstraint());
+        assertEquals(svgParameters0.getArrowShift(), svgParameters1.getArrowShift());
+        assertEquals(svgParameters0.getArrowLabelShift(), svgParameters1.getArrowLabelShift());
+        assertEquals(svgParameters0.getConverterStationWidth(), svgParameters1.getConverterStationWidth());
+        assertEquals(svgParameters0.getVoltageLevelCircleRadius(), svgParameters1.getVoltageLevelCircleRadius());
+        assertEquals(svgParameters0.getFictitiousVoltageLevelCircleRadius(), svgParameters1.getFictitiousVoltageLevelCircleRadius());
+        assertEquals(svgParameters0.getTransformerCircleRadius(), svgParameters1.getTransformerCircleRadius());
+        assertEquals(svgParameters0.getNodeHollowWidth(), svgParameters1.getNodeHollowWidth());
+        assertEquals(svgParameters0.getEdgesForkLength(), svgParameters1.getEdgesForkLength());
+        assertEquals(svgParameters0.getEdgesForkAperture(), svgParameters1.getEdgesForkAperture());
+        assertEquals(svgParameters0.getEdgeStartShift(), svgParameters1.getEdgeStartShift());
+        assertEquals(svgParameters0.getUnknownBusNodeExtraRadius(), svgParameters1.getUnknownBusNodeExtraRadius());
+        assertEquals(svgParameters0.getLoopDistance(), svgParameters1.getLoopDistance());
+        assertEquals(svgParameters0.getLoopEdgesAperture(), svgParameters1.getLoopEdgesAperture());
+        assertEquals(svgParameters0.getLoopControlDistance(), svgParameters1.getLoopControlDistance());
+        assertEquals(svgParameters0.isTextNodeBackground(), svgParameters1.isTextNodeBackground());
+        assertEquals(svgParameters0.isEdgeInfoAlongEdge(), svgParameters1.isEdgeInfoAlongEdge());
+    }
+}


### PR DESCRIPTION
Only the properties diagramPadding and svgWidthAndHeightAdded can be copied from another object in the current version. But this is easily modifiable by adding `property` = `other.property` in `public SvgParameters(SvgParameters other)`.

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** No



**What kind of change does this PR introduce?** Feature



**What is the current behavior?** Creating a new SvgParameters object that copies another SvgParameters object's properties is not possible.



**What is the new behavior (if this is a feature change)?** Creating a new SvgParameters object that copies another SvgParameters object's properties is possible for the properties diagramPadding and svgWidthAndHeightAdded.



**Does this PR introduce a breaking change or deprecate an API?** No
