### PR TITLE
Compute exactly edges coordinates

### DIFF
--- a/src/main/java/com/powsybl/nad/model/AbstractEdge.java
+++ b/src/main/java/com/powsybl/nad/model/AbstractEdge.java
@@ -14,8 +14,4 @@ public abstract class AbstractEdge extends AbstractIdentifiable implements Edge 
     protected AbstractEdge(String diagramId, String equipmentId, String nameOrId) {
         super(diagramId, equipmentId, nameOrId);
     }
-
-    protected double getAngle(Point point0, Point point1) {
-        return Math.atan2(point1.getY() - point0.getY(), point1.getX() - point0.getX());
-    }
 }

--- a/src/main/java/com/powsybl/nad/model/BranchEdge.java
+++ b/src/main/java/com/powsybl/nad/model/BranchEdge.java
@@ -86,11 +86,11 @@ public class BranchEdge extends AbstractEdge {
 
     public double getEdgeStartAngle(Side side) {
         List<Point> points = getPoints(side);
-        return getAngle(points.get(0), points.get(1));
+        return points.get(0).getAngle(points.get(1));
     }
 
     public double getEdgeEndAngle(Side side) {
         List<Point> points = getPoints(side);
-        return getAngle(points.get(points.size() - 2), points.get(points.size() - 1));
+        return points.get(points.size() - 2).getAngle(points.get(points.size() - 1));
     }
 }

--- a/src/main/java/com/powsybl/nad/model/Graph.java
+++ b/src/main/java/com/powsybl/nad/model/Graph.java
@@ -119,6 +119,10 @@ public class Graph {
         return voltageLevelGraph.edgesOf(node).stream();
     }
 
