### PR TITLE
Voltage level neighborhood : consider other ends of dc links

### DIFF
--- a/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
+++ b/src/main/java/com/powsybl/nad/build/iidm/VoltageLevelFilter.java
@@ -118,6 +118,11 @@ public class VoltageLevelFilter implements Predicate<VoltageLevel> {
             }
         }
 
+        @Override
+        public void visitHvdcConverterStation(HvdcConverterStation<?> converterStation) {
+            converterStation.getOtherConverterStation().ifPresent(c -> visitTerminal(c.getTerminal()));
+        }
+
         private void visitBranch(Branch<?> branch, Branch.Side side) {
             visitTerminal(branch.getTerminal(IidmUtils.getOpposite(side)));
         }

--- a/src/test/java/com/powsybl/nad/svg/HvdcTest.java
+++ b/src/test/java/com/powsybl/nad/svg/HvdcTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.nad.svg;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.HvdcTestNetwork;
+import com.powsybl.nad.AbstractTest;
+import com.powsybl.nad.build.iidm.VoltageLevelFilter;
+import com.powsybl.nad.layout.LayoutParameters;
+import com.powsybl.nad.svg.iidm.DefaultLabelProvider;
+import com.powsybl.nad.svg.iidm.NominalVoltageStyleProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Luma Zamarreño <zamarrenolm at aia.es>
+ */
+class HvdcTest extends AbstractTest {
+
+    @BeforeEach
+    public void setup() {
+        setLayoutParameters(new LayoutParameters());
+        setSvgParameters(new SvgParameters()
+                .setInsertNameDesc(true)
+                .setSvgWidthAndHeightAdded(true)
+                .setFixedWidth(800));
+    }
+
+    @Override
+    protected StyleProvider getStyleProvider(Network network) {
+        return new NominalVoltageStyleProvider(network);
+    }
+
+    @Override
+    protected LabelProvider getLabelProvider(Network network) {
+        return new DefaultLabelProvider(network, getSvgParameters());
+    }
+
+    @Test
+    void testHvdcVL1Depth1() {
+        Network network = HvdcTestNetwork.createVsc();
+        debugSvg = true;
+        assertEquals(
+                toString("/hvdc-vl-depth-1.svg"),
+                generateSvgString(network,
+                        VoltageLevelFilter.createVoltageLevelDepthFilter(network, network.getVoltageLevel("VL1").getId(), 1),
+                        "/hvdc-vl-depth-1.svg"));
+    }
+}

