### PR TITLE
Allow applying repulsion force between springs

### DIFF
--- a/src/main/java/com/powsybl/forcelayout/ForceLayout.java
+++ b/src/main/java/com/powsybl/forcelayout/ForceLayout.java
@@ -199,6 +199,8 @@ public class ForceLayout<V, E> {
                     Vector center = q1.add(q2.subtract(q1).multiply(0.5));
                     Vector force = coulombsForce(p, center, repulsion * springRepulsionFactor);
                     point.applyForce(force);
+                    n1.applyForce(force.multiply(-0.5));
+                    n2.applyForce(force.multiply(-0.5));
                 }
             }
         }

--- a/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
+++ b/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
@@ -23,7 +23,7 @@ public class BasicForceLayout extends AbstractLayout {
     protected void nodesLayout(Graph graph, LayoutParameters layoutParameters) {
         org.jgrapht.Graph<Node, Edge> jgraphtGraph = graph.getJgraphtGraph(layoutParameters.isTextNodesForceLayout());
         ForceLayout<Node, Edge> forceLayout = new ForceLayout<>(jgraphtGraph);
-        forceLayout.setSpringRepulsion(layoutParameters.isSpringRepulsionForceLayout());
+        forceLayout.setSpringRepulsionFactor(layoutParameters.getSpringRepulsionFactorForceLayout());
         forceLayout.execute();
 
         jgraphtGraph.vertexSet().forEach(node -> {

--- a/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
+++ b/src/main/java/com/powsybl/nad/layout/BasicForceLayout.java
@@ -23,6 +23,7 @@ public class BasicForceLayout extends AbstractLayout {
     protected void nodesLayout(Graph graph, LayoutParameters layoutParameters) {
         org.jgrapht.Graph<Node, Edge> jgraphtGraph = graph.getJgraphtGraph(layoutParameters.isTextNodesForceLayout());
         ForceLayout<Node, Edge> forceLayout = new ForceLayout<>(jgraphtGraph);
+        forceLayout.setSpringRepulsion(layoutParameters.isSpringRepulsionForceLayout());
         forceLayout.execute();
 
         jgraphtGraph.vertexSet().forEach(node -> {

--- a/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -11,12 +11,14 @@ package com.powsybl.nad.layout;
  */
 public class LayoutParameters {
     private boolean textNodesForceLayout = false;
+    private boolean springRepulsionForceLayout = false;
 
     public LayoutParameters() {
     }
 
     public LayoutParameters(LayoutParameters other) {
         this.textNodesForceLayout = other.textNodesForceLayout;
+        this.springRepulsionForceLayout = other.springRepulsionForceLayout;
     }
 
     public boolean isTextNodesForceLayout() {
@@ -25,6 +27,15 @@ public class LayoutParameters {
 
     public LayoutParameters setTextNodesForceLayout(boolean textNodesForceLayout) {
         this.textNodesForceLayout = textNodesForceLayout;
+        return this;
+    }
+
+    public boolean isSpringRepulsionForceLayout() {
+        return springRepulsionForceLayout;
+    }
+
+    public LayoutParameters setSpringRepulsionForceLayout(boolean springRepulsionForceLayout) {
+        this.springRepulsionForceLayout = springRepulsionForceLayout;
         return this;
     }
 }

--- a/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
+++ b/src/main/java/com/powsybl/nad/layout/LayoutParameters.java
@@ -11,14 +11,14 @@ package com.powsybl.nad.layout;
  */
 public class LayoutParameters {
     private boolean textNodesForceLayout = false;
-    private boolean springRepulsionForceLayout = false;
+    private double springRepulsionFactorForceLayout = 0.0;
 
     public LayoutParameters() {
     }
 
     public LayoutParameters(LayoutParameters other) {
         this.textNodesForceLayout = other.textNodesForceLayout;
-        this.springRepulsionForceLayout = other.springRepulsionForceLayout;
+        this.springRepulsionFactorForceLayout = other.springRepulsionFactorForceLayout;
     }
 
     public boolean isTextNodesForceLayout() {
@@ -30,12 +30,12 @@ public class LayoutParameters {
         return this;
     }
 
-    public boolean isSpringRepulsionForceLayout() {
-        return springRepulsionForceLayout;
+    public LayoutParameters setSpringRepulsionFactorForceLayout(double springRepulsionFactorForceLayout) {
+        this.springRepulsionFactorForceLayout = springRepulsionFactorForceLayout;
+        return this;
     }
 
-    public LayoutParameters setSpringRepulsionForceLayout(boolean springRepulsionForceLayout) {
-        this.springRepulsionForceLayout = springRepulsionForceLayout;
-        return this;
+    public double getSpringRepulsionFactorForceLayout() {
+        return springRepulsionFactorForceLayout;
     }
 }

--- a/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
+++ b/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.layout;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.svg.LabelProvider;
+import com.powsybl.nad.svg.StyleProvider;
+import com.powsybl.nad.svg.SvgParameters;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Luma Zamarreno <zamarrenolm at aia.es>
+ */
+class ForceLayoutTest extends AbstractTest {
+
+    @BeforeEach
+    public void setup() {
+        setLayoutParameters(new LayoutParameters().setTextNodesForceLayout(false));
+        setSvgParameters(new SvgParameters()
+                .setInsertNameDesc(false)
+                .setSvgWidthAndHeightAdded(false));
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new NominalVoltageStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new DefaultLabelProvider(network, getSvgParameters());
+    }
+
+    @Test
+    void testDiamondNoSpringRepulsionFactor() {
+        assertEquals(
+                toString("/diamond-spring-repulsion-factor-0.0.svg"),
+                generateSvgString(createDiamondNetwork(), "/diamond.svg"));
+    }
+
+    @Test
+    void testDiamondSmallSpringRepulsionFactor() {
+        getLayoutParameters().setSpringRepulsionFactorForceLayout(0.2);
+        assertEquals(
+                toString("/diamond-spring-repulsion-factor-0.2.svg"),
+                generateSvgString(createDiamondNetwork(), "/diamond.svg"));
+    }
+
+    static Network createDiamondNetwork() {
+        Network network = NetworkFactory.findDefault().createNetwork("diamond", "manual");
+        network.setName("diamond");
+
+        Substation subA = network.newSubstation().setId("A").add();
+        Bus subA400 = createBus(subA, 400);
+        Bus subA230 = createBus(subA, 230);
+        createTransformer(subA400, subA230);
+
+        Substation subB = network.newSubstation().setId("B").add();
+        Bus subB230 = createBus(subB, 230);
+        createLine(subA230, subB230);
+
+        Substation subC = network.newSubstation().setId("C").add();
+        Bus subC230 = createBus(subC, 230);
+        Bus subC66 = createBus(subC, 66);
+        Bus subC20 = createBus(subC, 20);
+        createTransformer(subC230, subC66);
+        createTransformer(subC66, subC20);
+        createLine(subB230, subC230);
+
+        Substation subD = network.newSubstation().setId("D").add();
+        Bus subD66 = createBus(subD, 66);
+        Bus subD10 = createBus(subD, 10);
+        createTransformer(subD66, subD10);
+        createLine(subC66, subD66);
+
+        Substation subE = network.newSubstation().setId("E").add();
+        Bus subE10 = createBus(subE, 10);
+        createLine(subD10, subE10);
+
+        Bus subF10 = createBus(network, "F", 10);
+        Bus subG10 = createBus(network, "G", 10);
+        Bus subH10 = createBus(network, "H", 10);
+        Bus subI10 = createBus(network, "I", 10);
+        Bus subJ10 = createBus(network, "J", 10);
+        Bus subK10 = createBus(network, "K", 10);
+
+        createLine(subE10, subF10);
+        createLine(subF10, subG10);
+        createLine(subG10, subH10);
+        createLine(subH10, subD10);
+
+        createLine(subF10, subI10);
+        createLine(subI10, subJ10);
+        createLine(subJ10, subK10);
+        createLine(subK10, subD10);
+
+        return network;
+    }
+
+    private static Bus createBus(Network network, String substationId, double nominalVoltage) {
+        Substation substation = network.newSubstation().setId(substationId).add();
+        return createBus(substation, nominalVoltage);
+    }
+
+    private static Bus createBus(Substation substation, double nominalVoltage) {
+        String vlId = String.format("%s %.0f", substation.getId(), nominalVoltage);
+        String busId = String.format("%s %s", vlId, "Bus");
+        return substation.newVoltageLevel()
+                .setId(vlId)
+                .setNominalV(nominalVoltage)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add()
+                .getBusBreakerView()
+                .newBus()
+                .setId(busId)
+                .add();
+    }
+
+    private static void createTransformer(Bus bus1, Bus bus2) {
+        Substation substation = bus1.getVoltageLevel().getSubstation().orElseThrow();
+        String id = String.format("%s %.0f %.0f",
+                substation.getId(),
+                bus1.getVoltageLevel().getNominalV(),
+                bus2.getVoltageLevel().getNominalV());
+        substation.newTwoWindingsTransformer().setId(id)
+                .setR(0.0)
+                .setX(1.0)
+                .setG(0.0)
+                .setB(0.0)
+                .setVoltageLevel1(bus1.getVoltageLevel().getId())
+                .setVoltageLevel2(bus2.getVoltageLevel().getId())
+                .setConnectableBus1(bus1.getId())
+                .setConnectableBus2(bus2.getId())
+                .setRatedU1(bus1.getVoltageLevel().getNominalV())
+                .setRatedU2(bus2.getVoltageLevel().getNominalV())
+                .setBus1(bus1.getId())
+                .setBus2(bus2.getId())
+                .add();
+    }
+
+    private static void createLine(Bus bus1, Bus bus2) {
+        String id = String.format("%s - %s",
+                bus1.getVoltageLevel().getSubstation().orElseThrow().getId(),
+                bus2.getVoltageLevel().getSubstation().orElseThrow().getId());
+        bus1.getNetwork().newLine().setId(id)
+                .setR(0.0)
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .setVoltageLevel1(bus1.getVoltageLevel().getId())
+                .setVoltageLevel2(bus2.getVoltageLevel().getId())
+                .setConnectableBus1(bus1.getId())
+                .setConnectableBus2(bus2.getId())
+                .setBus1(bus1.getId())
+                .setBus2(bus2.getId())
+                .add();
+    }
+}

--- a/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
+++ b/src/test/java/com/powsybl/nad/layout/ForceLayoutTest.java
@@ -45,7 +45,7 @@ class ForceLayoutTest extends AbstractTest {
     void testDiamondNoSpringRepulsionFactor() {
         assertEquals(
                 toString("/diamond-spring-repulsion-factor-0.0.svg"),
-                generateSvgString(createDiamondNetwork(), "/diamond.svg"));
+                generateSvgString(createDiamondNetwork(), "/diamond-spring-repulsion-factor-0.0.svg"));
     }
 
     @Test
@@ -53,7 +53,7 @@ class ForceLayoutTest extends AbstractTest {
         getLayoutParameters().setSpringRepulsionFactorForceLayout(0.2);
         assertEquals(
                 toString("/diamond-spring-repulsion-factor-0.2.svg"),
-                generateSvgString(createDiamondNetwork(), "/diamond.svg"));
+                generateSvgString(createDiamondNetwork(), "/diamond-spring-repulsion-factor-0.2.svg"));
     }
 
     static Network createDiamondNetwork() {

--- a/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
+++ b/src/test/java/com/powsybl/nad/layout/LayoutParametersTest.java
@@ -18,10 +18,12 @@ class LayoutParametersTest {
     @Test
     void test() {
         LayoutParameters layoutParameters0 = new LayoutParameters()
-                .setTextNodesForceLayout(true);
+                .setTextNodesForceLayout(true)
+                .setSpringRepulsionFactorForceLayout(1.0);
 
         LayoutParameters layoutParameters1 = new LayoutParameters(layoutParameters0);
 
         assertEquals(layoutParameters0.isTextNodesForceLayout(), layoutParameters1.isTextNodesForceLayout());
+        assertEquals(layoutParameters0.getSpringRepulsionFactorForceLayout(), layoutParameters1.getSpringRepulsionFactorForceLayout());
     }
 }

--- a/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-16.01 -8.28 29.72 16.17" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black; dominant-baseline: central}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 0.05}
+  40% {stroke: #FFEB3B; stroke-width: 0.15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 0.15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 0.15}
+}
+]]></style>
+    <metadata xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+        <nad:busNodes>
+            <nad:busNode diagramId="1" equipmentId="A 230_0"/>
+            <nad:busNode diagramId="3" equipmentId="A 400_0"/>
+            <nad:busNode diagramId="5" equipmentId="B 230_0"/>
+            <nad:busNode diagramId="7" equipmentId="C 20_0"/>
+            <nad:busNode diagramId="9" equipmentId="C 230_0"/>
+            <nad:busNode diagramId="11" equipmentId="C 66_0"/>
+            <nad:busNode diagramId="13" equipmentId="D 10_0"/>
+            <nad:busNode diagramId="15" equipmentId="D 66_0"/>
+            <nad:busNode diagramId="17" equipmentId="E 10_0"/>
+            <nad:busNode diagramId="19" equipmentId="F 10_0"/>
+            <nad:busNode diagramId="21" equipmentId="G 10_0"/>
+            <nad:busNode diagramId="23" equipmentId="H 10_0"/>
+            <nad:busNode diagramId="25" equipmentId="I 10_0"/>
+            <nad:busNode diagramId="27" equipmentId="J 10_0"/>
+            <nad:busNode diagramId="29" equipmentId="K 10_0"/>
+        </nad:busNodes>
+        <nad:nodes>
+            <nad:node diagramId="0" equipmentId="A 230"/>
+            <nad:node diagramId="2" equipmentId="A 400"/>
+            <nad:node diagramId="4" equipmentId="B 230"/>
+            <nad:node diagramId="6" equipmentId="C 20"/>
+            <nad:node diagramId="8" equipmentId="C 230"/>
+            <nad:node diagramId="10" equipmentId="C 66"/>
+            <nad:node diagramId="12" equipmentId="D 10"/>
+            <nad:node diagramId="14" equipmentId="D 66"/>
+            <nad:node diagramId="16" equipmentId="E 10"/>
+            <nad:node diagramId="18" equipmentId="F 10"/>
+            <nad:node diagramId="20" equipmentId="G 10"/>
+            <nad:node diagramId="22" equipmentId="H 10"/>
+            <nad:node diagramId="24" equipmentId="I 10"/>
+            <nad:node diagramId="26" equipmentId="J 10"/>
+            <nad:node diagramId="28" equipmentId="K 10"/>
+        </nad:nodes>
+        <nad:edges>
+            <nad:edge diagramId="30" equipmentId="A - B"/>
+            <nad:edge diagramId="31" equipmentId="A 400 230"/>
+            <nad:edge diagramId="32" equipmentId="B - C"/>
+            <nad:edge diagramId="33" equipmentId="C 66 20"/>
+            <nad:edge diagramId="34" equipmentId="C 230 66"/>
+            <nad:edge diagramId="35" equipmentId="C - D"/>
+            <nad:edge diagramId="36" equipmentId="D - E"/>
+            <nad:edge diagramId="37" equipmentId="H - D"/>
+            <nad:edge diagramId="38" equipmentId="K - D"/>
+            <nad:edge diagramId="39" equipmentId="D 66 10"/>
+            <nad:edge diagramId="40" equipmentId="E - F"/>
+            <nad:edge diagramId="41" equipmentId="F - G"/>
+            <nad:edge diagramId="42" equipmentId="F - I"/>
+            <nad:edge diagramId="43" equipmentId="G - H"/>
+            <nad:edge diagramId="44" equipmentId="I - J"/>
+            <nad:edge diagramId="45" equipmentId="J - K"/>
+        </nad:edges>
+    </metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-10.80,3.34)" id="0" class="nad-vl180to300">
+            <circle r="0.27" id="1"/>
+        </g>
+        <g transform="translate(-14.01,1.10)" id="2" class="nad-vl300to500">
+            <circle r="0.27" id="3"/>
+        </g>
+        <g transform="translate(-6.53,4.50)" id="4" class="nad-vl180to300">
+            <circle r="0.27" id="5"/>
+        </g>
+        <g transform="translate(10.71,-3.58)" id="6" class="nad-vl0to30">
+            <circle r="0.27" id="7"/>
+        </g>
+        <g transform="translate(-1.33,3.62)" id="8" class="nad-vl180to300">
+            <circle r="0.27" id="9"/>
+        </g>
+        <g transform="translate(6.97,-0.45)" id="10" class="nad-vl50to70">
+            <circle r="0.27" id="11"/>
+        </g>
+        <g transform="translate(3.95,0.19)" id="12" class="nad-vl0to30">
+            <circle r="0.27" id="13"/>
+        </g>
+        <g transform="translate(8.90,1.97)" id="14" class="nad-vl50to70">
+            <circle r="0.27" id="15"/>
+        </g>
+        <g transform="translate(3.88,-4.80)" id="16" class="nad-vl0to30">
+            <circle r="0.27" id="17"/>
+        </g>
+        <g transform="translate(0.27,-5.28)" id="18" class="nad-vl0to30">
+            <circle r="0.27" id="19"/>
+        </g>
+        <g transform="translate(-3.53,-6.28)" id="20" class="nad-vl0to30">
+            <circle r="0.27" id="21"/>
+        </g>
+        <g transform="translate(-2.02,-2.56)" id="22" class="nad-vl0to30">
+            <circle r="0.27" id="23"/>
+        </g>
+        <g transform="translate(0.37,0.46)" id="24" class="nad-vl0to30">
+            <circle r="0.27" id="25"/>
+        </g>
+        <g transform="translate(1.97,5.89)" id="26" class="nad-vl0to30">
+            <circle r="0.27" id="27"/>
+        </g>
+        <g transform="translate(5.31,5.41)" id="28" class="nad-vl0to30">
+            <circle r="0.27" id="29"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="30">
+            <g class="nad-vl180to300">
+                <polyline points="-10.55,3.40 -8.66,3.92"/>
+                <g class="nad-edge-infos" transform="translate(-10.24,3.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(105.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.22)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(105.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(15.22)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-6.77,4.43 -8.66,3.92"/>
+                <g class="nad-edge-infos" transform="translate(-7.09,4.35)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-74.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-344.78)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-74.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-344.78)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <g class="nad-vl300to500">
+                <polyline points="-13.80,1.25 -12.65,2.05"/>
+                <g class="nad-edge-infos" transform="translate(-13.53,1.43)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(124.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.88)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(124.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(34.88)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="-12.48" cy="2.16" r="0.20"/>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-11.01,3.19 -12.16,2.39"/>
+                <g class="nad-edge-infos" transform="translate(-11.28,3.01)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-55.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-325.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-55.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-325.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="-12.32" cy="2.28" r="0.20"/>
+            </g>
+        </g>
+        <g id="32">
+            <g class="nad-vl180to300">
+                <polyline points="-6.28,4.46 -3.93,4.06"/>
+                <g class="nad-edge-infos" transform="translate(-5.96,4.40)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(80.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-9.61)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(80.39)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-9.61)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-1.58,3.66 -3.93,4.06"/>
+                <g class="nad-edge-infos" transform="translate(-1.90,3.72)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-99.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-9.61)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-99.61)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-9.61)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g class="nad-vl50to70">
+                <polyline points="7.16,-0.61 8.61,-1.82"/>
+                <g class="nad-edge-infos" transform="translate(7.41,-0.82)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(50.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.82)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(50.18)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.82)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="8.76" cy="-1.95" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="10.52,-3.41 9.07,-2.20"/>
+                <g class="nad-edge-infos" transform="translate(10.27,-3.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-129.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.82)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-129.82)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-39.82)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="8.92" cy="-2.08" r="0.20"/>
+            </g>
+        </g>
+        <g id="34">
+            <g class="nad-vl180to300">
+                <polyline points="-1.10,3.51 2.55,1.72"/>
+                <g class="nad-edge-infos" transform="translate(-0.81,3.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(63.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.12)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(63.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.12)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="2.73" cy="1.63" r="0.20"/>
+            </g>
+            <g class="nad-vl50to70">
+                <polyline points="6.74,-0.34 3.09,1.45"/>
+                <g class="nad-edge-infos" transform="translate(6.44,-0.19)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-116.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-116.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-26.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="2.91" cy="1.54" r="0.20"/>
+            </g>
+        </g>
+        <g id="35">
+            <g class="nad-vl50to70">
+                <polyline points="7.13,-0.25 7.93,0.76"/>
+                <g class="nad-edge-infos" transform="translate(7.33,0.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(141.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(51.33)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(141.33)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(51.33)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl50to70">
+                <polyline points="8.74,1.77 7.93,0.76"/>
+                <g class="nad-edge-infos" transform="translate(8.54,1.51)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-38.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-308.67)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-38.67)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-308.67)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <g class="nad-vl0to30">
+                <polyline points="3.94,-0.07 3.92,-2.31"/>
+                <g class="nad-edge-infos" transform="translate(3.94,-0.39)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-0.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-270.72)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-0.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-270.72)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="3.89,-4.55 3.92,-2.31"/>
+                <g class="nad-edge-infos" transform="translate(3.89,-4.22)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(179.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.28)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(179.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.28)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="37">
+            <g class="nad-vl0to30">
+                <polyline points="-1.79,-2.45 0.96,-1.19"/>
+                <g class="nad-edge-infos" transform="translate(-1.49,-2.31)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(114.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.68)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(114.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(24.68)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="3.72,0.08 0.96,-1.19"/>
+                <g class="nad-edge-infos" transform="translate(3.42,-0.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-65.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-335.32)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-65.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-335.32)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="38">
+            <g class="nad-vl0to30">
+                <polyline points="5.25,5.16 4.63,2.80"/>
+                <g class="nad-edge-infos" transform="translate(5.16,4.85)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-14.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-284.64)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-14.64)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-284.64)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="4.01,0.43 4.63,2.80"/>
+                <g class="nad-edge-infos" transform="translate(4.09,0.75)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(165.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.36)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(165.36)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.36)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="39">
+            <g class="nad-vl50to70">
+                <polyline points="8.66,1.88 6.71,1.18"/>
+                <g class="nad-edge-infos" transform="translate(8.35,1.77)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-70.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-340.22)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-70.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-340.22)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="6.52" cy="1.11" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="4.19,0.27 6.14,0.97"/>
+                <g class="nad-edge-infos" transform="translate(4.49,0.38)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(109.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.78)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(109.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(19.78)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="6.33" cy="1.04" r="0.20"/>
+            </g>
+        </g>
+        <g id="40">
+            <g class="nad-vl0to30">
+                <polyline points="3.63,-4.84 2.08,-5.04"/>
+                <g class="nad-edge-infos" transform="translate(3.31,-4.88)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-82.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-352.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-82.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-352.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="0.52,-5.24 2.08,-5.04"/>
+                <g class="nad-edge-infos" transform="translate(0.85,-5.20)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(97.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.43)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(97.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(7.43)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="41">
+            <g class="nad-vl0to30">
+                <polyline points="0.02,-5.34 -1.63,-5.78"/>
+                <g class="nad-edge-infos" transform="translate(-0.29,-5.42)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-75.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-345.26)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-75.26)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-345.26)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-3.29,-6.21 -1.63,-5.78"/>
+                <g class="nad-edge-infos" transform="translate(-2.97,-6.13)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(104.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.74)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(104.74)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(14.74)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="42">
+            <g class="nad-vl0to30">
+                <polyline points="0.28,-5.02 0.32,-2.41"/>
+                <g class="nad-edge-infos" transform="translate(0.28,-4.70)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(179.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(179.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(89.01)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="0.37,0.21 0.32,-2.41"/>
+                <g class="nad-edge-infos" transform="translate(0.36,-0.12)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-0.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-270.99)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-0.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-270.99)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="43">
+            <g class="nad-vl0to30">
+                <polyline points="-3.44,-6.04 -2.78,-4.42"/>
+                <g class="nad-edge-infos" transform="translate(-3.31,-5.74)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(157.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.88)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(157.88)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(67.88)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-2.12,-2.79 -2.78,-4.42"/>
+                <g class="nad-edge-infos" transform="translate(-2.24,-3.09)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-22.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-292.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-22.12)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-292.12)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="44">
+            <g class="nad-vl0to30">
+                <polyline points="0.44,0.71 1.17,3.18"/>
+                <g class="nad-edge-infos" transform="translate(0.53,1.02)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(163.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.56)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(163.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(73.56)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="1.90,5.65 1.17,3.18"/>
+                <g class="nad-edge-infos" transform="translate(1.81,5.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-16.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-286.44)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-16.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-286.44)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="45">
+            <g class="nad-vl0to30">
+                <polyline points="2.22,5.85 3.64,5.65"/>
+                <g class="nad-edge-infos" transform="translate(2.55,5.81)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(81.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.20)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(81.80)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.20)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="5.06,5.45 3.64,5.65"/>
+                <g class="nad-edge-infos" transform="translate(4.74,5.49)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-98.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.20)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-98.20)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-8.20)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_edge" points="-10.50,3.34 -9.80,3.34"/>
+        <polyline id="2_edge" points="-13.71,1.10 -13.01,1.10"/>
+        <polyline id="4_edge" points="-6.23,4.50 -5.53,4.50"/>
+        <polyline id="6_edge" points="11.01,-3.58 11.71,-3.58"/>
+        <polyline id="8_edge" points="-1.03,3.62 -0.33,3.62"/>
+        <polyline id="10_edge" points="7.27,-0.45 7.97,-0.45"/>
+        <polyline id="12_edge" points="4.25,0.19 4.95,0.19"/>
+        <polyline id="14_edge" points="9.20,1.97 9.90,1.97"/>
+        <polyline id="16_edge" points="4.18,-4.80 4.88,-4.80"/>
+        <polyline id="18_edge" points="0.57,-5.28 1.27,-5.28"/>
+        <polyline id="20_edge" points="-3.23,-6.28 -2.53,-6.28"/>
+        <polyline id="22_edge" points="-1.72,-2.56 -1.02,-2.56"/>
+        <polyline id="24_edge" points="0.67,0.46 1.37,0.46"/>
+        <polyline id="26_edge" points="2.27,5.89 2.97,5.89"/>
+        <polyline id="28_edge" points="5.61,5.41 6.31,5.41"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" y="3.34" x="-9.80">A 230</text>
+        <text filter="url(#textBgFilter)" y="1.10" x="-13.01">A 400</text>
+        <text filter="url(#textBgFilter)" y="4.50" x="-5.53">B 230</text>
+        <text filter="url(#textBgFilter)" y="-3.58" x="11.71">C 20</text>
+        <text filter="url(#textBgFilter)" y="3.62" x="-0.33">C 230</text>
+        <text filter="url(#textBgFilter)" y="-0.45" x="7.97">C 66</text>
+        <text filter="url(#textBgFilter)" y="0.19" x="4.95">D 10</text>
+        <text filter="url(#textBgFilter)" y="1.97" x="9.90">D 66</text>
+        <text filter="url(#textBgFilter)" y="-4.80" x="4.88">E 10</text>
+        <text filter="url(#textBgFilter)" y="-5.28" x="1.27">F 10</text>
+        <text filter="url(#textBgFilter)" y="-6.28" x="-2.53">G 10</text>
+        <text filter="url(#textBgFilter)" y="-2.56" x="-1.02">H 10</text>
+        <text filter="url(#textBgFilter)" y="0.46" x="1.37">I 10</text>
+        <text filter="url(#textBgFilter)" y="5.89" x="2.97">J 10</text>
+        <text filter="url(#textBgFilter)" y="5.41" x="6.31">K 10</text>
+    </g>
+</svg>

--- a/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="-22.04 -11.17 39.78 20.63" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="-22.27 -10.89 40.19 21.51" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
 .nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
 .nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
@@ -106,734 +106,734 @@
         </filter>
     </defs>
     <g class="nad-vl-nodes">
-        <g transform="translate(-17.30,2.22)" id="0" class="nad-vl180to300">
+        <g transform="translate(-17.87,2.92)" id="0" class="nad-vl180to300">
             <circle r="0.27" id="1"/>
         </g>
-        <g transform="translate(-20.04,-0.66)" id="2" class="nad-vl300to500">
+        <g transform="translate(-20.27,-0.33)" id="2" class="nad-vl300to500">
             <circle r="0.27" id="3"/>
         </g>
-        <g transform="translate(-13.84,5.33)" id="4" class="nad-vl180to300">
+        <g transform="translate(-14.51,6.35)" id="4" class="nad-vl180to300">
             <circle r="0.27" id="5"/>
         </g>
-        <g transform="translate(-5.17,2.49)" id="6" class="nad-vl0to30">
+        <g transform="translate(-5.56,3.62)" id="6" class="nad-vl0to30">
             <circle r="0.27" id="7"/>
         </g>
-        <g transform="translate(-9.46,7.46)" id="8" class="nad-vl180to300">
+        <g transform="translate(-10.05,8.63)" id="8" class="nad-vl180to300">
             <circle r="0.27" id="9"/>
         </g>
-        <g transform="translate(-4.14,6.45)" id="10" class="nad-vl50to70">
+        <g transform="translate(-4.54,7.60)" id="10" class="nad-vl50to70">
             <circle r="0.27" id="11"/>
         </g>
-        <g transform="translate(5.25,0.47)" id="12" class="nad-vl0to30">
+        <g transform="translate(5.05,1.18)" id="12" class="nad-vl0to30">
             <circle r="0.27" id="13"/>
         </g>
-        <g transform="translate(1.41,5.25)" id="14" class="nad-vl50to70">
+        <g transform="translate(1.12,6.12)" id="14" class="nad-vl50to70">
             <circle r="0.27" id="15"/>
         </g>
-        <g transform="translate(7.18,-4.22)" id="16" class="nad-vl0to30">
+        <g transform="translate(7.17,-3.63)" id="16" class="nad-vl0to30">
             <circle r="0.27" id="17"/>
         </g>
-        <g transform="translate(7.92,-9.05)" id="18" class="nad-vl0to30">
+        <g transform="translate(8.19,-8.58)" id="18" class="nad-vl0to30">
             <circle r="0.27" id="19"/>
         </g>
-        <g transform="translate(2.55,-9.17)" id="20" class="nad-vl0to30">
+        <g transform="translate(2.68,-8.89)" id="20" class="nad-vl0to30">
             <circle r="0.27" id="21"/>
         </g>
-        <g transform="translate(1.24,-4.36)" id="22" class="nad-vl0to30">
+        <g transform="translate(1.11,-3.98)" id="22" class="nad-vl0to30">
             <circle r="0.27" id="23"/>
         </g>
-        <g transform="translate(13.23,-7.87)" id="24" class="nad-vl0to30">
+        <g transform="translate(13.59,-7.07)" id="24" class="nad-vl0to30">
             <circle r="0.27" id="25"/>
         </g>
-        <g transform="translate(14.75,-2.98)" id="26" class="nad-vl0to30">
+        <g transform="translate(14.92,-1.98)" id="26" class="nad-vl0to30">
             <circle r="0.27" id="27"/>
         </g>
-        <g transform="translate(11.45,1.03)" id="28" class="nad-vl0to30">
+        <g transform="translate(11.37,1.97)" id="28" class="nad-vl0to30">
             <circle r="0.27" id="29"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="30">
             <g class="nad-vl180to300">
-                <polyline points="-17.11,2.39 -15.57,3.78"/>
-                <g class="nad-edge-infos" transform="translate(-16.87,2.61)">
+                <polyline points="-17.69,3.10 -16.19,4.63"/>
+                <g class="nad-edge-infos" transform="translate(-17.46,3.33)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(131.96)">
+                        <g transform="rotate(135.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.96)" x="0.19">0</text>
+                        <text transform="rotate(45.65)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(131.96)">
+                        <g transform="rotate(135.65)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(41.96)" x="0.19">0</text>
+                        <text transform="rotate(45.65)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-14.03,5.16 -15.57,3.78"/>
-                <g class="nad-edge-infos" transform="translate(-14.27,4.94)">
+                <polyline points="-14.69,6.16 -16.19,4.63"/>
+                <g class="nad-edge-infos" transform="translate(-14.92,5.93)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-48.04)">
+                        <g transform="rotate(-44.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-318.04)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-314.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-48.04)">
+                        <g transform="rotate(-44.35)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-318.04)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-314.35)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="31">
             <g class="nad-vl300to500">
-                <polyline points="-19.86,-0.47 -18.87,0.56"/>
-                <g class="nad-edge-infos" transform="translate(-19.64,-0.24)">
+                <polyline points="-20.12,-0.13 -19.25,1.05"/>
+                <g class="nad-edge-infos" transform="translate(-19.92,0.13)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(136.43)">
+                        <g transform="rotate(143.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.43)" x="0.19">0</text>
+                        <text transform="rotate(53.55)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(136.43)">
+                        <g transform="rotate(143.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(46.43)" x="0.19">0</text>
+                        <text transform="rotate(53.55)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="-18.74" cy="0.71" r="0.20"/>
+                <circle cx="-19.13" cy="1.21" r="0.20"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-17.47,2.04 -18.46,1.00"/>
-                <g class="nad-edge-infos" transform="translate(-17.70,1.80)">
+                <polyline points="-18.02,2.71 -18.89,1.53"/>
+                <g class="nad-edge-infos" transform="translate(-18.21,2.45)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-43.57)">
+                        <g transform="rotate(-36.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-313.57)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-306.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-43.57)">
+                        <g transform="rotate(-36.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-313.57)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-306.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-18.60" cy="0.85" r="0.20"/>
+                <circle cx="-19.01" cy="1.37" r="0.20"/>
             </g>
         </g>
         <g id="32">
             <g class="nad-vl180to300">
-                <polyline points="-13.61,5.44 -11.65,6.40"/>
-                <g class="nad-edge-infos" transform="translate(-13.32,5.59)">
+                <polyline points="-14.29,6.46 -12.28,7.49"/>
+                <g class="nad-edge-infos" transform="translate(-14.00,6.61)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(115.99)">
+                        <g transform="rotate(117.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.99)" x="0.19">0</text>
+                        <text transform="rotate(27.02)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(115.99)">
+                        <g transform="rotate(117.02)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(25.99)" x="0.19">0</text>
+                        <text transform="rotate(27.02)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-9.69,7.35 -11.65,6.40"/>
-                <g class="nad-edge-infos" transform="translate(-9.98,7.21)">
+                <polyline points="-10.27,8.51 -12.28,7.49"/>
+                <g class="nad-edge-infos" transform="translate(-10.56,8.36)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-64.01)">
+                        <g transform="rotate(-62.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-334.01)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-332.98)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-64.01)">
+                        <g transform="rotate(-62.98)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-334.01)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-332.98)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="33">
             <g class="nad-vl50to70">
-                <polyline points="-4.20,6.21 -4.58,4.76"/>
-                <g class="nad-edge-infos" transform="translate(-4.28,5.89)">
+                <polyline points="-4.61,7.35 -4.98,5.90"/>
+                <g class="nad-edge-infos" transform="translate(-4.69,7.04)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-14.56)">
+                        <g transform="rotate(-14.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-284.56)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-284.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-14.56)">
+                        <g transform="rotate(-14.41)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-284.56)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-284.41)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-4.63" cy="4.57" r="0.20"/>
+                <circle cx="-5.03" cy="5.71" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-5.10,2.74 -4.73,4.18"/>
-                <g class="nad-edge-infos" transform="translate(-5.02,3.05)">
+                <polyline points="-5.50,3.87 -5.13,5.32"/>
+                <g class="nad-edge-infos" transform="translate(-5.42,4.18)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(165.44)">
+                        <g transform="rotate(165.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.44)" x="0.19">0</text>
+                        <text transform="rotate(75.59)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(165.44)">
+                        <g transform="rotate(165.59)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(75.44)" x="0.19">0</text>
+                        <text transform="rotate(75.59)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="-4.68" cy="4.38" r="0.20"/>
+                <circle cx="-5.08" cy="5.51" r="0.20"/>
             </g>
         </g>
         <g id="34">
             <g class="nad-vl180to300">
-                <polyline points="-9.21,7.42 -7.10,7.01"/>
-                <g class="nad-edge-infos" transform="translate(-8.89,7.36)">
+                <polyline points="-9.80,8.58 -7.59,8.17"/>
+                <g class="nad-edge-infos" transform="translate(-9.48,8.52)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(79.25)">
+                        <g transform="rotate(79.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.75)" x="0.19">0</text>
+                        <text transform="rotate(-10.58)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(79.25)">
+                        <g transform="rotate(79.42)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.75)" x="0.19">0</text>
+                        <text transform="rotate(-10.58)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="-6.90" cy="6.98" r="0.20"/>
+                <circle cx="-7.39" cy="8.13" r="0.20"/>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="-4.39,6.50 -6.51,6.90"/>
-                <g class="nad-edge-infos" transform="translate(-4.71,6.56)">
+                <polyline points="-4.79,7.64 -7.00,8.06"/>
+                <g class="nad-edge-infos" transform="translate(-5.11,7.70)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-100.75)">
+                        <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.75)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-10.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-100.75)">
+                        <g transform="rotate(-100.58)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-10.75)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-10.58)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-6.70" cy="6.94" r="0.20"/>
+                <circle cx="-7.20" cy="8.09" r="0.20"/>
             </g>
         </g>
         <g id="35">
             <g class="nad-vl50to70">
-                <polyline points="-3.89,6.40 -1.36,5.85"/>
-                <g class="nad-edge-infos" transform="translate(-3.57,6.33)">
+                <polyline points="-4.30,7.53 -1.71,6.86"/>
+                <g class="nad-edge-infos" transform="translate(-3.98,7.45)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(77.75)">
+                        <g transform="rotate(75.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.25)" x="0.19">0</text>
+                        <text transform="rotate(-14.64)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(77.75)">
+                        <g transform="rotate(75.36)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.25)" x="0.19">0</text>
+                        <text transform="rotate(-14.64)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="1.16,5.30 -1.36,5.85"/>
-                <g class="nad-edge-infos" transform="translate(0.84,5.37)">
+                <polyline points="0.88,6.18 -1.71,6.86"/>
+                <g class="nad-edge-infos" transform="translate(0.56,6.26)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-102.25)">
+                        <g transform="rotate(-104.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.25)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-14.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-102.25)">
+                        <g transform="rotate(-104.64)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-12.25)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-14.64)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="36">
             <g class="nad-vl0to30">
-                <polyline points="5.35,0.24 6.22,-1.87"/>
-                <g class="nad-edge-infos" transform="translate(5.47,-0.06)">
+                <polyline points="5.16,0.95 6.11,-1.22"/>
+                <g class="nad-edge-infos" transform="translate(5.29,0.65)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(22.32)">
+                        <g transform="rotate(23.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.68)" x="0.19">0</text>
+                        <text transform="rotate(-66.26)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(22.32)">
+                        <g transform="rotate(23.74)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.68)" x="0.19">0</text>
+                        <text transform="rotate(-66.26)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="7.08,-3.98 6.22,-1.87"/>
-                <g class="nad-edge-infos" transform="translate(6.96,-3.68)">
+                <polyline points="7.07,-3.40 6.11,-1.22"/>
+                <g class="nad-edge-infos" transform="translate(6.94,-3.10)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-157.68)">
+                        <g transform="rotate(-156.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.68)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-66.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-157.68)">
+                        <g transform="rotate(-156.26)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-67.68)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-66.26)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="37">
             <g class="nad-vl0to30">
-                <polyline points="1.41,-4.16 3.25,-1.94"/>
-                <g class="nad-edge-infos" transform="translate(1.61,-3.91)">
+                <polyline points="1.26,-3.78 3.08,-1.40"/>
+                <g class="nad-edge-infos" transform="translate(1.46,-3.52)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(140.30)">
+                        <g transform="rotate(142.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.30)" x="0.19">0</text>
+                        <text transform="rotate(52.63)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(140.30)">
+                        <g transform="rotate(142.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(50.30)" x="0.19">0</text>
+                        <text transform="rotate(52.63)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.09,0.28 3.25,-1.94"/>
-                <g class="nad-edge-infos" transform="translate(4.88,0.03)">
+                <polyline points="4.90,0.98 3.08,-1.40"/>
+                <g class="nad-edge-infos" transform="translate(4.70,0.72)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-39.70)">
+                        <g transform="rotate(-37.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-309.70)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-307.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-39.70)">
+                        <g transform="rotate(-37.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-309.70)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-307.37)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="38">
             <g class="nad-vl0to30">
-                <polyline points="11.20,1.00 8.35,0.75"/>
-                <g class="nad-edge-infos" transform="translate(10.87,0.98)">
+                <polyline points="11.12,1.93 8.21,1.58"/>
+                <g class="nad-edge-infos" transform="translate(10.80,1.89)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-84.89)">
+                        <g transform="rotate(-82.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-354.89)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-352.95)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-84.89)">
+                        <g transform="rotate(-82.95)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-354.89)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-352.95)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.51,0.50 8.35,0.75"/>
-                <g class="nad-edge-infos" transform="translate(5.83,0.52)">
+                <polyline points="5.31,1.22 8.21,1.58"/>
+                <g class="nad-edge-infos" transform="translate(5.63,1.26)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(95.11)">
+                        <g transform="rotate(97.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.11)" x="0.19">0</text>
+                        <text transform="rotate(7.05)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(95.11)">
+                        <g transform="rotate(97.05)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(5.11)" x="0.19">0</text>
+                        <text transform="rotate(7.05)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="39">
             <g class="nad-vl50to70">
-                <polyline points="1.57,5.05 3.14,3.09"/>
-                <g class="nad-edge-infos" transform="translate(1.77,4.80)">
+                <polyline points="1.28,5.92 2.90,3.89"/>
+                <g class="nad-edge-infos" transform="translate(1.49,5.66)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(38.83)">
+                        <g transform="rotate(38.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.17)" x="0.19">0</text>
+                        <text transform="rotate(-51.45)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(38.83)">
+                        <g transform="rotate(38.55)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.17)" x="0.19">0</text>
+                        <text transform="rotate(-51.45)" x="0.19">0</text>
                     </g>
                 </g>
-                <circle cx="3.27" cy="2.94" r="0.20"/>
+                <circle cx="3.03" cy="3.73" r="0.20"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="5.09,0.67 3.52,2.63"/>
-                <g class="nad-edge-infos" transform="translate(4.89,0.92)">
+                <polyline points="4.90,1.38 3.28,3.42"/>
+                <g class="nad-edge-infos" transform="translate(4.69,1.64)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-141.17)">
+                        <g transform="rotate(-141.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.17)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-51.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-141.17)">
+                        <g transform="rotate(-141.45)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-51.17)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-51.45)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="3.40" cy="2.78" r="0.20"/>
+                <circle cx="3.15" cy="3.57" r="0.20"/>
             </g>
         </g>
         <g id="40">
             <g class="nad-vl0to30">
-                <polyline points="7.22,-4.47 7.55,-6.64"/>
-                <g class="nad-edge-infos" transform="translate(7.27,-4.79)">
+                <polyline points="7.22,-3.88 7.68,-6.10"/>
+                <g class="nad-edge-infos" transform="translate(7.29,-4.20)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(8.72)">
+                        <g transform="rotate(11.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.28)" x="0.19">0</text>
+                        <text transform="rotate(-78.33)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(8.72)">
+                        <g transform="rotate(11.67)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.28)" x="0.19">0</text>
+                        <text transform="rotate(-78.33)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="7.88,-8.80 7.55,-6.64"/>
-                <g class="nad-edge-infos" transform="translate(7.83,-8.48)">
+                <polyline points="8.14,-8.33 7.68,-6.10"/>
+                <g class="nad-edge-infos" transform="translate(8.08,-8.01)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-171.28)">
+                        <g transform="rotate(-168.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.28)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-78.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-171.28)">
+                        <g transform="rotate(-168.33)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-81.28)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-78.33)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="41">
             <g class="nad-vl0to30">
-                <polyline points="7.67,-9.06 5.24,-9.11"/>
-                <g class="nad-edge-infos" transform="translate(7.34,-9.06)">
+                <polyline points="7.94,-8.59 5.44,-8.73"/>
+                <g class="nad-edge-infos" transform="translate(7.62,-8.61)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-88.77)">
+                        <g transform="rotate(-86.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-358.77)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-356.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-88.77)">
+                        <g transform="rotate(-86.78)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-358.77)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-356.78)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="2.81,-9.16 5.24,-9.11"/>
-                <g class="nad-edge-infos" transform="translate(3.13,-9.15)">
+                <polyline points="2.94,-8.87 5.44,-8.73"/>
+                <g class="nad-edge-infos" transform="translate(3.26,-8.85)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(91.23)">
+                        <g transform="rotate(93.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.19">0</text>
+                        <text transform="rotate(3.22)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(91.23)">
+                        <g transform="rotate(93.22)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(1.23)" x="0.19">0</text>
+                        <text transform="rotate(3.22)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="42">
             <g class="nad-vl0to30">
-                <polyline points="8.17,-9.00 10.58,-8.46"/>
-                <g class="nad-edge-infos" transform="translate(8.49,-8.93)">
+                <polyline points="8.44,-8.51 10.89,-7.82"/>
+                <g class="nad-edge-infos" transform="translate(8.75,-8.42)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(102.55)">
+                        <g transform="rotate(105.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.55)" x="0.19">0</text>
+                        <text transform="rotate(15.62)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(102.55)">
+                        <g transform="rotate(105.62)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(12.55)" x="0.19">0</text>
+                        <text transform="rotate(15.62)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="12.99,-7.92 10.58,-8.46"/>
-                <g class="nad-edge-infos" transform="translate(12.67,-8.00)">
+                <polyline points="13.35,-7.14 10.89,-7.82"/>
+                <g class="nad-edge-infos" transform="translate(13.03,-7.22)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-77.45)">
+                        <g transform="rotate(-74.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-347.45)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-344.38)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-77.45)">
+                        <g transform="rotate(-74.38)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-347.45)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-344.38)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="43">
             <g class="nad-vl0to30">
-                <polyline points="2.49,-8.92 1.90,-6.76"/>
-                <g class="nad-edge-infos" transform="translate(2.40,-8.61)">
+                <polyline points="2.61,-8.64 1.90,-6.43"/>
+                <g class="nad-edge-infos" transform="translate(2.51,-8.33)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-164.78)">
+                        <g transform="rotate(-162.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.78)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-72.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-164.78)">
+                        <g transform="rotate(-162.21)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.78)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-72.21)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1.31,-4.60 1.90,-6.76"/>
-                <g class="nad-edge-infos" transform="translate(1.40,-4.92)">
+                <polyline points="1.19,-4.22 1.90,-6.43"/>
+                <g class="nad-edge-infos" transform="translate(1.29,-4.53)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(15.22)">
+                        <g transform="rotate(17.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.78)" x="0.19">0</text>
+                        <text transform="rotate(-72.21)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(15.22)">
+                        <g transform="rotate(17.79)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-74.78)" x="0.19">0</text>
+                        <text transform="rotate(-72.21)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="44">
             <g class="nad-vl0to30">
-                <polyline points="13.31,-7.63 13.99,-5.42"/>
-                <g class="nad-edge-infos" transform="translate(13.41,-7.32)">
+                <polyline points="13.66,-6.82 14.25,-4.53"/>
+                <g class="nad-edge-infos" transform="translate(13.74,-6.51)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(162.83)">
+                        <g transform="rotate(165.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.83)" x="0.19">0</text>
+                        <text transform="rotate(75.37)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(162.83)">
+                        <g transform="rotate(165.37)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(72.83)" x="0.19">0</text>
+                        <text transform="rotate(75.37)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="14.67,-3.22 13.99,-5.42"/>
-                <g class="nad-edge-infos" transform="translate(14.58,-3.53)">
+                <polyline points="14.85,-2.23 14.25,-4.53"/>
+                <g class="nad-edge-infos" transform="translate(14.77,-2.54)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-17.17)">
+                        <g transform="rotate(-14.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-287.17)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-284.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-17.17)">
+                        <g transform="rotate(-14.63)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-287.17)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-284.63)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
         </g>
         <g id="45">
             <g class="nad-vl0to30">
-                <polyline points="14.58,-2.78 13.10,-0.97"/>
-                <g class="nad-edge-infos" transform="translate(14.38,-2.53)">
+                <polyline points="14.75,-1.79 13.15,-0.01"/>
+                <g class="nad-edge-infos" transform="translate(14.53,-1.55)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(-140.55)">
+                        <g transform="rotate(-138.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.55)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-48.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(-140.55)">
+                        <g transform="rotate(-138.07)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.55)" x="-0.19" style="text-anchor:end">0</text>
+                        <text transform="rotate(-48.07)" x="-0.19" style="text-anchor:end">0</text>
                     </g>
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="11.61,0.83 13.10,-0.97"/>
-                <g class="nad-edge-infos" transform="translate(11.82,0.58)">
+                <polyline points="11.54,1.78 13.15,-0.01"/>
+                <g class="nad-edge-infos" transform="translate(11.76,1.53)">
                     <g class="nad-active nad-state-out">
-                        <g transform="rotate(39.45)">
+                        <g transform="rotate(41.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.55)" x="0.19">0</text>
+                        <text transform="rotate(-48.07)" x="0.19">0</text>
                     </g>
                     <g class="nad-reactive nad-state-out">
-                        <g transform="rotate(39.45)">
+                        <g transform="rotate(41.93)">
                             <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
                             <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
                         </g>
-                        <text transform="rotate(-50.55)" x="0.19">0</text>
+                        <text transform="rotate(-48.07)" x="0.19">0</text>
                     </g>
                 </g>
             </g>
         </g>
     </g>
     <g class="nad-text-edges">
-        <polyline id="0_edge" points="-17.00,2.22 -16.30,2.22"/>
-        <polyline id="2_edge" points="-19.74,-0.66 -19.04,-0.66"/>
-        <polyline id="4_edge" points="-13.54,5.33 -12.84,5.33"/>
-        <polyline id="6_edge" points="-4.87,2.49 -4.17,2.49"/>
-        <polyline id="8_edge" points="-9.16,7.46 -8.46,7.46"/>
-        <polyline id="10_edge" points="-3.84,6.45 -3.14,6.45"/>
-        <polyline id="12_edge" points="5.55,0.47 6.25,0.47"/>
-        <polyline id="14_edge" points="1.71,5.25 2.41,5.25"/>
-        <polyline id="16_edge" points="7.48,-4.22 8.18,-4.22"/>
-        <polyline id="18_edge" points="8.22,-9.05 8.92,-9.05"/>
-        <polyline id="20_edge" points="2.85,-9.17 3.55,-9.17"/>
-        <polyline id="22_edge" points="1.54,-4.36 2.24,-4.36"/>
-        <polyline id="24_edge" points="13.53,-7.87 14.23,-7.87"/>
-        <polyline id="26_edge" points="15.05,-2.98 15.75,-2.98"/>
-        <polyline id="28_edge" points="11.75,1.03 12.45,1.03"/>
+        <polyline id="0_edge" points="-17.57,2.92 -16.87,2.92"/>
+        <polyline id="2_edge" points="-19.97,-0.33 -19.27,-0.33"/>
+        <polyline id="4_edge" points="-14.21,6.35 -13.51,6.35"/>
+        <polyline id="6_edge" points="-5.26,3.62 -4.56,3.62"/>
+        <polyline id="8_edge" points="-9.75,8.63 -9.05,8.63"/>
+        <polyline id="10_edge" points="-4.24,7.60 -3.54,7.60"/>
+        <polyline id="12_edge" points="5.35,1.18 6.05,1.18"/>
+        <polyline id="14_edge" points="1.42,6.12 2.12,6.12"/>
+        <polyline id="16_edge" points="7.47,-3.63 8.17,-3.63"/>
+        <polyline id="18_edge" points="8.49,-8.58 9.19,-8.58"/>
+        <polyline id="20_edge" points="2.98,-8.89 3.68,-8.89"/>
+        <polyline id="22_edge" points="1.41,-3.98 2.11,-3.98"/>
+        <polyline id="24_edge" points="13.89,-7.07 14.59,-7.07"/>
+        <polyline id="26_edge" points="15.22,-1.98 15.92,-1.98"/>
+        <polyline id="28_edge" points="11.67,1.97 12.37,1.97"/>
     </g>
     <g class="nad-text-nodes">
-        <text filter="url(#textBgFilter)" y="2.22" x="-16.30">A 230</text>
-        <text filter="url(#textBgFilter)" y="-0.66" x="-19.04">A 400</text>
-        <text filter="url(#textBgFilter)" y="5.33" x="-12.84">B 230</text>
-        <text filter="url(#textBgFilter)" y="2.49" x="-4.17">C 20</text>
-        <text filter="url(#textBgFilter)" y="7.46" x="-8.46">C 230</text>
-        <text filter="url(#textBgFilter)" y="6.45" x="-3.14">C 66</text>
-        <text filter="url(#textBgFilter)" y="0.47" x="6.25">D 10</text>
-        <text filter="url(#textBgFilter)" y="5.25" x="2.41">D 66</text>
-        <text filter="url(#textBgFilter)" y="-4.22" x="8.18">E 10</text>
-        <text filter="url(#textBgFilter)" y="-9.05" x="8.92">F 10</text>
-        <text filter="url(#textBgFilter)" y="-9.17" x="3.55">G 10</text>
-        <text filter="url(#textBgFilter)" y="-4.36" x="2.24">H 10</text>
-        <text filter="url(#textBgFilter)" y="-7.87" x="14.23">I 10</text>
-        <text filter="url(#textBgFilter)" y="-2.98" x="15.75">J 10</text>
-        <text filter="url(#textBgFilter)" y="1.03" x="12.45">K 10</text>
+        <text filter="url(#textBgFilter)" y="2.92" x="-16.87">A 230</text>
+        <text filter="url(#textBgFilter)" y="-0.33" x="-19.27">A 400</text>
+        <text filter="url(#textBgFilter)" y="6.35" x="-13.51">B 230</text>
+        <text filter="url(#textBgFilter)" y="3.62" x="-4.56">C 20</text>
+        <text filter="url(#textBgFilter)" y="8.63" x="-9.05">C 230</text>
+        <text filter="url(#textBgFilter)" y="7.60" x="-3.54">C 66</text>
+        <text filter="url(#textBgFilter)" y="1.18" x="6.05">D 10</text>
+        <text filter="url(#textBgFilter)" y="6.12" x="2.12">D 66</text>
+        <text filter="url(#textBgFilter)" y="-3.63" x="8.17">E 10</text>
+        <text filter="url(#textBgFilter)" y="-8.58" x="9.19">F 10</text>
+        <text filter="url(#textBgFilter)" y="-8.89" x="3.68">G 10</text>
+        <text filter="url(#textBgFilter)" y="-3.98" x="2.11">H 10</text>
+        <text filter="url(#textBgFilter)" y="-7.07" x="14.59">I 10</text>
+        <text filter="url(#textBgFilter)" y="-1.98" x="15.92">J 10</text>
+        <text filter="url(#textBgFilter)" y="1.97" x="12.37">K 10</text>
     </g>
 </svg>

--- a/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -1,0 +1,839 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="-22.04 -11.17 39.78 20.63" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black; dominant-baseline: central}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 0.05}
+  40% {stroke: #FFEB3B; stroke-width: 0.15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 0.15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 0.15}
+}
+]]></style>
+    <metadata xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+        <nad:busNodes>
+            <nad:busNode diagramId="1" equipmentId="A 230_0"/>
+            <nad:busNode diagramId="3" equipmentId="A 400_0"/>
+            <nad:busNode diagramId="5" equipmentId="B 230_0"/>
+            <nad:busNode diagramId="7" equipmentId="C 20_0"/>
+            <nad:busNode diagramId="9" equipmentId="C 230_0"/>
+            <nad:busNode diagramId="11" equipmentId="C 66_0"/>
+            <nad:busNode diagramId="13" equipmentId="D 10_0"/>
+            <nad:busNode diagramId="15" equipmentId="D 66_0"/>
+            <nad:busNode diagramId="17" equipmentId="E 10_0"/>
+            <nad:busNode diagramId="19" equipmentId="F 10_0"/>
+            <nad:busNode diagramId="21" equipmentId="G 10_0"/>
+            <nad:busNode diagramId="23" equipmentId="H 10_0"/>
+            <nad:busNode diagramId="25" equipmentId="I 10_0"/>
+            <nad:busNode diagramId="27" equipmentId="J 10_0"/>
+            <nad:busNode diagramId="29" equipmentId="K 10_0"/>
+        </nad:busNodes>
+        <nad:nodes>
+            <nad:node diagramId="0" equipmentId="A 230"/>
+            <nad:node diagramId="2" equipmentId="A 400"/>
+            <nad:node diagramId="4" equipmentId="B 230"/>
+            <nad:node diagramId="6" equipmentId="C 20"/>
+            <nad:node diagramId="8" equipmentId="C 230"/>
+            <nad:node diagramId="10" equipmentId="C 66"/>
+            <nad:node diagramId="12" equipmentId="D 10"/>
+            <nad:node diagramId="14" equipmentId="D 66"/>
+            <nad:node diagramId="16" equipmentId="E 10"/>
+            <nad:node diagramId="18" equipmentId="F 10"/>
+            <nad:node diagramId="20" equipmentId="G 10"/>
+            <nad:node diagramId="22" equipmentId="H 10"/>
+            <nad:node diagramId="24" equipmentId="I 10"/>
+            <nad:node diagramId="26" equipmentId="J 10"/>
+            <nad:node diagramId="28" equipmentId="K 10"/>
+        </nad:nodes>
+        <nad:edges>
+            <nad:edge diagramId="30" equipmentId="A - B"/>
+            <nad:edge diagramId="31" equipmentId="A 400 230"/>
+            <nad:edge diagramId="32" equipmentId="B - C"/>
+            <nad:edge diagramId="33" equipmentId="C 66 20"/>
+            <nad:edge diagramId="34" equipmentId="C 230 66"/>
+            <nad:edge diagramId="35" equipmentId="C - D"/>
+            <nad:edge diagramId="36" equipmentId="D - E"/>
+            <nad:edge diagramId="37" equipmentId="H - D"/>
+            <nad:edge diagramId="38" equipmentId="K - D"/>
+            <nad:edge diagramId="39" equipmentId="D 66 10"/>
+            <nad:edge diagramId="40" equipmentId="E - F"/>
+            <nad:edge diagramId="41" equipmentId="F - G"/>
+            <nad:edge diagramId="42" equipmentId="F - I"/>
+            <nad:edge diagramId="43" equipmentId="G - H"/>
+            <nad:edge diagramId="44" equipmentId="I - J"/>
+            <nad:edge diagramId="45" equipmentId="J - K"/>
+        </nad:edges>
+    </metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(-17.30,2.22)" id="0" class="nad-vl180to300">
+            <circle r="0.27" id="1"/>
+        </g>
+        <g transform="translate(-20.04,-0.66)" id="2" class="nad-vl300to500">
+            <circle r="0.27" id="3"/>
+        </g>
+        <g transform="translate(-13.84,5.33)" id="4" class="nad-vl180to300">
+            <circle r="0.27" id="5"/>
+        </g>
+        <g transform="translate(-5.17,2.49)" id="6" class="nad-vl0to30">
+            <circle r="0.27" id="7"/>
+        </g>
+        <g transform="translate(-9.46,7.46)" id="8" class="nad-vl180to300">
+            <circle r="0.27" id="9"/>
+        </g>
+        <g transform="translate(-4.14,6.45)" id="10" class="nad-vl50to70">
+            <circle r="0.27" id="11"/>
+        </g>
+        <g transform="translate(5.25,0.47)" id="12" class="nad-vl0to30">
+            <circle r="0.27" id="13"/>
+        </g>
+        <g transform="translate(1.41,5.25)" id="14" class="nad-vl50to70">
+            <circle r="0.27" id="15"/>
+        </g>
+        <g transform="translate(7.18,-4.22)" id="16" class="nad-vl0to30">
+            <circle r="0.27" id="17"/>
+        </g>
+        <g transform="translate(7.92,-9.05)" id="18" class="nad-vl0to30">
+            <circle r="0.27" id="19"/>
+        </g>
+        <g transform="translate(2.55,-9.17)" id="20" class="nad-vl0to30">
+            <circle r="0.27" id="21"/>
+        </g>
+        <g transform="translate(1.24,-4.36)" id="22" class="nad-vl0to30">
+            <circle r="0.27" id="23"/>
+        </g>
+        <g transform="translate(13.23,-7.87)" id="24" class="nad-vl0to30">
+            <circle r="0.27" id="25"/>
+        </g>
+        <g transform="translate(14.75,-2.98)" id="26" class="nad-vl0to30">
+            <circle r="0.27" id="27"/>
+        </g>
+        <g transform="translate(11.45,1.03)" id="28" class="nad-vl0to30">
+            <circle r="0.27" id="29"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="30">
+            <g class="nad-vl180to300">
+                <polyline points="-17.11,2.39 -15.57,3.78"/>
+                <g class="nad-edge-infos" transform="translate(-16.87,2.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(131.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.96)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(131.96)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(41.96)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-14.03,5.16 -15.57,3.78"/>
+                <g class="nad-edge-infos" transform="translate(-14.27,4.94)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-48.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-318.04)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-48.04)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-318.04)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="31">
+            <g class="nad-vl300to500">
+                <polyline points="-19.86,-0.47 -18.87,0.56"/>
+                <g class="nad-edge-infos" transform="translate(-19.64,-0.24)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(136.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.43)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(136.43)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(46.43)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="-18.74" cy="0.71" r="0.20"/>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-17.47,2.04 -18.46,1.00"/>
+                <g class="nad-edge-infos" transform="translate(-17.70,1.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-43.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-313.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-43.57)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-313.57)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="-18.60" cy="0.85" r="0.20"/>
+            </g>
+        </g>
+        <g id="32">
+            <g class="nad-vl180to300">
+                <polyline points="-13.61,5.44 -11.65,6.40"/>
+                <g class="nad-edge-infos" transform="translate(-13.32,5.59)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(115.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.99)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(115.99)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(25.99)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl180to300">
+                <polyline points="-9.69,7.35 -11.65,6.40"/>
+                <g class="nad-edge-infos" transform="translate(-9.98,7.21)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-64.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-334.01)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-64.01)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-334.01)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="33">
+            <g class="nad-vl50to70">
+                <polyline points="-4.20,6.21 -4.58,4.76"/>
+                <g class="nad-edge-infos" transform="translate(-4.28,5.89)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-14.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-284.56)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-14.56)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-284.56)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="-4.63" cy="4.57" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="-5.10,2.74 -4.73,4.18"/>
+                <g class="nad-edge-infos" transform="translate(-5.02,3.05)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(165.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.44)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(165.44)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(75.44)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="-4.68" cy="4.38" r="0.20"/>
+            </g>
+        </g>
+        <g id="34">
+            <g class="nad-vl180to300">
+                <polyline points="-9.21,7.42 -7.10,7.01"/>
+                <g class="nad-edge-infos" transform="translate(-8.89,7.36)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(79.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.75)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(79.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.75)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="-6.90" cy="6.98" r="0.20"/>
+            </g>
+            <g class="nad-vl50to70">
+                <polyline points="-4.39,6.50 -6.51,6.90"/>
+                <g class="nad-edge-infos" transform="translate(-4.71,6.56)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-100.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.75)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-100.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-10.75)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="-6.70" cy="6.94" r="0.20"/>
+            </g>
+        </g>
+        <g id="35">
+            <g class="nad-vl50to70">
+                <polyline points="-3.89,6.40 -1.36,5.85"/>
+                <g class="nad-edge-infos" transform="translate(-3.57,6.33)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(77.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.25)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(77.75)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.25)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl50to70">
+                <polyline points="1.16,5.30 -1.36,5.85"/>
+                <g class="nad-edge-infos" transform="translate(0.84,5.37)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-102.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.25)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-102.25)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-12.25)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="36">
+            <g class="nad-vl0to30">
+                <polyline points="5.35,0.24 6.22,-1.87"/>
+                <g class="nad-edge-infos" transform="translate(5.47,-0.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(22.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.68)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(22.32)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.68)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="7.08,-3.98 6.22,-1.87"/>
+                <g class="nad-edge-infos" transform="translate(6.96,-3.68)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-157.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.68)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-157.68)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-67.68)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="37">
+            <g class="nad-vl0to30">
+                <polyline points="1.41,-4.16 3.25,-1.94"/>
+                <g class="nad-edge-infos" transform="translate(1.61,-3.91)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(140.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.30)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(140.30)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(50.30)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="5.09,0.28 3.25,-1.94"/>
+                <g class="nad-edge-infos" transform="translate(4.88,0.03)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-39.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-309.70)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-39.70)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-309.70)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="38">
+            <g class="nad-vl0to30">
+                <polyline points="11.20,1.00 8.35,0.75"/>
+                <g class="nad-edge-infos" transform="translate(10.87,0.98)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-84.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-354.89)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-84.89)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-354.89)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="5.51,0.50 8.35,0.75"/>
+                <g class="nad-edge-infos" transform="translate(5.83,0.52)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(95.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(95.11)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(5.11)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="39">
+            <g class="nad-vl50to70">
+                <polyline points="1.57,5.05 3.14,3.09"/>
+                <g class="nad-edge-infos" transform="translate(1.77,4.80)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(38.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-51.17)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(38.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-51.17)" x="0.19">0</text>
+                    </g>
+                </g>
+                <circle cx="3.27" cy="2.94" r="0.20"/>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="5.09,0.67 3.52,2.63"/>
+                <g class="nad-edge-infos" transform="translate(4.89,0.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-141.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-51.17)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-141.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-51.17)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+                <circle cx="3.40" cy="2.78" r="0.20"/>
+            </g>
+        </g>
+        <g id="40">
+            <g class="nad-vl0to30">
+                <polyline points="7.22,-4.47 7.55,-6.64"/>
+                <g class="nad-edge-infos" transform="translate(7.27,-4.79)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(8.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.28)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(8.72)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.28)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="7.88,-8.80 7.55,-6.64"/>
+                <g class="nad-edge-infos" transform="translate(7.83,-8.48)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-171.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.28)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-171.28)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-81.28)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="41">
+            <g class="nad-vl0to30">
+                <polyline points="7.67,-9.06 5.24,-9.11"/>
+                <g class="nad-edge-infos" transform="translate(7.34,-9.06)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-88.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-358.77)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-88.77)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-358.77)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="2.81,-9.16 5.24,-9.11"/>
+                <g class="nad-edge-infos" transform="translate(3.13,-9.15)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(91.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.23)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(91.23)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(1.23)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="42">
+            <g class="nad-vl0to30">
+                <polyline points="8.17,-9.00 10.58,-8.46"/>
+                <g class="nad-edge-infos" transform="translate(8.49,-8.93)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(102.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.55)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(102.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(12.55)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="12.99,-7.92 10.58,-8.46"/>
+                <g class="nad-edge-infos" transform="translate(12.67,-8.00)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-77.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-347.45)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-77.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-347.45)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="43">
+            <g class="nad-vl0to30">
+                <polyline points="2.49,-8.92 1.90,-6.76"/>
+                <g class="nad-edge-infos" transform="translate(2.40,-8.61)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-164.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.78)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-164.78)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.78)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="1.31,-4.60 1.90,-6.76"/>
+                <g class="nad-edge-infos" transform="translate(1.40,-4.92)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(15.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.78)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(15.22)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-74.78)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="44">
+            <g class="nad-vl0to30">
+                <polyline points="13.31,-7.63 13.99,-5.42"/>
+                <g class="nad-edge-infos" transform="translate(13.41,-7.32)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(162.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.83)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(162.83)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(72.83)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="14.67,-3.22 13.99,-5.42"/>
+                <g class="nad-edge-infos" transform="translate(14.58,-3.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-17.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-287.17)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-17.17)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-287.17)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <g id="45">
+            <g class="nad-vl0to30">
+                <polyline points="14.58,-2.78 13.10,-0.97"/>
+                <g class="nad-edge-infos" transform="translate(14.38,-2.53)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-140.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.55)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-140.55)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.55)" x="-0.19" style="text-anchor:end">0</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl0to30">
+                <polyline points="11.61,0.83 13.10,-0.97"/>
+                <g class="nad-edge-infos" transform="translate(11.82,0.58)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(39.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.55)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(39.45)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-50.55)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_edge" points="-17.00,2.22 -16.30,2.22"/>
+        <polyline id="2_edge" points="-19.74,-0.66 -19.04,-0.66"/>
+        <polyline id="4_edge" points="-13.54,5.33 -12.84,5.33"/>
+        <polyline id="6_edge" points="-4.87,2.49 -4.17,2.49"/>
+        <polyline id="8_edge" points="-9.16,7.46 -8.46,7.46"/>
+        <polyline id="10_edge" points="-3.84,6.45 -3.14,6.45"/>
+        <polyline id="12_edge" points="5.55,0.47 6.25,0.47"/>
+        <polyline id="14_edge" points="1.71,5.25 2.41,5.25"/>
+        <polyline id="16_edge" points="7.48,-4.22 8.18,-4.22"/>
+        <polyline id="18_edge" points="8.22,-9.05 8.92,-9.05"/>
+        <polyline id="20_edge" points="2.85,-9.17 3.55,-9.17"/>
+        <polyline id="22_edge" points="1.54,-4.36 2.24,-4.36"/>
+        <polyline id="24_edge" points="13.53,-7.87 14.23,-7.87"/>
+        <polyline id="26_edge" points="15.05,-2.98 15.75,-2.98"/>
+        <polyline id="28_edge" points="11.75,1.03 12.45,1.03"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" y="2.22" x="-16.30">A 230</text>
+        <text filter="url(#textBgFilter)" y="-0.66" x="-19.04">A 400</text>
+        <text filter="url(#textBgFilter)" y="5.33" x="-12.84">B 230</text>
+        <text filter="url(#textBgFilter)" y="2.49" x="-4.17">C 20</text>
+        <text filter="url(#textBgFilter)" y="7.46" x="-8.46">C 230</text>
+        <text filter="url(#textBgFilter)" y="6.45" x="-3.14">C 66</text>
+        <text filter="url(#textBgFilter)" y="0.47" x="6.25">D 10</text>
+        <text filter="url(#textBgFilter)" y="5.25" x="2.41">D 66</text>
+        <text filter="url(#textBgFilter)" y="-4.22" x="8.18">E 10</text>
+        <text filter="url(#textBgFilter)" y="-9.05" x="8.92">F 10</text>
+        <text filter="url(#textBgFilter)" y="-9.17" x="3.55">G 10</text>
+        <text filter="url(#textBgFilter)" y="-4.36" x="2.24">H 10</text>
+        <text filter="url(#textBgFilter)" y="-7.87" x="14.23">I 10</text>
+        <text filter="url(#textBgFilter)" y="-2.98" x="15.75">J 10</text>
+        <text filter="url(#textBgFilter)" y="1.03" x="12.45">K 10</text>
+    </g>
+</svg>


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature.

**What is the current behavior?** *(You can also link to an open issue here)*
Diagrams usually contain overlaps or near-overlaps. See the example:
![diamond-spring-repulsion-factor-0 0](https://user-images.githubusercontent.com/3374819/192470778-06aa6983-a3e4-4d38-8cb3-2b60ea5012a9.svg)

**What is the new behavior (if this is a feature change)?**
An additional force that separates the centers of the edges applying Coulomb's law is added. By default it is disabled. It can be configured using:

```java
new NetworkAreaDiagram(network).draw("output.svg",
    new SvgParams(),
    new LayoutParameters().setSpringRepulsionFactorForceLayout(0.2));
```

The expected result on the same network is:
![diamond-spring-repulsion-factor-0 2](https://user-images.githubusercontent.com/3374819/192471002-109c9e9b-af82-4927-8a79-720f6efb1b2a.svg)

The spring repulsion factor is combined with the `repulsion` parameter used to separate nodes in the graph. The repulsion force between springs is computed between the centers of the springs (the edges of the graph) and applied to its end nodes. The centers of the springs are also repelled from the other nodes in the graph.