+    public Stream<ThreeWtEdge> getThreeWtEdgeStream(ThreeWtNode node) {
+        return voltageLevelGraph.edgesOf(node).stream().filter(ThreeWtEdge.class::isInstance).map(ThreeWtEdge.class::cast);
+    }
+
     public Stream<BranchEdge> getBranchEdgeStream(Node node) {
         return getEdgeStream(node)
                 .filter(BranchEdge.class::isInstance)

--- a/src/main/java/com/powsybl/nad/model/Point.java
+++ b/src/main/java/com/powsybl/nad/model/Point.java
@@ -31,11 +31,6 @@ public class Point {
         return new Point(0.5 * (point1.x + point2.x), 0.5 * (point1.y + point2.y));
     }
 
-    public static Point createPointFromRhoTheta(double rho, double thetaDeg) {
-        return new Point(rho * Math.cos(Math.toRadians(thetaDeg)),
-                rho * Math.sin(Math.toRadians(thetaDeg)));
-    }
-
     public double distanceSquare(Point other) {
         Objects.requireNonNull(other);
         double dx = other.x - x;
@@ -46,6 +41,10 @@ public class Point {
     public double distance(Point other) {
         Objects.requireNonNull(other);
         return Math.sqrt(distanceSquare(other));
+    }
+
+    public Point shiftRhoTheta(double rho, double theta) {
+        return shift(rho * Math.cos(theta), rho * Math.sin(theta));
     }
 
     public Point shift(double shiftX, double shiftY) {
@@ -69,5 +68,9 @@ public class Point {
     public Point atDistance(double dist, double angle) {
         return new Point(x + dist * Math.cos(angle),
                 y + dist * Math.sin(angle));
+    }
+
+    public double getAngle(Point other) {
+        return Math.atan2(other.y - y, other.x - x);
     }
 }

--- a/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
+++ b/src/main/java/com/powsybl/nad/model/ThreeWtEdge.java
@@ -48,6 +48,6 @@ public class ThreeWtEdge extends AbstractEdge {
     }
 
     public double getEdgeAngle() {
-        return getAngle(points.get(0), points.get(1));
+        return points.get(0).getAngle(points.get(1));
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/AbstractStyleProvider.java
@@ -98,11 +98,6 @@ public abstract class AbstractStyleProvider implements StyleProvider {
     }
 
     @Override
-    public Optional<String> getThreeWtNodeBackgroundStyle(ThreeWtNode threeWtNode) {
-        return Optional.empty();
-    }
-
-    @Override
     public List<String> getThreeWtNodeStyle(ThreeWtNode threeWtNode, ThreeWtEdge.Side side) {
         Objects.requireNonNull(side);
         List<String> result = new ArrayList<>();

--- a/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -8,9 +8,7 @@ package com.powsybl.nad.svg;
 
 import com.powsybl.nad.model.*;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -25,7 +23,7 @@ public class DefaultEdgeRendering implements EdgeRendering {
         graph.getNonMultiBranchEdgesStream().forEach(edge -> computeSingleBranchEdgeCoordinates(graph, edge, svgParameters));
         graph.getMultiBranchEdgesStream().forEach(edges -> computeMultiBranchEdgesCoordinates(graph, edges, svgParameters));
         graph.getLoopBranchEdgesMap().forEach((node, edges) -> loopEdgesLayout(graph, node, edges, svgParameters));
-        graph.getThreeWtEdgesStream().forEach(edge -> computeThreeWtEdgeCoordinates(graph, edge, svgParameters));
+        graph.getThreeWtNodesStream().forEach(threeWtNode -> computeThreeWtEdgeCoordinates(graph, threeWtNode, svgParameters));
         graph.getTextEdgesMap().forEach((edge, nodes) -> computeTextEdgeLayoutCoordinates(nodes.getFirst(), nodes.getSecond(), edge));
     }
 
@@ -221,16 +219,51 @@ public class DefaultEdgeRendering implements EdgeRendering {
         return edge.getEdgeStartAngle(side);
     }
 
-    private void computeThreeWtEdgeCoordinates(Graph graph, ThreeWtEdge edge, SvgParameters svgParameters) {
-        Node node1 = graph.getBusGraphNode1(edge);
-        Node node2 = graph.getBusGraphNode2(edge);
+    private void computeThreeWtEdgeCoordinates(Graph graph, ThreeWtNode threeWtNode, SvgParameters svgParameters) {
+        // The 3wt edges are computed by finding the "leading" edge and then placing the other edges at 120°
+        // The leading edge is chosen to be the opposite edge of the smallest aperture.
+        List<ThreeWtEdge> edges = graph.getThreeWtEdgeStream(threeWtNode).collect(Collectors.toList());
+        List<Double> angles = edges.stream()
+                .map(edge -> computeEdgeStart(graph.getBusGraphNode(edge), threeWtNode.getPosition(), graph.getVoltageLevelNode(edge), svgParameters))
+                .map(edgeStart -> threeWtNode.getPosition().getAngle(edgeStart))
+                .collect(Collectors.toList());
+        List<Integer> sortedIndices = IntStream.range(0, 3)
+                .boxed().sorted(Comparator.comparingDouble(angles::get))
+                .collect(Collectors.toList());
 
-        Point direction1 = getDirection(node2, () -> graph.getNode2(edge));
-        Point edgeStart1 = computeEdgeStart(node1, direction1, graph.getVoltageLevelNode(edge), svgParameters);
+        int leadingSortedIndex = getSortedIndexMaximumAperture(angles);
+        double leadingAngle = angles.get(sortedIndices.get(leadingSortedIndex));
 
-        Point direction2 = getDirection(node1, () -> graph.getNode1(edge));
-        Point edgeStart2 = computeEdgeStart(node2, direction2, null, svgParameters);
+        List<ThreeWtEdge> edgesSorted = IntStream.range(0, 3)
+                .map(i -> (leadingSortedIndex + i) % 3)
+                .map(sortedIndices::get)
+                .mapToObj(edges::get)
+                .collect(Collectors.toList());
+        double dNodeToAnchor = svgParameters.getTransformerCircleRadius() * 1.6;
+        for (int i = 0; i < edgesSorted.size(); i++) {
+            ThreeWtEdge edge = edgesSorted.get(i);
+            Point edgeStart = computeEdgeStart(graph.getBusGraphNode(edge), threeWtNode.getPosition(), graph.getVoltageLevelNode(edge), svgParameters);
+            double anchorAngle = leadingAngle + i * 2 * Math.PI / 3;
+            Point threeWtAnchor = threeWtNode.getPosition().shiftRhoTheta(dNodeToAnchor, anchorAngle);
+            edge.setPoints(edgeStart, threeWtAnchor);
+        }
+    }
 
-        edge.setPoints(edgeStart1, edgeStart2);
+    private int getSortedIndexMaximumAperture(List<Double> angles) {
+        // Sorting the given angles
+        List<Double> sortedAngles = angles.stream().sorted().collect(Collectors.toList());
+
+        // Then calculating the apertures
+        sortedAngles.add(sortedAngles.get(0) + 2 * Math.PI);
+        double[] deltaAngles = new double[3];
+        for (int i = 0; i < 3; i++) {
+            deltaAngles[i] = sortedAngles.get(i + 1) - sortedAngles.get(i);
+        }
+
+        // Returning the (sorted) index of the angle facing the minimal aperture
+        int minDeltaIndex = IntStream.range(0, 3)
+                .boxed().min(Comparator.comparingDouble(i -> deltaAngles[i]))
+                .orElse(0);
+        return ((minDeltaIndex - 1) + 3) % 3;
     }
 }

--- a/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -100,24 +100,26 @@ public class DefaultEdgeRendering implements EdgeRendering {
                 double alpha = -forkAperture / 2 + i * angleStep;
                 double angleForkA = angle - alpha;
                 double angleForkB = angle + Math.PI + alpha;
+
                 Point forkA = pointA.shift(forkLength * Math.cos(angleForkA), forkLength * Math.sin(angleForkA));
                 Point forkB = pointB.shift(forkLength * Math.cos(angleForkB), forkLength * Math.sin(angleForkB));
                 Point middle = Point.createMiddlePoint(forkA, forkB);
-
                 BranchEdge.Side sideA = graph.getNode1(edge) == nodeA ? BranchEdge.Side.ONE : BranchEdge.Side.TWO;
-                BranchEdge.Side sideB = sideA.getOpposite();
 
-                Node busNodeA = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode1(edge) : graph.getBusGraphNode2(edge);
-                Node busNodeB = sideA == BranchEdge.Side.ONE ? graph.getBusGraphNode2(edge) : graph.getBusGraphNode1(edge);
-
-                Point edgeStartA = computeEdgeStart(busNodeA, forkA, nodeA, svgParameters);
-                edge.setPoints(sideA, edgeStartA, forkA, middle);
-
-                Point edgeStartB = computeEdgeStart(busNodeB, forkB, nodeB, svgParameters);
-                edge.setPoints(sideB, edgeStartB, forkB, middle);
+                computeHalfForkCoordinates(graph, svgParameters, nodeA, edge, forkA, middle, sideA);
+                computeHalfForkCoordinates(graph, svgParameters, nodeB, edge, forkB, middle, sideA.getOpposite());
             }
             i++;
         }
+    }
+
+    private void computeHalfForkCoordinates(Graph graph, SvgParameters svgParameters, VoltageLevelNode node, BranchEdge edge, Point fork, Point middle, BranchEdge.Side side) {
+        Node busNodeA = side == BranchEdge.Side.ONE ? graph.getBusGraphNode1(edge) : graph.getBusGraphNode2(edge);
+        Point edgeStart = computeEdgeStart(busNodeA, fork, node, svgParameters);
+        Point endFork = edge.getType().equals(BranchEdge.TWO_WT_EDGE)
+                ? middle.atDistance(1.5 * svgParameters.getTransformerCircleRadius(), fork)
+                : middle;
+        edge.setPoints(side, edgeStart, fork, endFork);
     }
 
     private void loopEdgesLayout(Graph graph, VoltageLevelNode node, List<BranchEdge> loopEdges, SvgParameters svgParameters) {

--- a/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
+++ b/src/main/java/com/powsybl/nad/svg/DefaultEdgeRendering.java
@@ -44,8 +44,14 @@ public class DefaultEdgeRendering implements EdgeRendering {
         Point edgeStart2 = computeEdgeStart(node2, direction2, graph.getVoltageLevelNode2(edge), svgParameters);
 
         Point middle = Point.createMiddlePoint(edgeStart1, edgeStart2);
-        edge.setPoints1(edgeStart1, middle);
-        edge.setPoints2(edgeStart2, middle);
+        if (edge.getType().equals(BranchEdge.TWO_WT_EDGE)) {
+            double radius = svgParameters.getTransformerCircleRadius();
+            edge.setPoints1(edgeStart1, middle.atDistance(1.5 * radius, direction2));
+            edge.setPoints2(edgeStart2, middle.atDistance(1.5 * radius, direction1));
+        } else {
+            edge.setPoints1(edgeStart1, middle);
+            edge.setPoints2(edgeStart2, middle);
+        }
     }
 
     private Point getDirection(Node directionBusGraphNode, Supplier<Node> vlNodeSupplier) {

--- a/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -9,7 +9,6 @@ package com.powsybl.nad.svg;
 import com.powsybl.nad.model.*;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * @author Florian Dupuy <florian.dupuy at rte-france.com>
@@ -48,8 +47,6 @@ public interface StyleProvider {
     List<String> getSideEdgeStyleClasses(BranchEdge edge, BranchEdge.Side side);
 
     List<String> getEdgeInfoStyles(EdgeInfo info);
-
-    Optional<String> getThreeWtNodeBackgroundStyle(ThreeWtNode threeWtNode);
 
     List<String> getThreeWtNodeStyle(ThreeWtNode threeWtNode, ThreeWtEdge.Side one);
 }

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -385,10 +385,10 @@ public class SvgWriter {
 
     private void draw2WtWinding(XMLStreamWriter writer, List<Point> half) throws XMLStreamException {
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
-        Point point1 = half.get(half.size() - 1); // point in the middle
-        Point point2 = half.get(half.size() - 2); // point before
+        Point point1 = half.get(half.size() - 1); // point near 2wt
+        Point point2 = half.get(half.size() - 2); // point near voltage level
         double radius = svgParameters.getTransformerCircleRadius();
-        Point circleCenter = point1.atDistance(radius / 2, point2);
+        Point circleCenter = point1.atDistance(-1 * radius, point2);
         writer.writeAttribute("cx", getFormattedValue(circleCenter.getX()));
         writer.writeAttribute("cy", getFormattedValue(circleCenter.getY()));
         writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(radius));

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -236,35 +236,24 @@ public class SvgWriter {
             return;
         }
 
-        double dNodeCenter = svgParameters.getTransformerCircleRadius() * 0.6;
-        Point point1 = Point.createPointFromRhoTheta(dNodeCenter, 90);
-        Point point2 = Point.createPointFromRhoTheta(dNodeCenter, 210);
-        Point point3 = Point.createPointFromRhoTheta(dNodeCenter, 330);
-
         writer.writeStartElement(GROUP_ELEMENT_NAME);
         writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.THREE_WT_NODES_CLASS);
         for (ThreeWtNode threeWtNode : threeWtNodes) {
             writer.writeStartElement(GROUP_ELEMENT_NAME);
-            writer.writeAttribute(TRANSFORM_ATTRIBUTE, getTranslateString(threeWtNode));
             addStylesIfAny(writer, styleProvider.getNodeStyleClasses(threeWtNode));
-            Optional<String> backgroundStyle = styleProvider.getThreeWtNodeBackgroundStyle(threeWtNode);
-            if (backgroundStyle.isPresent()) {
-                writer.writeStartElement(GROUP_ELEMENT_NAME);
-                writer.writeAttribute(CLASS_ATTRIBUTE, backgroundStyle.get());
-                draw3WtWinding(point1, Collections.emptyList(), writer);
-                draw3WtWinding(point2, Collections.emptyList(), writer);
-                draw3WtWinding(point3, Collections.emptyList(), writer);
-                writer.writeEndElement();
+            List<ThreeWtEdge> edges = graph.getThreeWtEdgeStream(threeWtNode).collect(Collectors.toList());
+            for (ThreeWtEdge edge : edges) {
+                draw3WtWinding(edge, threeWtNode, writer);
             }
-            draw3WtWinding(point1, styleProvider.getThreeWtNodeStyle(threeWtNode, ThreeWtEdge.Side.ONE), writer);
-            draw3WtWinding(point2, styleProvider.getThreeWtNodeStyle(threeWtNode, ThreeWtEdge.Side.TWO), writer);
-            draw3WtWinding(point3, styleProvider.getThreeWtNodeStyle(threeWtNode, ThreeWtEdge.Side.THREE), writer);
             writer.writeEndElement();
         }
         writer.writeEndElement();
     }
 
-    private void draw3WtWinding(Point circleCenter, List<String> styles, XMLStreamWriter writer) throws XMLStreamException {
+    private void draw3WtWinding(ThreeWtEdge edge, ThreeWtNode threeWtNode, XMLStreamWriter writer) throws XMLStreamException {
+        List<String> styles = styleProvider.getThreeWtNodeStyle(threeWtNode, edge.getSide());
+        double radius = svgParameters.getTransformerCircleRadius();
+        Point circleCenter = edge.getPoints().get(1).atDistance(radius, threeWtNode.getPosition());
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
         addStylesIfAny(writer, styles);
         writer.writeAttribute("cx", getFormattedValue(circleCenter.getX()));

--- a/src/main/java/com/powsybl/nad/svg/iidm/AbstractVoltageStyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/iidm/AbstractVoltageStyleProvider.java
@@ -67,11 +67,6 @@ public abstract class AbstractVoltageStyleProvider extends AbstractStyleProvider
     }
 
     @Override
-    public Optional<String> getThreeWtNodeBackgroundStyle(ThreeWtNode threeWtNode) {
-        return Optional.of(CLASSES_PREFIX + "3wt-bg");
-    }
-
-    @Override
     protected Optional<String> getBaseVoltageStyle(ThreeWtNode threeWtNode, ThreeWtEdge.Side side) {
         Terminal terminal = network.getThreeWindingsTransformer(threeWtNode.getEquipmentId())
                 .getTerminal(IidmUtils.getIidmSideFromThreeWtEdgeSide(side));

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -1,5 +1,5 @@
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -7,7 +7,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -1,5 +1,5 @@
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -7,7 +7,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
+++ b/src/test/java/com/powsybl/nad/svg/NetworkTestFactory.java
@@ -161,4 +161,92 @@ public final class NetworkTestFactory {
 
         return network;
     }
+
+    /**
+     * <pre>
+     *   g1         dl1
+     *   |    tr1    |
+     *   |  --oo--   |
+     *  b1 /      \ b2
+     *     \      /
+     *      --oo--
+     *       tr2</pre>
+     */
+    public static Network createTwoVoltageLevelsTwoTransformers() {
+        Network network = Network.create("dl", "test");
+        Substation s = network.newSubstation().setId("s1").add();
+        VoltageLevel vl1 = s.newVoltageLevel()
+                .setId("vl1")
+                .setNominalV(400)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        network.getVoltageLevel("vl1").getBusBreakerView().newBus()
+                .setId("b0")
+                .add();
+        vl1.getBusBreakerView().newBus()
+                .setId("b1")
+                .add();
+        vl1.newGenerator()
+                .setId("g1")
+                .setConnectableBus("b1")
+                .setBus("b1")
+                .setTargetP(101.3664)
+                .setTargetV(390)
+                .setMinP(0)
+                .setMaxP(150)
+                .setVoltageRegulatorOn(true)
+                .add();
+        VoltageLevel vl2 = s.newVoltageLevel()
+                .setId("vl2")
+                .setNominalV(200)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        vl2.getBusBreakerView().newBus()
+                .setId("b2")
+                .add();
+        vl2.newDanglingLine()
+                .setId("dl1")
+                .setConnectableBus("b2")
+                .setBus("b2")
+                .setR(0.7)
+                .setX(1)
+                .setG(1e-6)
+                .setB(3e-6)
+                .setP0(101)
+                .setQ0(150)
+                .newGeneration()
+                .setTargetP(0)
+                .setTargetQ(0)
+                .setTargetV(390)
+                .setVoltageRegulationOn(false)
+                .add()
+                .add();
+        s.newTwoWindingsTransformer()
+                .setId("tr1")
+                .setVoltageLevel1("vl1")
+                .setBus1("b0")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setRatedU1(380)
+                .setRatedU2(190)
+                .setR(1)
+                .setX(30)
+                .setG(0)
+                .setB(0)
+                .add();
+        s.newTwoWindingsTransformer()
+                .setId("tr2")
+                .setVoltageLevel1("vl1")
+                .setBus1("b1")
+                .setVoltageLevel2("vl2")
+                .setBus2("b2")
+                .setRatedU1(380)
+                .setRatedU2(190)
+                .setR(1)
+                .setX(30)
+                .setG(0)
+                .setB(0)
+                .add();
+        return network;
+    }
 }

--- a/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
+++ b/src/test/java/com/powsybl/nad/svg/NominalVoltageStyleTest.java
@@ -11,20 +11,15 @@ import com.powsybl.iidm.import_.Importers;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Terminal;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
-import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import com.powsybl.iidm.xml.NetworkXml;
 import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.nad.AbstractTest;
-import com.powsybl.nad.build.iidm.VoltageLevelFilter;
 import com.powsybl.nad.layout.LayoutParameters;
 import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
 import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -116,26 +111,6 @@ class NominalVoltageStyleTest extends AbstractTest {
         Network network = Importers.loadNetwork("simple-eu.uct", getClass().getResourceAsStream("/simple-eu.uct"));
         getSvgParameters().setLoopEdgesAperture(100);
         assertEquals(toString("/simple-eu-loop100.svg"), generateSvgString(network, "/simple-eu-loop100.svg"));
-    }
-
-    @Test
-    void test3wt() {
-        Network network = ThreeWindingsTransformerNetworkFactory.create();
-        assertEquals(toString("/3wt.svg"), generateSvgString(network, "/3wt.svg"));
-    }
-
-    @Test
-    void testDisconnected3wt() {
-        Network network = ThreeWindingsTransformerNetworkFactory.create();
-        network.getThreeWindingsTransformer("3WT").getTerminal(ThreeWindingsTransformer.Side.TWO).disconnect();
-        assertEquals(toString("/3wt_disconnected.svg"), generateSvgString(network, "/3wt_disconnected.svg"));
-    }
-
-    @Test
-    void testPartial3wt() {
-        Network network = ThreeWindingsTransformerNetworkFactory.create();
-        VoltageLevelFilter filter = VoltageLevelFilter.createVoltageLevelsFilter(network, Collections.singletonList("VL_11"));
-        assertEquals(toString("/3wt_partial.svg"), generateSvgString(network, filter, "/3wt_partial.svg"));
     }
 
     @Test

--- a/src/test/java/com/powsybl/nad/svg/ParallelTransformerTest.java
+++ b/src/test/java/com/powsybl/nad/svg/ParallelTransformerTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Florian Dupuy <florian.dupuy at rte-france.com>
+ */
+class ParallelTransformerTest extends AbstractTest {
+
+    @BeforeEach
+    public void setup() {
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800));
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new NominalVoltageStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new DefaultLabelProvider(network);
+    }
+
+    @Test
+    void test() {
+        Network network = NetworkTestFactory.createTwoVoltageLevelsTwoTransformers();
+        assertEquals(toString("/parallel_transformers.svg"), generateSvgString(network, "/parallel_transformers.svg"));
+    }
+}

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="680.96" viewBox="-3.99 -4.23 11.54 9.82" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -81,47 +80,47 @@
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline points="-1.80,-2.03 0.73,0.53"/>
+            <polyline points="-1.80,-2.03 0.49,0.31"/>
             <g class="nad-edge-infos" transform="translate(-1.59,-1.82)">
                 <g class="nad-active nad-state-out">
-                    <g transform="rotate(135.46)">
+                    <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.19">0</text>
+                    <text transform="rotate(45.72)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
-                    <g transform="rotate(135.46)">
+                    <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.19">0</text>
+                    <text transform="rotate(45.72)" x="0.19">0</text>
                 </g>
             </g>
         </g>
         <g id="8" class="nad-vl30to50">
             <desc>3WT</desc>
-            <polyline points="-1.63,3.38 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(-1.44,3.15)">
+            <polyline points="-1.63,3.38 0.66,0.84"/>
+            <g class="nad-edge-infos" transform="translate(-1.43,3.16)">
                 <g class="nad-active nad-state-out">
-                    <g transform="rotate(39.54)">
+                    <g transform="rotate(41.95)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.19">0</text>
+                    <text transform="rotate(-48.05)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
-                    <g transform="rotate(39.54)">
+                    <g transform="rotate(41.95)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.19">0</text>
+                    <text transform="rotate(-48.05)" x="0.19">0</text>
                 </g>
             </g>
         </g>
         <g id="9" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="4.29,-0.57 0.73,0.53"/>
+            <polyline points="4.29,-0.57 1.03,0.44"/>
             <g class="nad-edge-infos" transform="translate(4.00,-0.49)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
@@ -141,15 +140,10 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g transform="translate(0.73,0.53)">
-            <g class="nad-3wt-bg">
-                <circle cx="0.00" cy="0.12" r="0.20"/>
-                <circle cx="-0.10" cy="-0.06" r="0.20"/>
-                <circle cx="0.10" cy="-0.06" r="0.20"/>
-            </g>
-            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
-            <circle class="nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
-            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+        <g>
+            <circle class="nad-vl120to180" cx="0.64" cy="0.45" r="0.20"/>
+            <circle class="nad-vl30to50" cx="0.70" cy="0.65" r="0.20"/>
+            <circle class="nad-vl0to30" cx="0.84" cy="0.50" r="0.20"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/3wt_disconnected.svg
+++ b/src/test/resources/3wt_disconnected.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="680.96" viewBox="-3.99 -4.23 11.54 9.82" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -81,47 +80,47 @@
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline points="-1.80,-2.03 0.73,0.53"/>
+            <polyline points="-1.80,-2.03 0.49,0.31"/>
             <g class="nad-edge-infos" transform="translate(-1.59,-1.82)">
                 <g class="nad-active nad-state-out">
-                    <g transform="rotate(135.46)">
+                    <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.19">0</text>
+                    <text transform="rotate(45.72)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
-                    <g transform="rotate(135.46)">
+                    <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.19">0</text>
+                    <text transform="rotate(45.72)" x="0.19">0</text>
                 </g>
             </g>
         </g>
         <g id="7" class="nad-disconnected nad-vl30to50">
             <desc>3WT</desc>
-            <polyline points="-1.54,3.28 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(-1.35,3.05)">
+            <polyline points="-1.54,3.28 0.66,0.84"/>
+            <g class="nad-edge-infos" transform="translate(-1.34,3.06)">
                 <g class="nad-active nad-state-out">
-                    <g transform="rotate(39.54)">
+                    <g transform="rotate(42.05)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.19">0</text>
+                    <text transform="rotate(-47.95)" x="0.19">0</text>
                 </g>
                 <g class="nad-reactive nad-state-out">
-                    <g transform="rotate(39.54)">
+                    <g transform="rotate(42.05)">
                         <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.19">0</text>
+                    <text transform="rotate(-47.95)" x="0.19">0</text>
                 </g>
             </g>
         </g>
         <g id="8" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="4.29,-0.57 0.73,0.53"/>
+            <polyline points="4.29,-0.57 1.03,0.44"/>
             <g class="nad-edge-infos" transform="translate(4.00,-0.49)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
@@ -141,15 +140,10 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g transform="translate(0.73,0.53)">
-            <g class="nad-3wt-bg">
-                <circle cx="0.00" cy="0.12" r="0.20"/>
-                <circle cx="-0.10" cy="-0.06" r="0.20"/>
-                <circle cx="0.10" cy="-0.06" r="0.20"/>
-            </g>
-            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
-            <circle class="nad-disconnected nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
-            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+        <g>
+            <circle class="nad-vl120to180" cx="0.64" cy="0.45" r="0.20"/>
+            <circle class="nad-disconnected nad-vl30to50" cx="0.70" cy="0.65" r="0.20"/>
+            <circle class="nad-vl0to30" cx="0.84" cy="0.50" r="0.20"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="770.68" viewBox="-5.78 -4.98 10.39 10.01" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -73,7 +72,7 @@
     <g class="nad-3wt-edges">
         <g id="3" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="-3.52,1.03 0.06,0.04"/>
+            <polyline points="-3.52,1.03 -0.25,0.13"/>
             <g class="nad-edge-infos" transform="translate(-3.23,0.95)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(74.59)">
@@ -93,15 +92,10 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g transform="translate(0.06,0.04)">
-            <g class="nad-3wt-bg">
-                <circle cx="0.00" cy="0.12" r="0.20"/>
-                <circle cx="-0.10" cy="-0.06" r="0.20"/>
-                <circle cx="0.10" cy="-0.06" r="0.20"/>
-            </g>
-            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
-            <circle class="nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
-            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+        <g>
+            <circle class="nad-vl0to30" cx="-0.06" cy="0.07" r="0.20"/>
+            <circle class="nad-vl120to180" cx="0.14" cy="0.13" r="0.20"/>
+            <circle class="nad-vl30to50" cx="0.09" cy="-0.07" r="0.20"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="605.61" viewBox="-42.29 -28.50 77.81 58.90" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -1232,7 +1231,7 @@
         <g id="244">
             <desc>T8-5-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="14.80,-18.45 17.32,-20.70"/>
+                <polyline points="14.80,-18.45 17.10,-20.50"/>
                 <g class="nad-edge-infos" transform="translate(15.02,-18.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.30)">
@@ -1252,7 +1251,7 @@
                 <circle cx="17.25" cy="-20.63" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="19.85,-22.95 17.32,-20.70"/>
+                <polyline points="19.85,-22.95 17.55,-20.90"/>
                 <g class="nad-edge-infos" transform="translate(19.63,-22.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.70)">
@@ -2013,7 +2012,7 @@
         <g id="263">
             <desc>T30-17-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="16.95,-7.35 20.42,-6.13"/>
+                <polyline points="16.95,-7.35 20.14,-6.23"/>
                 <g class="nad-edge-infos" transform="translate(17.23,-7.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.37)">
@@ -2033,7 +2032,7 @@
                 <circle cx="20.33" cy="-6.16" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="23.89,-4.91 20.42,-6.13"/>
+                <polyline points="23.89,-4.91 20.70,-6.03"/>
                 <g class="nad-edge-infos" transform="translate(23.61,-5.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.63)">
@@ -2589,7 +2588,7 @@
         <g id="277">
             <desc>T26-25-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="19.95,0.45 20.40,3.57"/>
+                <polyline points="19.95,0.45 20.35,3.27"/>
                 <g class="nad-edge-infos" transform="translate(19.99,0.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.79)">
@@ -2609,7 +2608,7 @@
                 <circle cx="20.38" cy="3.47" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="20.85,6.68 20.40,3.57"/>
+                <polyline points="20.85,6.68 20.44,3.86"/>
                 <g class="nad-edge-infos" transform="translate(20.80,6.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.21)">
@@ -3329,7 +3328,7 @@
         <g id="295">
             <desc>T38-37-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="7.42,-3.12 8.53,-5.45"/>
+                <polyline points="7.42,-3.12 8.40,-5.18"/>
                 <g class="nad-edge-infos" transform="translate(7.55,-3.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.63)">
@@ -3349,7 +3348,7 @@
                 <circle cx="8.49" cy="-5.36" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="9.65,-7.78 8.53,-5.45"/>
+                <polyline points="9.65,-7.78 8.66,-5.72"/>
                 <g class="nad-edge-infos" transform="translate(9.52,-7.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.37)">
@@ -5053,7 +5052,7 @@
         <g id="337">
             <desc>T63-59-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-2.70,26.01 -1.50,25.90"/>
+                <polyline points="-2.70,26.01 -1.80,25.93"/>
                 <g class="nad-edge-infos" transform="translate(-2.40,25.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.90)">
@@ -5073,7 +5072,7 @@
                 <circle cx="-1.60" cy="25.91" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.31,25.79 -1.50,25.90"/>
+                <polyline points="-0.31,25.79 -1.20,25.87"/>
                 <g class="nad-edge-infos" transform="translate(-0.60,25.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.10)">
@@ -5219,7 +5218,7 @@
         <g id="341">
             <desc>T64-61-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1.95,18.91 -2.70,20.65"/>
+                <polyline points="-1.95,18.91 -2.58,20.37"/>
                 <g class="nad-edge-infos" transform="translate(-2.07,19.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.63)">
@@ -5239,7 +5238,7 @@
                 <circle cx="-2.66" cy="20.56" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-3.45,22.39 -2.70,20.65"/>
+                <polyline points="-3.45,22.39 -2.82,20.93"/>
                 <g class="nad-edge-infos" transform="translate(-3.33,22.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.37)">
@@ -5426,7 +5425,7 @@
         <g id="346">
             <desc>T65-66-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-0.62,7.41 -1.47,10.91"/>
+                <polyline points="-0.62,7.41 -1.40,10.62"/>
                 <g class="nad-edge-infos" transform="translate(-0.69,7.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.41)">
@@ -5446,7 +5445,7 @@
                 <circle cx="-1.44" cy="10.81" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2.31,14.41 -1.47,10.91"/>
+                <polyline points="-2.31,14.41 -1.54,11.20"/>
                 <g class="nad-edge-infos" transform="translate(-2.24,14.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.59)">
@@ -5551,7 +5550,7 @@
         <g id="349">
             <desc>T68-69-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-3.40,0.74 -3.56,2.60"/>
+                <polyline points="-3.40,0.74 -3.54,2.30"/>
                 <g class="nad-edge-infos" transform="translate(-3.43,1.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.05)">
@@ -5571,7 +5570,7 @@
                 <circle cx="-3.56" cy="2.50" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-3.73,4.46 -3.56,2.60"/>
+                <polyline points="-3.73,4.46 -3.59,2.90"/>
                 <g class="nad-edge-infos" transform="translate(-3.70,4.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.95)">
@@ -6455,7 +6454,7 @@
         <g id="371">
             <desc>T81-80-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-7.04,-5.09 -9.49,-6.84"/>
+                <polyline points="-7.04,-5.09 -9.25,-6.67"/>
                 <g class="nad-edge-infos" transform="translate(-7.29,-5.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.49)">
@@ -6475,7 +6474,7 @@
                 <circle cx="-9.41" cy="-6.78" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-11.95,-8.59 -9.49,-6.84"/>
+                <polyline points="-11.95,-8.59 -9.74,-7.02"/>
                 <g class="nad-edge-infos" transform="translate(-11.70,-8.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.51)">

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="986.50" viewBox="-15.40 -16.21 29.52 36.40" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -1609,7 +1608,7 @@
         <g id="83">
             <desc>T63-59-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-2.03,-13.44 -1.24,-11.20"/>
+                <polyline points="-2.03,-13.44 -1.34,-11.49"/>
                 <g class="nad-edge-infos" transform="translate(-1.93,-13.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.58)">
@@ -1629,7 +1628,7 @@
                 <circle cx="-1.27" cy="-11.30" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.45,-8.96 -1.24,-11.20"/>
+                <polyline points="-0.45,-8.96 -1.14,-10.92"/>
                 <g class="nad-edge-infos" transform="translate(-0.55,-9.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.42)">
@@ -1740,7 +1739,7 @@
                 <circle cx="-6.09" cy="-12.14" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-6.10,-10.13 -6.09,-12.04"/>
+                <polyline points="-6.10,-10.13 -6.09,-11.74"/>
                 <g class="nad-edge-infos" transform="translate(-6.10,-10.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.12)">
@@ -1810,7 +1809,7 @@
                 <circle cx="-9.46" cy="5.16" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-8.16,3.32 -9.40,5.08"/>
+                <polyline points="-8.16,3.32 -9.23,4.83"/>
                 <g class="nad-edge-infos" transform="translate(-8.33,3.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.68)">
@@ -1858,7 +1857,7 @@
                 <circle cx="1.60" cy="14.46" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-0.48,13.27 1.51,14.41"/>
+                <polyline points="-0.48,13.27 1.25,14.26"/>
                 <g class="nad-edge-infos" transform="translate(-0.22,13.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.78)">

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="534.06" viewBox="-19.04 -12.42 37.46 25.01" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -438,7 +437,7 @@
         <g id="40">
             <desc>T30-17-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="2.16,-6.28 -0.46,-5.79"/>
+                <polyline points="2.16,-6.28 -0.17,-5.84"/>
                 <g class="nad-edge-infos" transform="translate(1.87,-6.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
@@ -782,7 +781,7 @@
         <g id="64">
             <desc>T38-37-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="8.00,-1.84 8.67,1.69"/>
+                <polyline points="8.00,-1.84 8.61,1.39"/>
                 <g class="nad-edge-infos" transform="translate(8.05,-1.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.22)">
@@ -802,7 +801,7 @@
                 <circle cx="8.65" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="9.34,5.21 8.67,1.69"/>
+                <polyline points="9.34,5.21 8.72,1.98"/>
                 <g class="nad-edge-infos" transform="translate(9.28,4.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.78)">
@@ -932,7 +931,7 @@
         <g id="77">
             <desc>T65-66-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="12.64,-5.86 12.25,-7.68"/>
+                <polyline points="12.64,-5.86 12.32,-7.39"/>
                 <g class="nad-edge-infos" transform="translate(12.58,-6.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.07)">

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="773.52" viewBox="-8.76 -9.98 22.20 21.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -441,7 +440,7 @@
         <g id="35">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <polyline points="2.09,-3.29 3.81,-2.77"/>
                 <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
@@ -461,7 +460,7 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <polyline points="6.10,-2.09 4.38,-2.60"/>
                 <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-73.33)">
@@ -484,7 +483,7 @@
         <g id="36">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <polyline points="1.89,-3.10 2.25,-1.42"/>
                 <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
@@ -504,7 +503,7 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <polyline points="2.74,0.84 2.38,-0.84"/>
                 <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-12.12)">
@@ -527,7 +526,7 @@
         <g id="37">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <polyline points="-1.35,-1.59 -2.13,1.40"/>
                 <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
@@ -547,7 +546,7 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <polyline points="-3.05,4.96 -2.28,1.98"/>
                 <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(14.49)">

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="773.52" viewBox="-8.76 -9.98 22.20 21.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -441,7 +440,7 @@
         <g id="34">
             <desc>T4-7-1</desc>
             <g class="nad-disconnected nad-vl120to180">
-                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <polyline points="2.09,-3.29 3.81,-2.77"/>
                 <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
@@ -461,7 +460,7 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <polyline points="6.10,-2.09 4.38,-2.60"/>
                 <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.33)">
@@ -484,7 +483,7 @@
         <g id="35">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <polyline points="1.89,-3.10 2.25,-1.42"/>
                 <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
@@ -504,7 +503,7 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <polyline points="2.74,0.84 2.38,-0.84"/>
                 <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-12.12)">
@@ -527,7 +526,7 @@
         <g id="36">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <polyline points="-1.35,-1.59 -2.13,1.40"/>
                 <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
@@ -547,7 +546,7 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <polyline points="-3.05,4.96 -2.28,1.98"/>
                 <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(14.49)">

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="773.52" viewBox="-8.76 -9.98 22.20 21.47" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -441,7 +440,7 @@
         <g id="35">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="2.09,-3.29 4.10,-2.69"/>
+                <polyline points="2.09,-3.29 3.81,-2.77"/>
                 <g class="nad-edge-infos" transform="translate(2.38,-3.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.67)">
@@ -461,7 +460,7 @@
                 <circle cx="4.00" cy="-2.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="6.10,-2.09 4.10,-2.69"/>
+                <polyline points="6.10,-2.09 4.38,-2.60"/>
                 <g class="nad-edge-infos" transform="translate(5.81,-2.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.33)">
@@ -484,7 +483,7 @@
         <g id="36">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="1.89,-3.10 2.31,-1.13"/>
+                <polyline points="1.89,-3.10 2.25,-1.42"/>
                 <g class="nad-edge-infos" transform="translate(1.95,-2.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.88)">
@@ -504,7 +503,7 @@
                 <circle cx="2.29" cy="-1.23" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.74,0.84 2.31,-1.13"/>
+                <polyline points="2.74,0.84 2.38,-0.84"/>
                 <g class="nad-edge-infos" transform="translate(2.67,0.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.12)">
@@ -527,7 +526,7 @@
         <g id="37">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-1.35,-1.59 -2.20,1.69"/>
+                <polyline points="-1.35,-1.59 -2.13,1.40"/>
                 <g class="nad-edge-infos" transform="translate(-1.43,-1.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.51)">
@@ -547,7 +546,7 @@
                 <circle cx="-2.18" cy="1.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-3.05,4.96 -2.20,1.69"/>
+                <polyline points="-3.05,4.96 -2.28,1.98"/>
                 <g class="nad-edge-infos" transform="translate(-2.97,4.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(14.49)">

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="1008.31" viewBox="-13.41 -15.92 27.08 34.13" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -435,7 +434,7 @@
         <g id="35">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="0.60,-4.36 3.60,-4.70"/>
+                <polyline points="0.60,-4.36 3.30,-4.66"/>
                 <g class="nad-edge-infos" transform="translate(0.90,-4.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(83.57)">
@@ -455,7 +454,7 @@
                 <circle cx="3.50" cy="-4.69" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="6.60,-5.04 3.60,-4.70"/>
+                <polyline points="6.60,-5.04 3.90,-4.73"/>
                 <g class="nad-edge-infos" transform="translate(6.30,-5.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-96.43)">
@@ -478,7 +477,7 @@
         <g id="36">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="0.53,-4.15 3.25,-1.81"/>
+                <polyline points="0.53,-4.15 3.02,-2.01"/>
                 <g class="nad-edge-infos" transform="translate(0.76,-3.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.78)">
@@ -498,7 +497,7 @@
                 <circle cx="3.17" cy="-1.88" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.96,0.52 3.25,-1.81"/>
+                <polyline points="5.96,0.52 3.47,-1.62"/>
                 <g class="nad-edge-infos" transform="translate(5.73,0.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.22)">
@@ -521,7 +520,7 @@
         <g id="37">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-6.33,0.03 -5.41,3.68"/>
+                <polyline points="-6.33,0.03 -5.49,3.39"/>
                 <g class="nad-edge-infos" transform="translate(-6.26,0.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.90)">
@@ -541,7 +540,7 @@
                 <circle cx="-5.44" cy="3.58" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-4.50,7.32 -5.41,3.68"/>
+                <polyline points="-4.50,7.32 -5.34,3.97"/>
                 <g class="nad-edge-infos" transform="translate(-4.57,7.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.10)">

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="969.43" viewBox="-13.03 -15.46 26.51 32.13" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -427,7 +426,7 @@
         <g id="53">
             <desc>T-24-3-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="0.59,-6.38 1.09,-3.94"/>
+                <polyline points="0.59,-6.38 1.03,-4.23"/>
                 <g class="nad-edge-infos" transform="translate(0.65,-6.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.29)">
@@ -447,7 +446,7 @@
                 <circle cx="1.07" cy="-4.04" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="1.60,-1.50 1.09,-3.94"/>
+                <polyline points="1.60,-1.50 1.16,-3.65"/>
                 <g class="nad-edge-infos" transform="translate(1.54,-1.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.71)">
@@ -593,7 +592,7 @@
         <g id="57">
             <desc>T-5-10-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="2.17,3.05 3.54,4.65"/>
+                <polyline points="2.17,3.05 3.34,4.42"/>
                 <g class="nad-edge-infos" transform="translate(2.36,3.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.54)">
@@ -613,7 +612,7 @@
                 <circle cx="3.47" cy="4.58" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="4.90,6.26 3.54,4.65"/>
+                <polyline points="4.90,6.26 3.73,4.88"/>
                 <g class="nad-edge-infos" transform="translate(4.71,6.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.46)">
@@ -636,7 +635,7 @@
         <g id="58">
             <desc>T-11-9-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="7.43,1.35 6.64,2.64"/>
+                <polyline points="7.43,1.35 6.80,2.39"/>
                 <g class="nad-edge-infos" transform="translate(7.27,1.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.81)">
@@ -656,7 +655,7 @@
                 <circle cx="6.70" cy="2.56" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="5.86,3.94 6.64,2.64"/>
+                <polyline points="5.86,3.94 6.49,2.90"/>
                 <g class="nad-edge-infos" transform="translate(6.02,3.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.19)">
@@ -679,7 +678,7 @@
         <g id="59">
             <desc>T-9-12-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="5.89,4.38 6.92,5.70"/>
+                <polyline points="5.89,4.38 6.73,5.46"/>
                 <g class="nad-edge-infos" transform="translate(6.07,4.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.96)">
@@ -699,7 +698,7 @@
                 <circle cx="6.86" cy="5.62" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="7.95,7.01 6.92,5.70"/>
+                <polyline points="7.95,7.01 7.10,5.93"/>
                 <g class="nad-edge-infos" transform="translate(7.76,6.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.04)">
@@ -763,7 +762,7 @@
         <g id="61">
             <desc>T-11-10-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="7.45,1.37 6.32,3.79"/>
+                <polyline points="7.45,1.37 6.45,3.52"/>
                 <g class="nad-edge-infos" transform="translate(7.33,1.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.03)">
@@ -783,7 +782,7 @@
                 <circle cx="6.37" cy="3.70" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="5.19,6.22 6.32,3.79"/>
+                <polyline points="5.19,6.22 6.20,4.06"/>
                 <g class="nad-edge-infos" transform="translate(5.32,5.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.97)">
@@ -806,7 +805,7 @@
         <g id="62">
             <desc>T-12-10-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="7.85,7.16 6.60,6.84"/>
+                <polyline points="7.85,7.16 6.89,6.92"/>
                 <g class="nad-edge-infos" transform="translate(7.56,7.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.92)">
@@ -826,7 +825,7 @@
                 <circle cx="6.69" cy="6.87" r="0.20"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="5.34,6.53 6.60,6.84"/>
+                <polyline points="5.34,6.53 6.31,6.77"/>
                 <g class="nad-edge-infos" transform="translate(5.63,6.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.08)">

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="669.87" viewBox="-14.96 -13.42 33.95 28.43" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -542,7 +541,7 @@
         <g id="67">
             <desc>T4-12-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-4.56,4.13 -1.62,1.28"/>
+                <polyline points="-4.56,4.13 -1.83,1.49"/>
                 <g class="nad-edge-infos" transform="translate(-4.34,3.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.88)">
@@ -562,7 +561,7 @@
                 <circle cx="-1.69" cy="1.35" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="1.32,-1.57 -1.62,1.28"/>
+                <polyline points="1.32,-1.57 -1.40,1.07"/>
                 <g class="nad-edge-infos" transform="translate(1.11,-1.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.12)">
@@ -708,7 +707,7 @@
         <g id="71">
             <desc>T6-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-1.78,4.08 -3.91,0.85"/>
+                <polyline points="-1.78,4.08 -3.74,1.10"/>
                 <g class="nad-edge-infos" transform="translate(-1.94,3.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.38)">
@@ -728,7 +727,7 @@
                 <circle cx="-3.85" cy="0.93" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-6.04,-2.38 -3.91,0.85"/>
+                <polyline points="-6.04,-2.38 -4.07,0.60"/>
                 <g class="nad-edge-infos" transform="translate(-5.87,-2.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.62)">
@@ -751,7 +750,7 @@
         <g id="72">
             <desc>T6-10-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-1.70,4.04 -2.96,-0.55"/>
+                <polyline points="-1.70,4.04 -2.88,-0.26"/>
                 <g class="nad-edge-infos" transform="translate(-1.78,3.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.36)">
@@ -771,7 +770,7 @@
                 <circle cx="-2.93" cy="-0.45" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-4.22,-5.14 -2.96,-0.55"/>
+                <polyline points="-4.22,-5.14 -3.04,-0.84"/>
                 <g class="nad-edge-infos" transform="translate(-4.14,-4.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.64)">
@@ -1778,7 +1777,7 @@
         <g id="97">
             <desc>T28-27-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="5.97,5.81 8.79,4.80"/>
+                <polyline points="5.97,5.81 8.51,4.90"/>
                 <g class="nad-edge-infos" transform="translate(6.25,5.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.26)">
@@ -1798,7 +1797,7 @@
                 <circle cx="8.70" cy="4.83" r="0.20"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="11.62,3.78 8.79,4.80"/>
+                <polyline points="11.62,3.78 9.07,4.70"/>
                 <g class="nad-edge-infos" transform="translate(11.34,3.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.74)">

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="925.00" viewBox="-19.69 -24.02 45.09 52.14" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -862,7 +861,7 @@
         <g id="123">
             <desc>T4-18-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="7.29,-3.91 7.10,-3.41 7.44,-1.06"/>
+                <polyline points="7.29,-3.91 7.10,-3.41 7.40,-1.36"/>
                 <g class="nad-edge-infos" transform="translate(7.14,-3.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.61)">
@@ -882,7 +881,7 @@
                 <circle cx="7.43" cy="-1.16" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="8.12,1.70 7.79,1.29 7.44,-1.06"/>
+                <polyline points="8.12,1.70 7.79,1.29 7.49,-0.77"/>
                 <g class="nad-edge-infos" transform="translate(7.75,0.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.39)">
@@ -905,7 +904,7 @@
         <g id="124">
             <desc>T4-18-2</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="7.56,-3.95 7.89,-3.53 8.24,-1.18"/>
+                <polyline points="7.56,-3.95 7.89,-3.53 8.19,-1.48"/>
                 <g class="nad-edge-infos" transform="translate(7.93,-3.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.61)">
@@ -925,7 +924,7 @@
                 <circle cx="8.22" cy="-1.28" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="8.39,1.66 8.58,1.17 8.24,-1.18"/>
+                <polyline points="8.39,1.66 8.58,1.17 8.28,-0.88"/>
                 <g class="nad-edge-infos" transform="translate(8.54,0.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.39)">
@@ -1112,7 +1111,7 @@
         <g id="129">
             <desc>T7-29-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="16.23,-4.00 18.00,-2.13"/>
+                <polyline points="16.23,-4.00 17.79,-2.35"/>
                 <g class="nad-edge-infos" transform="translate(16.44,-3.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.61)">
@@ -1132,7 +1131,7 @@
                 <circle cx="17.93" cy="-2.20" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="19.76,-0.26 18.00,-2.13"/>
+                <polyline points="19.76,-0.26 18.20,-1.91"/>
                 <g class="nad-edge-infos" transform="translate(19.56,-0.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.39)">
@@ -1360,7 +1359,7 @@
         <g id="135">
             <desc>T9-55-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="5.82,-11.52 8.86,-12.66"/>
+                <polyline points="5.82,-11.52 8.58,-12.55"/>
                 <g class="nad-edge-infos" transform="translate(6.10,-11.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.48)">
@@ -1380,7 +1379,7 @@
                 <circle cx="8.76" cy="-12.62" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="11.89,-13.80 8.86,-12.66"/>
+                <polyline points="11.89,-13.80 9.14,-12.76"/>
                 <g class="nad-edge-infos" transform="translate(11.61,-13.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.52)">
@@ -1444,7 +1443,7 @@
         <g id="137">
             <desc>T10-51-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="2.74,-12.87 0.57,-10.60"/>
+                <polyline points="2.74,-12.87 0.77,-10.81"/>
                 <g class="nad-edge-infos" transform="translate(2.53,-12.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.23)">
@@ -1464,7 +1463,7 @@
                 <circle cx="0.64" cy="-10.67" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-1.61,-8.33 0.57,-10.60"/>
+                <polyline points="-1.61,-8.33 0.36,-10.38"/>
                 <g class="nad-edge-infos" transform="translate(-1.40,-8.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.77)">
@@ -1528,7 +1527,7 @@
         <g id="139">
             <desc>T11-41-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="1.18,-5.84 -0.18,-3.10"/>
+                <polyline points="1.18,-5.84 -0.04,-3.37"/>
                 <g class="nad-edge-infos" transform="translate(1.05,-5.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.60)">
@@ -1548,7 +1547,7 @@
                 <circle cx="-0.13" cy="-3.19" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-1.54,-0.36 -0.18,-3.10"/>
+                <polyline points="-1.54,-0.36 -0.31,-2.83"/>
                 <g class="nad-edge-infos" transform="translate(-1.40,-0.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.40)">
@@ -1571,7 +1570,7 @@
         <g id="140">
             <desc>T11-43-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="1.31,-5.81 1.39,-4.09"/>
+                <polyline points="1.31,-5.81 1.37,-4.39"/>
                 <g class="nad-edge-infos" transform="translate(1.33,-5.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.61)">
@@ -1591,7 +1590,7 @@
                 <circle cx="1.38" cy="-4.19" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="1.46,-2.36 1.39,-4.09"/>
+                <polyline points="1.46,-2.36 1.40,-3.79"/>
                 <g class="nad-edge-infos" transform="translate(1.45,-2.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-2.39)">
@@ -1819,7 +1818,7 @@
         <g id="146">
             <desc>T13-49-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-3.25,-11.04 -5.96,-7.88"/>
+                <polyline points="-3.25,-11.04 -5.76,-8.10"/>
                 <g class="nad-edge-infos" transform="translate(-3.45,-10.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.43)">
@@ -1839,7 +1838,7 @@
                 <circle cx="-5.89" cy="-7.95" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-8.67,-4.71 -5.96,-7.88"/>
+                <polyline points="-8.67,-4.71 -6.15,-7.65"/>
                 <g class="nad-edge-infos" transform="translate(-8.47,-4.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.57)">
@@ -1903,7 +1902,7 @@
         <g id="148">
             <desc>T14-46-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-9.97,-14.04 -12.65,-13.35"/>
+                <polyline points="-9.97,-14.04 -12.36,-13.43"/>
                 <g class="nad-edge-infos" transform="translate(-10.26,-13.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.46)">
@@ -1923,7 +1922,7 @@
                 <circle cx="-12.55" cy="-13.38" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-15.33,-12.66 -12.65,-13.35"/>
+                <polyline points="-15.33,-12.66 -12.94,-13.28"/>
                 <g class="nad-edge-infos" transform="translate(-15.04,-12.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.54)">
@@ -1946,7 +1945,7 @@
         <g id="149">
             <desc>T15-45-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-6.06,-13.66 -8.20,-11.99"/>
+                <polyline points="-6.06,-13.66 -7.97,-12.17"/>
                 <g class="nad-edge-infos" transform="translate(-6.29,-13.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-127.94)">
@@ -1966,7 +1965,7 @@
                 <circle cx="-8.12" cy="-12.05" r="0.20"/>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="-10.35,-10.31 -8.20,-11.99"/>
+                <polyline points="-10.35,-10.31 -8.44,-11.80"/>
                 <g class="nad-edge-infos" transform="translate(-10.11,-10.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.06)">
@@ -2071,7 +2070,7 @@
         <g id="152">
             <desc>T21-20-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="1.88,9.78 3.76,9.58"/>
+                <polyline points="1.88,9.78 3.46,9.61"/>
                 <g class="nad-edge-infos" transform="translate(2.18,9.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.07)">
@@ -2091,7 +2090,7 @@
                 <circle cx="3.66" cy="9.59" r="0.20"/>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="5.65,9.38 3.76,9.58"/>
+                <polyline points="5.65,9.38 4.06,9.55"/>
                 <g class="nad-edge-infos" transform="translate(5.35,9.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.93)">
@@ -2278,7 +2277,7 @@
         <g id="157">
             <desc>T24-25-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="6.75,17.64 6.29,17.91 5.44,19.42"/>
+                <polyline points="6.75,17.64 6.29,17.91 5.59,19.16"/>
                 <g class="nad-edge-infos" transform="translate(6.14,18.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.72)">
@@ -2298,7 +2297,7 @@
                 <circle cx="5.49" cy="19.33" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="4.60,21.46 4.59,20.93 5.44,19.42"/>
+                <polyline points="4.60,21.46 4.59,20.93 5.30,19.68"/>
                 <g class="nad-edge-infos" transform="translate(4.74,20.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.28)">
@@ -2321,7 +2320,7 @@
         <g id="158">
             <desc>T24-25-2</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="6.98,17.77 6.99,18.30 6.14,19.81"/>
+                <polyline points="6.98,17.77 6.99,18.30 6.29,19.55"/>
                 <g class="nad-edge-infos" transform="translate(6.84,18.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.72)">
@@ -2341,7 +2340,7 @@
                 <circle cx="6.19" cy="19.72" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="4.84,21.60 5.29,21.32 6.14,19.81"/>
+                <polyline points="4.84,21.60 5.29,21.32 5.99,20.07"/>
                 <g class="nad-edge-infos" transform="translate(5.44,21.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.28)">
@@ -2364,7 +2363,7 @@
         <g id="159">
             <desc>T24-26-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="7.23,17.40 9.82,16.40"/>
+                <polyline points="7.23,17.40 9.54,16.51"/>
                 <g class="nad-edge-infos" transform="translate(7.51,17.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.90)">
@@ -2384,7 +2383,7 @@
                 <circle cx="9.72" cy="16.44" r="0.20"/>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="12.41,15.40 9.82,16.40"/>
+                <polyline points="12.41,15.40 10.10,16.29"/>
                 <g class="nad-edge-infos" transform="translate(12.13,15.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.10)">
@@ -2735,7 +2734,7 @@
         <g id="168">
             <desc>T34-32-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="-12.81,19.55 -11.13,21.09"/>
+                <polyline points="-12.81,19.55 -11.35,20.89"/>
                 <g class="nad-edge-infos" transform="translate(-12.59,19.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.63)">
@@ -2755,7 +2754,7 @@
                 <circle cx="-11.21" cy="21.02" r="0.20"/>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="-9.46,22.64 -11.13,21.09"/>
+                <polyline points="-9.46,22.64 -10.91,21.30"/>
                 <g class="nad-edge-infos" transform="translate(-9.68,22.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.37)">
@@ -3147,7 +3146,7 @@
         <g id="178">
             <desc>T39-57-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="-11.61,9.77 -9.91,9.35"/>
+                <polyline points="-11.61,9.77 -10.20,9.42"/>
                 <g class="nad-edge-infos" transform="translate(-11.32,9.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.12)">
@@ -3167,7 +3166,7 @@
                 <circle cx="-10.01" cy="9.37" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-8.22,8.93 -9.91,9.35"/>
+                <polyline points="-8.22,8.93 -9.62,9.28"/>
                 <g class="nad-edge-infos" transform="translate(-8.51,9.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.88)">
@@ -3190,7 +3189,7 @@
         <g id="179">
             <desc>T40-56-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="-10.99,6.11 -8.70,5.34"/>
+                <polyline points="-10.99,6.11 -8.98,5.44"/>
                 <g class="nad-edge-infos" transform="translate(-10.70,6.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.50)">
@@ -3210,7 +3209,7 @@
                 <circle cx="-8.79" cy="5.37" r="0.20"/>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-6.41,4.58 -8.70,5.34"/>
+                <polyline points="-6.41,4.58 -8.41,5.25"/>
                 <g class="nad-edge-infos" transform="translate(-6.69,4.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.50)">

--- a/src/test/resources/current_limits.svg
+++ b/src/test/resources/current_limits.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/src/test/resources/edge_info_double_labels.svg
+++ b/src/test/resources/edge_info_double_labels.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="680.96" viewBox="-3.99 -4.23 11.54 9.82" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -77,33 +76,33 @@
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl120to180">
-            <polyline points="-1.80,-2.03 0.73,0.53"/>
+            <polyline points="-1.80,-2.03 0.49,0.31"/>
             <g class="nad-edge-infos" transform="translate(-1.38,-1.61)">
                 <g class="nad-state-in">
-                    <g transform="rotate(135.46)">
+                    <g transform="rotate(135.72)">
                         <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(45.46)" x="0.20">145</text>
-                    <text transform="rotate(45.46)" x="-0.20" style="text-anchor:end">243</text>
+                    <text transform="rotate(45.72)" x="0.20">145</text>
+                    <text transform="rotate(45.72)" x="-0.20" style="text-anchor:end">243</text>
                 </g>
             </g>
         </g>
         <g id="8" class="nad-vl30to50">
-            <polyline points="-1.63,3.38 0.73,0.53"/>
-            <g class="nad-edge-infos" transform="translate(-1.25,2.92)">
+            <polyline points="-1.63,3.38 0.66,0.84"/>
+            <g class="nad-edge-infos" transform="translate(-1.23,2.94)">
                 <g class="nad-state-in">
-                    <g transform="rotate(39.54)">
+                    <g transform="rotate(41.95)">
                         <path class="nad-arrow-in" d="M-0.2 -0.1 H0.2 L0 0.1z"/>
                         <path class="nad-arrow-out" d="M-0.05 0.1 H0.05 L0 -0.1z"/>
                     </g>
-                    <text transform="rotate(-50.46)" x="0.20">145</text>
-                    <text transform="rotate(-50.46)" x="-0.20" style="text-anchor:end">243</text>
+                    <text transform="rotate(-48.05)" x="0.20">145</text>
+                    <text transform="rotate(-48.05)" x="-0.20" style="text-anchor:end">243</text>
                 </g>
             </g>
         </g>
         <g id="9" class="nad-vl0to30">
-            <polyline points="4.29,-0.57 0.73,0.53"/>
+            <polyline points="4.29,-0.57 1.03,0.44"/>
             <g class="nad-edge-infos" transform="translate(3.72,-0.40)">
                 <g class="nad-state-in">
                     <g transform="rotate(-107.23)">
@@ -117,15 +116,10 @@
         </g>
     </g>
     <g class="nad-3wt-nodes">
-        <g transform="translate(0.73,0.53)">
-            <g class="nad-3wt-bg">
-                <circle cx="0.00" cy="0.12" r="0.20"/>
-                <circle cx="-0.10" cy="-0.06" r="0.20"/>
-                <circle cx="0.10" cy="-0.06" r="0.20"/>
-            </g>
-            <circle class="nad-vl120to180" cx="0.00" cy="0.12" r="0.20"/>
-            <circle class="nad-vl30to50" cx="-0.10" cy="-0.06" r="0.20"/>
-            <circle class="nad-vl0to30" cx="0.10" cy="-0.06" r="0.20"/>
+        <g>
+            <circle class="nad-vl120to180" cx="0.64" cy="0.45" r="0.20"/>
+            <circle class="nad-vl30to50" cx="0.70" cy="0.65" r="0.20"/>
+            <circle class="nad-vl0to30" cx="0.84" cy="0.50" r="0.20"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/edge_info_missing_label.svg
+++ b/src/test/resources/edge_info_missing_label.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/src/test/resources/edge_info_perpendicular_label.svg
+++ b/src/test/resources/edge_info_perpendicular_label.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}