--- a/src/test/resources/hvdc-vl-depth-1.svg
+++ b/src/test/resources/hvdc-vl-depth-1.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800.00" height="705.66" viewBox="-2.85 -2.89 7.44 6.57" xmlns="http://www.w3.org/2000/svg">
+    <style><![CDATA[
+.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-text-edges {stroke: black; stroke-width: 0.02; stroke-dasharray: .03,.05}
+.nad-branch-edges .nad-disconnected polyline {stroke-dasharray: .1,.1}
+.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 0.05; stroke-dasharray: .05,.05; fill: none}
+.nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 0.2}
+.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 0.05; fill: none}
+.nad-state-out .nad-arrow-in {visibility: hidden}
+.nad-state-in .nad-arrow-out {visibility: hidden}
+.nad-active path {stroke: none; fill: #546e7a}
+.nad-active {visibility: visible}
+.nad-reactive {visibility: hidden}
+.nad-reactive path {stroke: none; fill: #0277bd}
+.nad-text-background {flood-color: #90a4aeaa}
+.nad-text-nodes {font: 0.25px "Verdana"; fill: black; dominant-baseline: central}
+.nad-edge-infos text {font: 0.2px "Verdana"; dominant-baseline:middle; stroke: #FFFFFFAA; stroke-width: 0.1; stroke-linejoin:round; paint-order: stroke}
+.nad-edge-infos .nad-state-in text {fill: #b71c1c}
+.nad-edge-infos .nad-state-out text {fill: #2e7d32}
+.nad-vl0to30 {--nad-vl-color: #AFB42B}
+.nad-vl30to50 {--nad-vl-color: #EF9A9A}
+.nad-vl50to70 {--nad-vl-color: #9C27B0}
+.nad-vl70to120 {--nad-vl-color: #E65100}
+.nad-vl120to180 {--nad-vl-color: #00ACC1}
+.nad-vl180to300 {--nad-vl-color: #2E7D32}
+.nad-vl300to500 {--nad-vl-color: #D32F2F}
+.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
+.nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
+
+@keyframes line-blink {
+  0%, 80%, 100% {stroke: var(--nad-vl-color, black); stroke-width: 0.05}
+  40% {stroke: #FFEB3B; stroke-width: 0.15}
+}
+@keyframes node-over-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #ff5722; stroke-width: 0.15}
+}
+@keyframes node-under-blink {
+  0%, 80%, 100% {stroke: white; stroke-width: 0}
+  40% {stroke: #00BCD4; stroke-width: 0.15}
+}
+]]></style>
+    <metadata xmlns:nad="http://www.powsybl.org/schema/nad-metadata/1_0">
+        <nad:busNodes>
+            <nad:busNode diagramId="1" equipmentId="VL1_0"/>
+            <nad:busNode diagramId="3" equipmentId="VL2_0"/>
+        </nad:busNodes>
+        <nad:nodes>
+            <nad:node diagramId="0" equipmentId="VL1"/>
+            <nad:node diagramId="2" equipmentId="VL2"/>
+        </nad:nodes>
+        <nad:edges>
+            <nad:edge diagramId="4" equipmentId="L"/>
+        </nad:edges>
+    </metadata>
+    <defs>
+        <filter id="textBgFilter" x="0" y="0" width="1" height="1">
+            <feFlood class="nad-text-background"/>
+            <feComposite in="SourceGraphic" operator="over"/>
+        </filter>
+    </defs>
+    <g class="nad-vl-nodes">
+        <g transform="translate(1.60,-0.89)" id="0" class="nad-vl300to500">
+            <desc>VL1</desc>
+            <circle r="0.27" id="1"/>
+        </g>
+        <g transform="translate(-0.85,1.68)" id="2" class="nad-vl300to500">
+            <desc>VL2</desc>
+            <circle r="0.27" id="3"/>
+        </g>
+    </g>
+    <g class="nad-branch-edges">
+        <g id="4" class="nad-hvdc-edge">
+            <desc>HVDC</desc>
+            <g class="nad-vl300to500">
+                <polyline points="1.42,-0.70 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(1.20,-0.47)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(-136.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">100</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(-136.40)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-46.40)" x="-0.19" style="text-anchor:end">50</text>
+                    </g>
+                </g>
+            </g>
+            <g class="nad-vl300to500">
+                <polyline points="-0.67,1.49 0.37,0.39"/>
+                <g class="nad-edge-infos" transform="translate(-0.45,1.26)">
+                    <g class="nad-active nad-state-out">
+                        <g transform="rotate(43.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
+                    </g>
+                    <g class="nad-reactive nad-state-out">
+                        <g transform="rotate(43.60)">
+                            <path class="nad-arrow-in" d="M-0.1 -0.1 H0.1 L0 0.1z"/>
+                            <path class="nad-arrow-out" d="M-0.1 0.1 H0.1 L0 -0.1z"/>
+                        </g>
+                        <text transform="rotate(-46.40)" x="0.19">0</text>
+                    </g>
+                </g>
+            </g>
+            <polyline points="0.58,0.18 0.17,0.61" class="nad-hvdc"/>
+        </g>
+    </g>
+    <g class="nad-text-edges">
+        <polyline id="0_edge" points="1.90,-0.89 2.60,-0.89"/>
+        <polyline id="2_edge" points="-0.55,1.68 0.15,1.68"/>
+    </g>
+    <g class="nad-text-nodes">
+        <text filter="url(#textBgFilter)" y="-0.89" x="2.60">VL1</text>
+        <text filter="url(#textBgFilter)" y="1.68" x="0.15">VL2</text>
+    </g>
+</svg>


### PR DESCRIPTION
Signed-off-by: Luma <zamarrenolm@aia.es>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature

**What is the current behavior?** *(You can also link to an open issue here)*
When building a diagram with a set of voltage levels plus neighbours up to a given depth, dc links are not considered.


**What is the new behavior (if this is a feature change)?**
Other ends of dc links are considered as neighbours at distance 1 when looking for neighbours of a given voltage level.