--- a/src/test/resources/edge_info_shift.svg
+++ b/src/test/resources/edge_info_shift.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="703.08" viewBox="-3.06 -3.40 8.39 7.37" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -161,7 +160,7 @@
         </g>
         <g id="10">
             <g class="nad-vl300to500">
-                <polyline points="0.09,-1.04 1.11,-0.22"/>
+                <polyline points="0.09,-1.04 0.87,-0.41"/>
                 <g class="nad-edge-infos" transform="translate(0.25,-0.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.02)">
@@ -181,7 +180,7 @@
                 <circle cx="1.03" cy="-0.28" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="2.12,0.60 1.11,-0.22"/>
+                <polyline points="2.12,0.60 1.34,-0.03"/>
                 <g class="nad-edge-infos" transform="translate(1.73,0.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.98)">
@@ -203,7 +202,7 @@
         </g>
         <g id="11">
             <g class="nad-vl300to500">
-                <polyline points="-0.81,1.88 0.49,1.42"/>
+                <polyline points="-0.81,1.88 0.21,1.52"/>
                 <g class="nad-edge-infos" transform="translate(-0.62,1.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.43)">
@@ -223,7 +222,7 @@
                 <circle cx="0.40" cy="1.45" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1.79,0.96 0.49,1.42"/>
+                <polyline points="1.79,0.96 0.77,1.32"/>
                 <g class="nad-edge-infos" transform="translate(1.60,1.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.57)">

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="394.38" viewBox="-7.73 -4.20 17.06 8.41" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -94,7 +93,7 @@
         <g id="10">
             <desc>TWT</desc>
             <g class="nad-vl180to300">
-                <polyline points="-5.46,0.60 -3.71,0.53"/>
+                <polyline points="-5.46,0.60 -4.01,0.55"/>
                 <g class="nad-edge-infos" transform="translate(-5.16,0.59)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(87.83)">
@@ -114,7 +113,7 @@
                 <circle cx="-3.81" cy="0.54" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-1.96,0.47 -3.71,0.53"/>
+                <polyline points="-1.96,0.47 -3.41,0.52"/>
                 <g class="nad-edge-infos" transform="translate(-2.26,0.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.17)">

--- a/src/test/resources/parallel_transformers.svg
+++ b/src/test/resources/parallel_transformers.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="800.00" height="703.08" viewBox="-3.06 -3.40 8.39 7.37" xmlns="http://www.w3.org/2000/svg">
+<svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -50,13 +49,10 @@
         <nad:nodes>
             <nad:node diagramId="0" equipmentId="vl1"/>
             <nad:node diagramId="3" equipmentId="vl2"/>
-            <nad:node diagramId="5" equipmentId="vl3"/>
         </nad:nodes>
         <nad:edges>
-            <nad:edge diagramId="8" equipmentId="l1"/>
-            <nad:edge diagramId="9" equipmentId="l2"/>
-            <nad:edge diagramId="10" equipmentId="tr1"/>
-            <nad:edge diagramId="11" equipmentId="tr2"/>
+            <nad:edge diagramId="5" equipmentId="tr1"/>
+            <nad:edge diagramId="6" equipmentId="tr2"/>
         </nad:edges>
     </metadata>
     <defs>
@@ -66,192 +62,106 @@
         </filter>
     </defs>
     <g class="nad-vl-nodes">
-        <g transform="translate(-0.35,-1.40)" id="0" class="nad-vl300to500">
+        <g transform="translate(1.60,-0.89)" id="0" class="nad-vl300to500">
             <circle r="0.30" id="1"/>
-            <path d="M-0.437,0.411 A0.600,0.600 350.451 1 1 -0.362,0.478 L-0.161,0.253 A0.300,0.300 -340.901 1 0 -0.235,0.187 Z " id="2"/>
+            <path d="M-0.588,0.121 A0.600,0.600 350.451 1 1 -0.559,0.217 L-0.270,0.131 A0.300,0.300 -340.901 1 0 -0.298,0.036 Z " id="2"/>
         </g>
-        <g transform="translate(-1.06,1.97)" id="3" class="nad-vl300to500">
+        <g transform="translate(-0.85,1.68)" id="3" class="nad-vl180to300">
             <circle r="0.30" id="4"/>
-        </g>
-        <g transform="translate(2.33,0.77)" id="5" class="nad-vl180to300">
-            <circle r="0.30" id="6"/>
-            <path d="M-0.433,-0.415 A0.600,0.600 350.451 1 1 -0.496,-0.338 L-0.261,-0.148 A0.300,0.300 -340.901 1 0 -0.199,-0.225 Z " id="7"/>
         </g>
     </g>
     <g class="nad-branch-edges">
-        <g id="8">
+        <g id="5">
             <g class="nad-vl300to500">
-                <polyline points="-0.53,-1.20 -0.88,-0.80 -1.10,0.20"/>
-                <g class="nad-edge-infos" transform="translate(-0.92,-0.61)">
+                <polyline points="1.34,-0.81 0.83,-0.66 0.29,-0.10"/>
+                <g class="nad-edge-infos" transform="translate(0.62,-0.45)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-168.06)">
+                        <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-168.06)">
+                        <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-            </g>
-            <g class="nad-vl300to500">
-                <polyline points="-1.14,1.71 -1.31,1.21 -1.10,0.20"/>
-                <g class="nad-edge-infos" transform="translate(-1.27,1.01)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(11.94)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="0.19">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(11.94)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="0.19">0</text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="9">
-            <g class="nad-vl300to500">
-                <polyline points="-0.17,-0.86 -0.10,-0.64 -0.31,0.37"/>
-                <g class="nad-edge-infos" transform="translate(-0.14,-0.44)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(-168.06)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-168.06)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
-                    </g>
-                </g>
-            </g>
-            <g class="nad-disconnected nad-vl300to500">
-                <polyline points="-0.88,1.77 -0.53,1.38 -0.31,0.37"/>
-                <g class="nad-edge-infos" transform="translate(-0.48,1.18)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(11.94)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="0.19">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(11.94)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(-78.06)" x="0.19">0</text>
-                    </g>
-                </g>
-            </g>
-        </g>
-        <g id="10">
-            <g class="nad-vl300to500">
-                <polyline points="0.09,-1.04 1.11,-0.22"/>
-                <g class="nad-edge-infos" transform="translate(0.25,-0.91)">
-                    <g class="nad-active nad-state-out">
-                        <g transform="rotate(129.02)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(39.02)" x="0.19">0</text>
-                    </g>
-                    <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(129.02)">
-                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
-                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
-                        </g>
-                        <text transform="rotate(39.02)" x="0.19">0</text>
-                    </g>
-                </g>
-                <circle cx="1.03" cy="-0.28" r="0.20"/>
+                <circle cx="0.15" cy="0.05" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="2.12,0.60 1.11,-0.22"/>
-                <g class="nad-edge-infos" transform="translate(1.73,0.28)">
+                <polyline points="-0.78,1.41 -0.66,0.90 -0.12,0.33"/>
+                <g class="nad-edge-infos" transform="translate(-0.45,0.68)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-50.98)">
+                        <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-320.98)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-50.98)">
+                        <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-320.98)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="1.18" cy="-0.16" r="0.20"/>
+                <circle cx="0.02" cy="0.19" r="0.20"/>
             </g>
         </g>
-        <g id="11">
+        <g id="6">
             <g class="nad-vl300to500">
-                <polyline points="-0.81,1.88 0.49,1.42"/>
-                <g class="nad-edge-infos" transform="translate(-0.62,1.81)">
+                <polyline points="1.46,-0.34 1.41,-0.11 0.87,0.45"/>
+                <g class="nad-edge-infos" transform="translate(1.20,0.11)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(70.43)">
+                        <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.57)" x="0.19">0</text>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(70.43)">
+                        <g transform="rotate(-136.40)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.57)" x="0.19">0</text>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="0.40" cy="1.45" r="0.20"/>
+                <circle cx="0.73" cy="0.60" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1.79,0.96 0.49,1.42"/>
-                <g class="nad-edge-infos" transform="translate(1.60,1.03)">
+                <polyline points="-0.59,1.60 -0.08,1.45 0.46,0.89"/>
+                <g class="nad-edge-infos" transform="translate(0.13,1.23)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-109.57)">
+                        <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.57)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-109.57)">
+                        <g transform="rotate(43.60)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-19.57)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="0.59" cy="1.39" r="0.20"/>
+                <circle cx="0.59" cy="0.74" r="0.20"/>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_edge" points="0.25,-1.40 0.65,-1.40"/>
-        <polyline id="3_edge" points="-0.76,1.97 -0.06,1.97"/>
-        <polyline id="5_edge" points="2.93,0.77 3.33,0.77"/>
+        <polyline id="0_edge" points="2.20,-0.89 2.60,-0.89"/>
+        <polyline id="3_edge" points="-0.55,1.68 0.15,1.68"/>
     </g>
     <g class="nad-text-nodes">
-        <text filter="url(#textBgFilter)" y="-1.40" style="dominant-baseline:middle" x="0.65">s1</text>
-        <text filter="url(#textBgFilter)" y="1.97" style="dominant-baseline:middle" x="-0.06">s1</text>
-        <text filter="url(#textBgFilter)" y="0.77" style="dominant-baseline:middle" x="3.33">s1</text>
+        <text filter="url(#textBgFilter)" y="-0.89" style="dominant-baseline:middle" x="2.60">s1</text>
+        <text filter="url(#textBgFilter)" y="1.68" style="dominant-baseline:middle" x="0.15">s1</text>
     </g>
 </svg>

--- a/src/test/resources/parallel_transformers.svg
+++ b/src/test/resources/parallel_transformers.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="703.08" viewBox="-3.06 -3.40 8.39 7.37" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue); stroke-width: 0.05; stroke: white; stroke-linejoin:round}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-bg circle {stroke: none; fill: white}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 0.05}
+  40% {stroke: #FFEB3B; stroke-width: 0.15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0.05}
+  40% {stroke: #ff5722; stroke-width: 0.15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0.05}
+  40% {stroke: #00BCD4; stroke-width: 0.15}
+}
+]]></style>
+    <metadata xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+        <nad:nodes>
+            <nad:node diagramId="0" equipmentId="vl1"/>
+            <nad:node diagramId="3" equipmentId="vl2"/>
+            <nad:node diagramId="5" equipmentId="vl3"/>
+        </nad:nodes>
+        <nad:edges>
+            <nad:edge diagramId="8" equipmentId="l1"/>
+            <nad:edge diagramId="9" equipmentId="l2"/>
+            <nad:edge diagramId="10" equipmentId="tr1"/>
+            <nad:edge diagramId="11" equipmentId="tr2"/>
+        </nad:edges>
+    </metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-0.35,-1.40)" id="0" class="nad-vl300to500">
+            <circle r="0.30" id="1"/>
+            <path d="M-0.437,0.411 A0.600,0.600 350.451 1 1 -0.362,0.478 L-0.161,0.253 A0.300,0.300 -340.901 1 0 -0.235,0.187 Z " id="2"/>
+        </g>
+        <g transform="translate(-1.06,1.97)" id="3" class="nad-vl300to500">
+            <circle r="0.30" id="4"/>
+        </g>
+        <g transform="translate(2.33,0.77)" id="5" class="nad-vl180to300">
+            <circle r="0.30" id="6"/>
+            <path d="M-0.433,-0.415 A0.600,0.600 350.451 1 1 -0.496,-0.338 L-0.261,-0.148 A0.300,0.300 -340.901 1 0 -0.199,-0.225 Z " id="7"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="8">
+            <g class="nad-vl300to500">
+                <polyline points="-0.53,-1.20 -0.88,-0.80 -1.10,0.20"/>
+                <g class="nad-edge-infos" transform="translate(-0.92,-0.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl300to500">
+                <polyline points="-1.14,1.71 -1.31,1.21 -1.10,0.20"/>
+                <g class="nad-edge-infos" transform="translate(-1.27,1.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="9">
+            <g class="nad-vl300to500">
+                <polyline points="-0.17,-0.86 -0.10,-0.64 -0.31,0.37"/>
+                <g class="nad-edge-infos" transform="translate(-0.14,-0.44)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-168.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-168.06)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-disconnected nad-vl300to500">
+                <polyline points="-0.88,1.77 -0.53,1.38 -0.31,0.37"/>
+                <g class="nad-edge-infos" transform="translate(-0.48,1.18)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(11.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(11.94)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-78.06)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="10">
+            <g class="nad-vl300to500">
+                <polyline points="0.09,-1.04 1.11,-0.22"/>
+                <g class="nad-edge-infos" transform="translate(0.25,-0.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(129.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.02)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(129.02)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(39.02)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="1.03" cy="-0.28" r="0.20"/>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="2.12,0.60 1.11,-0.22"/>
+                <g class="nad-edge-infos" transform="translate(1.73,0.28)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-50.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-320.98)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-50.98)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-320.98)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="1.18" cy="-0.16" r="0.20"/>
+            </g>
+        </g>
+        <g id="11">
+            <g class="nad-vl300to500">
+                <polyline points="-0.81,1.88 0.49,1.42"/>
+                <g class="nad-edge-infos" transform="translate(-0.62,1.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(70.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(70.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="0.40" cy="1.45" r="0.20"/>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="1.79,0.96 0.49,1.42"/>
+                <g class="nad-edge-infos" transform="translate(1.60,1.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-109.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-109.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-19.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="0.59" cy="1.39" r="0.20"/>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_edge" points="0.25,-1.40 0.65,-1.40"/>
+        <polyline id="3_edge" points="-0.76,1.97 -0.06,1.97"/>
+        <polyline id="5_edge" points="2.93,0.77 3.33,0.77"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" y="-1.40" style="dominant-baseline:middle" x="0.65">s1</text>
+        <text filter="url(#textBgFilter)" y="1.97" style="dominant-baseline:middle" x="-0.06">s1</text>
+        <text filter="url(#textBgFilter)" y="0.77" style="dominant-baseline:middle" x="3.33">s1</text>
+    </g>
+</svg>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="879.76" viewBox="-7.54 -10.03 17.60 19.35" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -216,7 +215,7 @@
         <g id="24">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-4.18,-2.15 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.86,-1.27"/>
+                <path d="M-4.18,-2.15 L-3.95,-2.18 C-3.55,-2.24 -3.59,-1.56 -3.66,-1.49"/>
                 <g class="nad-edge-infos" transform="translate(-3.95,-2.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.56)">
@@ -233,10 +232,10 @@
                         <text transform="rotate(-7.44)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="-3.87" cy="-1.37" r="0.20"/>
+                <circle cx="-3.79" cy="-1.34" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-4.75,-1.81 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -3.86,-1.27"/>
+                <path d="M-4.75,-1.81 L-4.78,-1.28 C-4.80,-0.88 -4.13,-0.97 -4.06,-1.05"/>
                 <g class="nad-edge-infos" transform="translate(-4.78,-1.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.44)">
@@ -253,7 +252,7 @@
                         <text transform="rotate(-87.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-3.96" cy="-1.27" r="0.20"/>
+                <circle cx="-3.93" cy="-1.19" r="0.20"/>
             </g>
         </g>
         <g id="25">
@@ -669,7 +668,7 @@
         <g id="35">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-0.19,7.20 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.20,6.26"/>
+                <path d="M-0.19,7.20 L-0.42,7.15 C-0.81,7.07 -0.56,6.45 -0.47,6.40"/>
                 <g class="nad-edge-infos" transform="translate(-0.42,7.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.28)">
@@ -686,10 +685,10 @@
                         <text transform="rotate(-348.28)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-0.23" cy="6.36" r="0.20"/>
+                <circle cx="-0.29" cy="6.31" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.46,7.07 L0.66,6.57 C0.81,6.20 0.15,6.07 -0.20,6.26"/>
+                <path d="M0.46,7.07 L0.66,6.57 C0.81,6.20 0.15,6.07 0.06,6.12"/>
                 <g class="nad-edge-infos" transform="translate(0.66,6.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.72)">
@@ -706,7 +705,7 @@
                         <text transform="rotate(-68.28)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="-0.11" cy="6.29" r="0.20"/>
+                <circle cx="-0.12" cy="6.21" r="0.20"/>
             </g>
         </g>
         <g id="36">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="879.76" viewBox="-7.54 -10.03 17.60 19.35" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -216,7 +215,7 @@
         <g id="24">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-5.31,-2.10 L-5.54,-2.12 C-5.94,-2.13 -5.90,-2.60 -5.63,-2.89"/>
+                <path d="M-5.31,-2.10 L-5.54,-2.12 C-5.94,-2.13 -5.90,-2.60 -5.83,-2.67"/>
                 <g class="nad-edge-infos" transform="translate(-5.54,-2.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.44)">
@@ -233,10 +232,10 @@
                         <text transform="rotate(-357.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-5.62" cy="-2.79" r="0.20"/>
+                <circle cx="-5.69" cy="-2.82" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-4.78,-2.35 L-4.85,-2.87 C-4.90,-3.27 -5.36,-3.19 -5.63,-2.89"/>
+                <path d="M-4.78,-2.35 L-4.85,-2.87 C-4.90,-3.27 -5.36,-3.19 -5.42,-3.11"/>
                 <g class="nad-edge-infos" transform="translate(-4.85,-2.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.44)">
@@ -253,7 +252,7 @@
                         <text transform="rotate(-277.44)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-5.53" cy="-2.89" r="0.20"/>
+                <circle cx="-5.56" cy="-2.96" r="0.20"/>
             </g>
         </g>
         <g id="25">
@@ -669,7 +668,7 @@
         <g id="35">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M0.57,7.85 L0.65,8.06 C0.79,8.44 0.34,8.58 -0.03,8.45"/>
+                <path d="M0.57,7.85 L0.65,8.06 C0.79,8.44 0.34,8.58 0.25,8.55"/>
                 <g class="nad-edge-infos" transform="translate(0.65,8.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.31)">
@@ -686,10 +685,10 @@
                         <text transform="rotate(69.31)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="0.05" cy="8.40" r="0.20"/>
+                <circle cx="0.06" cy="8.48" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.13,7.45 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.03,8.45"/>
+                <path d="M0.13,7.45 L-0.32,7.72 C-0.67,7.93 -0.41,8.32 -0.32,8.35"/>
                 <g class="nad-edge-infos" transform="translate(-0.32,7.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.69)">
@@ -706,7 +705,7 @@
                         <text transform="rotate(-30.69)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-0.07" cy="8.36" r="0.20"/>
+                <circle cx="-0.13" cy="8.42" r="0.20"/>
             </g>
         </g>
         <g id="36">

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="879.76" viewBox="-7.54 -10.03 17.60 19.35" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -216,7 +215,7 @@
         <g id="24">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-5.30,-2.20 L-5.52,-2.25 C-5.91,-2.34 -5.90,-2.60 -5.63,-2.89"/>
+                <path d="M-5.30,-2.20 L-5.52,-2.25 C-5.91,-2.34 -5.90,-2.60 -5.83,-2.67"/>
                 <g class="nad-edge-infos" transform="translate(-5.52,-2.25)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.44)">
@@ -233,10 +232,10 @@
                         <text transform="rotate(-347.44)" x="-0.19" style="text-anchor:end">8</text>
                     </g>
                 </g>
-                <circle cx="-5.61" cy="-2.79" r="0.20"/>
+                <circle cx="-5.69" cy="-2.82" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-4.82,-2.34 L-4.98,-2.84 C-5.10,-3.22 -5.36,-3.19 -5.63,-2.89"/>
+                <path d="M-4.82,-2.34 L-4.98,-2.84 C-5.10,-3.22 -5.36,-3.19 -5.42,-3.11"/>
                 <g class="nad-edge-infos" transform="translate(-4.98,-2.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.44)">
@@ -253,7 +252,7 @@
                         <text transform="rotate(-287.44)" x="-0.19" style="text-anchor:end">4</text>
                     </g>
                 </g>
-                <circle cx="-5.53" cy="-2.88" r="0.20"/>
+                <circle cx="-5.56" cy="-2.96" r="0.20"/>
             </g>
         </g>
         <g id="25">
@@ -669,7 +668,7 @@
         <g id="35">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M0.85,7.62 L1.04,7.74 C1.38,7.95 1.28,8.18 0.93,8.37"/>
+                <path d="M0.85,7.62 L1.04,7.74 C1.38,7.95 1.28,8.18 1.20,8.23"/>
                 <g class="nad-edge-infos" transform="translate(1.04,7.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.72)">
@@ -686,10 +685,10 @@
                         <text transform="rotate(31.72)" x="0.19">4</text>
                     </g>
                 </g>
-                <circle cx="0.95" cy="8.27" r="0.20"/>
+                <circle cx="1.02" cy="8.33" r="0.20"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M0.36,7.59 L0.34,8.12 C0.33,8.52 0.58,8.56 0.93,8.37"/>
+                <path d="M0.36,7.59 L0.34,8.12 C0.33,8.52 0.58,8.56 0.67,8.52"/>
                 <g class="nad-edge-infos" transform="translate(0.34,8.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-178.28)">
@@ -706,7 +705,7 @@
                         <text transform="rotate(-88.28)" x="-0.19" style="text-anchor:end">9</text>
                     </g>
                 </g>
-                <circle cx="0.84" cy="8.33" r="0.20"/>
+                <circle cx="0.84" cy="8.42" r="0.20"/>
             </g>
         </g>
         <g id="36">

--- a/src/test/resources/voltage_limits.svg
+++ b/src/test/resources/voltage_limits.svg
@@ -2,7 +2,7 @@
 <svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: white}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
 .nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
@@ -10,7 +10,6 @@
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-dasharray: .05,.05; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
 .nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
-.nad-3wt-bg circle {stroke: none; fill: white}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
A 2wt is draw at middle point between bus nodes. 
When svg circle fill attribut is set to none, the branch appears behind 2wt circles.
Similar behaviour for 3wt

**What is the new behavior (if this is a feature change)?**
When svg circle fill attribut is set to none, the branch does not appears behind 2wt / 3wt circles.


**Does this PR introduce a breaking change or deprecate an API?** 
No