### PR TITLE
Adding more specific CSS classes

### DIFF
--- a/src/main/java/com/powsybl/nad/svg/StyleProvider.java
+++ b/src/main/java/com/powsybl/nad/svg/StyleProvider.java
@@ -33,6 +33,9 @@ public interface StyleProvider {
     String LINE_OVERLOADED_CLASS = CLASSES_PREFIX + "overload";
     String VL_OVERVOLTAGE_CLASS = CLASSES_PREFIX + "overvoltage";
     String VL_UNDERVOLTAGE_CLASS = CLASSES_PREFIX + "undervoltage";
+    String EDGE_PATH_CLASS = CLASSES_PREFIX + "edge-path";
+    String WINDING_CLASS = CLASSES_PREFIX + "winding";
+    String BUSNODE_CLASS = CLASSES_PREFIX + "busnode";
 
     List<String> getCssFilenames();
 

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -183,10 +183,12 @@ public class SvgWriter {
         if (edge.isVisible(side)) {
             if (!graph.isLoop(edge)) {
                 writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
+                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.EDGE_PATH_CLASS);
                 writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge, side));
                 drawBranchEdgeInfo(graph, writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             } else {
                 writer.writeEmptyElement(PATH_ELEMENT_NAME);
+                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.EDGE_PATH_CLASS);
                 writer.writeAttribute(PATH_D_ATTRIBUTE, getLoopPathString(edge, side));
                 drawLoopEdgeInfo(writer, edge, side, labelProvider.getEdgeInfos(graph, edge, side));
             }
@@ -225,6 +227,7 @@ public class SvgWriter {
         addStylesIfAny(writer, styleProvider.getEdgeStyleClasses(edge));
         insertName(writer, edge::getName);
         writer.writeEmptyElement(POLYLINE_ELEMENT_NAME);
+        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.EDGE_PATH_CLASS);
         writer.writeAttribute(POINTS_ATTRIBUTE, getPolylinePointsString(edge));
         drawThreeWtEdgeInfo(graph, writer, edge, labelProvider.getEdgeInfos(graph, edge));
         writer.writeEndElement();
@@ -252,6 +255,7 @@ public class SvgWriter {
 
     private void draw3WtWinding(ThreeWtEdge edge, ThreeWtNode threeWtNode, XMLStreamWriter writer) throws XMLStreamException {
         List<String> styles = styleProvider.getThreeWtNodeStyle(threeWtNode, edge.getSide());
+        styles.add(StyleProvider.WINDING_CLASS);
         double radius = svgParameters.getTransformerCircleRadius();
         Point circleCenter = edge.getPoints().get(1).atDistance(radius, threeWtNode.getPosition());
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
@@ -368,6 +372,7 @@ public class SvgWriter {
 
     private void draw2WtWinding(XMLStreamWriter writer, List<Point> half) throws XMLStreamException {
         writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
+        writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.WINDING_CLASS);
         Point point1 = half.get(half.size() - 1); // point near 2wt
         Point point2 = half.get(half.size() - 2); // point near voltage level, or control point for loops
         double radius = svgParameters.getTransformerCircleRadius();
@@ -457,9 +462,11 @@ public class SvgWriter {
             double busOuterRadius = getBusAnnulusOuterRadius(busNode, vlNode, svgParameters);
             if (busInnerRadius == 0) {
                 writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
+                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.BUSNODE_CLASS);
                 writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(busOuterRadius));
             } else {
                 writer.writeEmptyElement(PATH_ELEMENT_NAME);
+                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.BUSNODE_CLASS);
                 writer.writeAttribute(PATH_D_ATTRIBUTE, getFragmentedAnnulusPath(busInnerRadius, busOuterRadius, traversingBusEdges, graph, vlNode, busNode));
             }
             writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(busNode.getDiagramId()));

--- a/src/main/java/com/powsybl/nad/svg/SvgWriter.java
+++ b/src/main/java/com/powsybl/nad/svg/SvgWriter.java
@@ -462,15 +462,17 @@ public class SvgWriter {
             double busOuterRadius = getBusAnnulusOuterRadius(busNode, vlNode, svgParameters);
             if (busInnerRadius == 0) {
                 writer.writeEmptyElement(CIRCLE_ELEMENT_NAME);
-                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.BUSNODE_CLASS);
                 writer.writeAttribute(CIRCLE_RADIUS_ATTRIBUTE, getFormattedValue(busOuterRadius));
             } else {
                 writer.writeEmptyElement(PATH_ELEMENT_NAME);
-                writer.writeAttribute(CLASS_ATTRIBUTE, StyleProvider.BUSNODE_CLASS);
                 writer.writeAttribute(PATH_D_ATTRIBUTE, getFragmentedAnnulusPath(busInnerRadius, busOuterRadius, traversingBusEdges, graph, vlNode, busNode));
             }
             writer.writeAttribute(ID_ATTRIBUTE, getPrefixedId(busNode.getDiagramId()));
-            addStylesIfAny(writer, styleProvider.getNodeStyleClasses(busNode));
+
+            List<String> nodeStyleClasses = styleProvider.getNodeStyleClasses(busNode);
+            nodeStyleClasses.add(StyleProvider.BUSNODE_CLASS);
+            addStylesIfAny(writer, nodeStyleClasses);
+
             traversingBusEdges.addAll(graph.getBusEdges(busNode));
         }
     }

--- a/src/main/resources/nominalStyle.css
+++ b/src/main/resources/nominalStyle.css
@@ -1,12 +1,10 @@
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -25,7 +23,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 

--- a/src/main/resources/topologicalStyle.css
+++ b/src/main/resources/topologicalStyle.css
@@ -1,12 +1,10 @@
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -89,7 +87,7 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -68,15 +68,15 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
             <desc>VL_132</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
             <desc>VL_33</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>

--- a/src/test/resources/3wt.svg
+++ b/src/test/resources/3wt.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="691.36" viewBox="-398.78 -437.73 1153.52 996.87" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -70,22 +68,22 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
             <desc>VL_132</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
             <desc>VL_33</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="-180.89,-204.55 49.18,31.35"/>
+            <polyline class="nad-edge-path" points="-180.89,-204.55 49.18,31.35"/>
             <g class="nad-edge-infos" transform="translate(-158.20,-181.29)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.72)">
@@ -105,7 +103,7 @@
         </g>
         <g id="8" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline points="-163.72,339.48 65.60,84.29"/>
+            <polyline class="nad-edge-path" points="-163.72,339.48 65.60,84.29"/>
             <g class="nad-edge-infos" transform="translate(-142.00,315.30)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(41.94)">
@@ -125,7 +123,7 @@
         </g>
         <g id="9" class="nad-vl30to50">
             <desc>3WT</desc>
-            <polyline points="430.38,-57.84 103.24,43.60"/>
+            <polyline class="nad-edge-path" points="430.38,-57.84 103.24,43.60"/>
             <g class="nad-edge-infos" transform="translate(399.34,-48.21)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
@@ -146,9 +144,9 @@
     </g>
     <g class="nad-3wt-nodes">
         <g>
-            <circle class="nad-vl0to30" cx="63.86" cy="44.93" r="20.00"/>
-            <circle class="nad-vl120to180" cx="70.02" cy="64.79" r="20.00"/>
-            <circle class="nad-vl30to50" cx="84.13" cy="49.53" r="20.00"/>
+            <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
+            <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
+            <circle class="nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/3wt_disconnected.svg
+++ b/src/test/resources/3wt_disconnected.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="691.36" viewBox="-398.78 -437.73 1153.52 996.87" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -69,11 +67,11 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
             <desc>VL_132</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
             <desc>VL_33</desc>
@@ -84,7 +82,7 @@
     <g class="nad-3wt-edges">
         <g id="6" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="-180.89,-204.55 49.18,31.35"/>
+            <polyline class="nad-edge-path" points="-180.89,-204.55 49.18,31.35"/>
             <g class="nad-edge-infos" transform="translate(-158.20,-181.29)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(135.72)">
@@ -104,7 +102,7 @@
         </g>
         <g id="7" class="nad-vl120to180">
             <desc>3WT</desc>
-            <polyline points="-163.72,339.48 65.60,84.29"/>
+            <polyline class="nad-edge-path" points="-163.72,339.48 65.60,84.29"/>
             <g class="nad-edge-infos" transform="translate(-142.00,315.30)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(41.94)">
@@ -124,7 +122,7 @@
         </g>
         <g id="8" class="nad-disconnected nad-vl30to50">
             <desc>3WT</desc>
-            <polyline points="416.54,-53.55 103.24,43.60"/>
+            <polyline class="nad-edge-path" points="416.54,-53.55 103.24,43.60"/>
             <g class="nad-edge-infos" transform="translate(385.49,-43.92)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(-107.23)">
@@ -145,9 +143,9 @@
     </g>
     <g class="nad-3wt-nodes">
         <g>
-            <circle class="nad-vl0to30" cx="63.86" cy="44.93" r="20.00"/>
-            <circle class="nad-vl120to180" cx="70.02" cy="64.79" r="20.00"/>
-            <circle class="nad-disconnected nad-vl30to50" cx="84.13" cy="49.53" r="20.00"/>
+            <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
+            <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
+            <circle class="nad-disconnected nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/3wt_disconnected.svg
+++ b/src/test/resources/3wt_disconnected.svg
@@ -67,11 +67,11 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
             <desc>VL_132</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
             <desc>VL_33</desc>

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -68,7 +68,7 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-377.54,109.86)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>

--- a/src/test/resources/3wt_partial.svg
+++ b/src/test/resources/3wt_partial.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="770.68" viewBox="-577.54 -498.22 1038.73 1000.67" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -70,14 +68,14 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-377.54,109.86)" id="0" class="nad-vl0to30">
             <desc>VL_11</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="3" class="nad-vl0to30">
             <desc>3WT</desc>
-            <polyline points="-352.96,103.08 -24.91,12.69"/>
+            <polyline class="nad-edge-path" points="-352.96,103.08 -24.91,12.69"/>
             <g class="nad-edge-infos" transform="translate(-321.62,94.45)">
                 <g class="nad-active nad-state-out">
                     <g transform="rotate(74.59)">
@@ -98,9 +96,9 @@
     </g>
     <g class="nad-3wt-nodes">
         <g>
-            <circle class="nad-vl0to30" cx="-5.63" cy="7.38" r="20.00"/>
-            <circle class="nad-vl120to180" cx="14.49" cy="12.61" r="20.00"/>
-            <circle class="nad-vl30to50" cx="8.97" cy="-7.42" r="20.00"/>
+            <circle class="nad-vl0to30 nad-winding" cx="-5.63" cy="7.38" r="20.00"/>
+            <circle class="nad-vl120to180 nad-winding" cx="14.49" cy="12.61" r="20.00"/>
+            <circle class="nad-vl30to50 nad-winding" cx="8.97" cy="-7.42" r="20.00"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -546,475 +546,475 @@
     <g class="nad-vl-nodes">
         <g transform="translate(736.99,-2973.24)" id="0">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="1" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1307.45,-2918.68)" id="2">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="3" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(2323.85,-469.66)" id="4">
             <desc>VL100</desc>
-            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="5" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2787.74,-301.89)" id="6">
             <desc>VL101</desc>
-            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="7" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(3037.91,-0.61)" id="8">
             <desc>VL102</desc>
-            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="9" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2317.93,-1246.85)" id="10">
             <desc>VL103</desc>
-            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="11" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2390.66,-930.45)" id="12">
             <desc>VL104</desc>
-            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="13" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2741.45,-1230.14)" id="14">
             <desc>VL105</desc>
-            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="15" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2817.56,-835.52)" id="16">
             <desc>VL106</desc>
-            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="17" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(3127.02,-1083.37)" id="18">
             <desc>VL107</desc>
-            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="19" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2896.05,-1690.56)" id="20">
             <desc>VL108</desc>
-            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="21" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2665.31,-2006.62)" id="22">
             <desc>VL109</desc>
-            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="23" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-67.16,-2211.79)" id="24">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="25" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2247.63,-1899.10)" id="26">
             <desc>VL110</desc>
-            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="27" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1858.44,-2031.11)" id="28">
             <desc>VL111</desc>
-            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="29" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2235.01,-2372.34)" id="30">
             <desc>VL112</desc>
-            <circle class="nad-busnode" r="27.50" id="31" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="31" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1385.76,-1526.69)" id="32">
             <desc>VL113</desc>
-            <circle class="nad-busnode" r="27.50" id="33" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="33" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2615.39,-1823.06)" id="34">
             <desc>VL114</desc>
-            <circle class="nad-busnode" r="27.50" id="35" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="35" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2868.05,-1598.59)" id="36">
             <desc>VL115</desc>
-            <circle class="nad-busnode" r="27.50" id="37" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="37" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1070.76,880.20)" id="38">
             <desc>VL116</desc>
-            <circle class="nad-busnode" r="27.50" id="39" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="39" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(783.39,-2129.92)" id="40">
             <desc>VL117</desc>
-            <circle class="nad-busnode" r="27.50" id="41" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="41" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-668.39,-83.87)" id="42">
             <desc>VL118</desc>
-            <circle class="nad-busnode" r="27.50" id="43" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="43" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(327.25,-2285.46)" id="44">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="45" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="45" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-13.23,-1620.95)" id="46">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="47" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="47" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(361.41,-1657.12)" id="48">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="49" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="49" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-94.90,-1143.77)" id="50">
             <desc>VL15</desc>
-            <circle class="nad-busnode" r="27.50" id="51" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="51" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-312.60,-1868.75)" id="52">
             <desc>VL16</desc>
-            <circle class="nad-busnode" r="27.50" id="53" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="53" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-811.77,-1466.12)" id="54">
             <desc>VL17</desc>
-            <circle class="nad-busnode" r="27.50" id="55" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="55" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-548.51,-1044.94)" id="56">
             <desc>VL18</desc>
-            <circle class="nad-busnode" r="27.50" id="57" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="57" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-410.89,-569.38)" id="58">
             <desc>VL19</desc>
-            <circle class="nad-busnode" r="27.50" id="59" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="59" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(795.95,-2616.31)" id="60">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="61" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="61" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1002.04,-540.85)" id="62">
             <desc>VL20</desc>
-            <circle class="nad-busnode" r="27.50" id="63" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="63" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1496.32,-509.09)" id="64">
             <desc>VL21</desc>
-            <circle class="nad-busnode" r="27.50" id="65" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="65" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1926.57,-571.94)" id="66">
             <desc>VL22</desc>
-            <circle class="nad-busnode" r="27.50" id="67" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="67" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2201.77,-810.71)" id="68">
             <desc>VL23</desc>
-            <circle class="nad-busnode" r="27.50" id="69" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="69" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2121.97,-123.57)" id="70">
             <desc>VL24</desc>
-            <circle class="nad-busnode" r="27.50" id="71" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="71" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2150.42,-1162.58)" id="72">
             <desc>VL25</desc>
-            <circle class="nad-busnode" r="27.50" id="73" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="73" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1584.83,-1094.99)" id="74">
             <desc>VL26</desc>
-            <circle class="nad-busnode" r="27.50" id="75" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="75" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-2396.03,-1575.73)" id="76">
             <desc>VL27</desc>
-            <circle class="nad-busnode" r="27.50" id="77" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="77" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2282.12,-2114.64)" id="78">
             <desc>VL28</desc>
-            <circle class="nad-busnode" r="27.50" id="79" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="79" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1895.57,-2216.66)" id="80">
             <desc>VL29</desc>
-            <circle class="nad-busnode" r="27.50" id="81" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="81" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(348.88,-2691.09)" id="82">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="83" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="83" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-967.99,-1064.51)" id="84">
             <desc>VL30</desc>
-            <circle class="nad-busnode" r="27.50" id="85" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="85" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-1563.34,-1851.27)" id="86">
             <desc>VL31</desc>
-            <circle class="nad-busnode" r="27.50" id="87" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="87" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2016.14,-1543.90)" id="88">
             <desc>VL32</desc>
-            <circle class="nad-busnode" r="27.50" id="89" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="89" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(140.90,-456.36)" id="90">
             <desc>VL33</desc>
-            <circle class="nad-busnode" r="27.50" id="91" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="91" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-87.82,499.20)" id="92">
             <desc>VL34</desc>
-            <circle class="nad-busnode" r="27.50" id="93" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="93" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(523.57,737.58)" id="94">
             <desc>VL35</desc>
-            <circle class="nad-busnode" r="27.50" id="95" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="95" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(165.15,857.17)" id="96">
             <desc>VL36</desc>
-            <circle class="nad-busnode" r="27.50" id="97" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="97" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(241.65,538.50)" id="98">
             <desc>VL37</desc>
-            <circle class="nad-busnode" r="27.50" id="99" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="99" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-515.99,257.27)" id="100">
             <desc>VL38</desc>
-            <circle class="nad-busnode" r="27.50" id="101" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="101" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(707.42,1039.26)" id="102">
             <desc>VL39</desc>
-            <circle class="nad-busnode" r="27.50" id="103" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="103" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-456.43,-2436.67)" id="104">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="105" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="105" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(512.74,1337.72)" id="106">
             <desc>VL40</desc>
-            <circle class="nad-busnode" r="27.50" id="107" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="107" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(634.21,1767.75)" id="108">
             <desc>VL41</desc>
-            <circle class="nad-busnode" r="27.50" id="109" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="109" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(149.99,1701.48)" id="110">
             <desc>VL42</desc>
-            <circle class="nad-busnode" r="27.50" id="111" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="111" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(55.03,1306.70)" id="112">
             <desc>VL43</desc>
-            <circle class="nad-busnode" r="27.50" id="113" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="113" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(202.50,2053.81)" id="114">
             <desc>VL44</desc>
-            <circle class="nad-busnode" r="27.50" id="115" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="115" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-204.25,2143.02)" id="116">
             <desc>VL45</desc>
-            <circle class="nad-busnode" r="27.50" id="117" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="117" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-307.65,1800.48)" id="118">
             <desc>VL46</desc>
-            <circle class="nad-busnode" r="27.50" id="119" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="119" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-561.68,1442.10)" id="120">
             <desc>VL47</desc>
-            <circle class="nad-busnode" r="27.50" id="121" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="121" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-567.75,1972.26)" id="122">
             <desc>VL48</desc>
-            <circle class="nad-busnode" r="27.50" id="123" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="123" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-865.91,1803.56)" id="124">
             <desc>VL49</desc>
-            <circle class="nad-busnode" r="27.50" id="125" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="125" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-226.14,-2597.43)" id="126">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="127" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="127" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1216.28,2348.42)" id="128">
             <desc>VL50</desc>
-            <circle class="nad-busnode" r="27.50" id="129" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="129" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1735.70,1570.73)" id="130">
             <desc>VL51</desc>
-            <circle class="nad-busnode" r="27.50" id="131" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="131" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2270.25,1451.22)" id="132">
             <desc>VL52</desc>
-            <circle class="nad-busnode" r="27.50" id="133" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="133" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2450.66,1826.24)" id="134">
             <desc>VL53</desc>
-            <circle class="nad-busnode" r="27.50" id="135" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="135" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1871.19,2164.77)" id="136">
             <desc>VL54</desc>
-            <circle class="nad-busnode" r="27.50" id="137" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="137" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2172.24,2632.80)" id="138">
             <desc>VL55</desc>
-            <circle class="nad-busnode" r="27.50" id="139" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="139" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2047.32,2402.77)" id="140">
             <desc>VL56</desc>
-            <circle class="nad-busnode" r="27.50" id="141" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="141" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1757.65,2835.12)" id="142">
             <desc>VL57</desc>
-            <circle class="nad-busnode" r="27.50" id="143" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="143" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2080.07,1873.46)" id="144">
             <desc>VL58</desc>
-            <circle class="nad-busnode" r="27.50" id="145" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="145" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1684.36,2545.40)" id="146">
             <desc>VL59</desc>
-            <circle class="nad-busnode" r="27.50" id="147" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="147" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-227.75,-3078.89)" id="148">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="149" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="149" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1272.84,2998.10)" id="150">
             <desc>VL60</desc>
-            <circle class="nad-busnode" r="27.50" id="151" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="151" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1237.34,2662.22)" id="152">
             <desc>VL61</desc>
-            <circle class="nad-busnode" r="27.50" id="153" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="153" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-856.69,2833.88)" id="154">
             <desc>VL62</desc>
-            <circle class="nad-busnode" r="27.50" id="155" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="155" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1522.71,2138.63)" id="156">
             <desc>VL63</desc>
-            <circle class="nad-busnode" r="27.50" id="157" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="157" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-1223.07,1924.77)" id="158">
             <desc>VL64</desc>
-            <circle class="nad-busnode" r="27.50" id="159" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="159" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-838.01,1302.47)" id="160">
             <desc>VL65</desc>
-            <circle class="nad-busnode" r="27.50" id="161" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="161" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-724.94,2291.00)" id="162">
             <desc>VL66</desc>
-            <circle class="nad-busnode" r="27.50" id="163" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="163" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-485.47,2800.21)" id="164">
             <desc>VL67</desc>
-            <circle class="nad-busnode" r="27.50" id="165" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="165" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-432.82,839.16)" id="166">
             <desc>VL68</desc>
-            <circle class="nad-busnode" r="27.50" id="167" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="167" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-737.13,811.74)" id="168">
             <desc>VL69</desc>
-            <circle class="nad-busnode" r="27.50" id="169" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="169" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(119.58,-2950.52)" id="170">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="171" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="171" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1569.94,376.64)" id="172">
             <desc>VL70</desc>
-            <circle class="nad-busnode" r="27.50" id="173" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="173" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2262.47,427.94)" id="174">
             <desc>VL71</desc>
-            <circle class="nad-busnode" r="27.50" id="175" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="175" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2481.37,82.57)" id="176">
             <desc>VL72</desc>
-            <circle class="nad-busnode" r="27.50" id="177" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="177" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-2719.03,566.35)" id="178">
             <desc>VL73</desc>
-            <circle class="nad-busnode" r="27.50" id="179" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="179" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1291.18,229.09)" id="180">
             <desc>VL74</desc>
-            <circle class="nad-busnode" r="27.50" id="181" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="181" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-873.64,301.84)" id="182">
             <desc>VL75</desc>
-            <circle class="nad-busnode" r="27.50" id="183" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="183" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-207.79,-92.40)" id="184">
             <desc>VL76</desc>
-            <circle class="nad-busnode" r="27.50" id="185" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="185" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(183.20,161.49)" id="186">
             <desc>VL77</desc>
-            <circle class="nad-busnode" r="27.50" id="187" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="187" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(565.97,-268.02)" id="188">
             <desc>VL78</desc>
-            <circle class="nad-busnode" r="27.50" id="189" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="189" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(911.14,-480.58)" id="190">
             <desc>VL79</desc>
-            <circle class="nad-busnode" r="27.50" id="191" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="191" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-822.77,-2072.63)" id="192">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="193" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="193" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(1115.02,-106.19)" id="194">
             <desc>VL80</desc>
-            <circle class="nad-busnode" r="27.50" id="195" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="195" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(555.40,284.23)" id="196">
             <desc>VL81</desc>
-            <circle class="nad-busnode" r="27.50" id="197" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="197" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(1185.49,633.29)" id="198">
             <desc>VL82</desc>
-            <circle class="nad-busnode" r="27.50" id="199" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="199" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1720.46,1225.26)" id="200">
             <desc>VL83</desc>
-            <circle class="nad-busnode" r="27.50" id="201" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="201" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1872.65,1592.24)" id="202">
             <desc>VL84</desc>
-            <circle class="nad-busnode" r="27.50" id="203" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="203" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2254.32,1505.38)" id="204">
             <desc>VL85</desc>
-            <circle class="nad-busnode" r="27.50" id="205" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="205" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2297.43,2057.25)" id="206">
             <desc>VL86</desc>
-            <circle class="nad-busnode" r="27.50" id="207" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="207" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2281.30,2465.48)" id="208">
             <desc>VL87</desc>
-            <circle class="nad-busnode" r="27.50" id="209" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="209" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2651.27,1470.48)" id="210">
             <desc>VL88</desc>
-            <circle class="nad-busnode" r="27.50" id="211" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="211" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2679.94,1059.28)" id="212">
             <desc>VL89</desc>
-            <circle class="nad-busnode" r="27.50" id="213" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="213" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-1110.36,-2546.02)" id="214">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="215" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="215" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(3119.18,992.09)" id="216">
             <desc>VL90</desc>
-            <circle class="nad-busnode" r="27.50" id="217" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="217" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(3112.24,597.31)" id="218">
             <desc>VL91</desc>
-            <circle class="nad-busnode" r="27.50" id="219" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="219" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2692.64,288.03)" id="220">
             <desc>VL92</desc>
-            <circle class="nad-busnode" r="27.50" id="221" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="221" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2425.16,462.49)" id="222">
             <desc>VL93</desc>
-            <circle class="nad-busnode" r="27.50" id="223" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="223" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(2198.12,143.57)" id="224">
             <desc>VL94</desc>
-            <circle class="nad-busnode" r="27.50" id="225" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="225" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1924.07,428.77)" id="226">
             <desc>VL95</desc>
-            <circle class="nad-busnode" r="27.50" id="227" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="227" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1578.37,285.28)" id="228">
             <desc>VL96</desc>
-            <circle class="nad-busnode" r="27.50" id="229" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="229" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1406.49,11.44)" id="230">
             <desc>VL97</desc>
-            <circle class="nad-busnode" r="27.50" id="231" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="231" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1634.60,-576.38)" id="232">
             <desc>VL98</desc>
-            <circle class="nad-busnode" r="27.50" id="233" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="233" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1794.79,-295.58)" id="234">
             <desc>VL99</desc>
-            <circle class="nad-busnode" r="27.50" id="235" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="235" class="nad-vl120to180-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_118_bus.svg
+++ b/src/test/resources/IEEE_118_bus.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="799.62" viewBox="-3068.05 -3293.89 6495.07 6491.99" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -92,7 +90,7 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -548,482 +546,482 @@
     <g class="nad-vl-nodes">
         <g transform="translate(736.99,-2973.24)" id="0">
             <desc>VL1</desc>
-            <circle r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1307.45,-2918.68)" id="2">
             <desc>VL10</desc>
-            <circle r="27.50" id="3" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(2323.85,-469.66)" id="4">
             <desc>VL100</desc>
-            <circle r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2787.74,-301.89)" id="6">
             <desc>VL101</desc>
-            <circle r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3037.91,-0.61)" id="8">
             <desc>VL102</desc>
-            <circle r="27.50" id="9" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2317.93,-1246.85)" id="10">
             <desc>VL103</desc>
-            <circle r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2390.66,-930.45)" id="12">
             <desc>VL104</desc>
-            <circle r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2741.45,-1230.14)" id="14">
             <desc>VL105</desc>
-            <circle r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2817.56,-835.52)" id="16">
             <desc>VL106</desc>
-            <circle r="27.50" id="17" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3127.02,-1083.37)" id="18">
             <desc>VL107</desc>
-            <circle r="27.50" id="19" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2896.05,-1690.56)" id="20">
             <desc>VL108</desc>
-            <circle r="27.50" id="21" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2665.31,-2006.62)" id="22">
             <desc>VL109</desc>
-            <circle r="27.50" id="23" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-67.16,-2211.79)" id="24">
             <desc>VL11</desc>
-            <circle r="27.50" id="25" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2247.63,-1899.10)" id="26">
             <desc>VL110</desc>
-            <circle r="27.50" id="27" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1858.44,-2031.11)" id="28">
             <desc>VL111</desc>
-            <circle r="27.50" id="29" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2235.01,-2372.34)" id="30">
             <desc>VL112</desc>
-            <circle r="27.50" id="31" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="31" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1385.76,-1526.69)" id="32">
             <desc>VL113</desc>
-            <circle r="27.50" id="33" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="33" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2615.39,-1823.06)" id="34">
             <desc>VL114</desc>
-            <circle r="27.50" id="35" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="35" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2868.05,-1598.59)" id="36">
             <desc>VL115</desc>
-            <circle r="27.50" id="37" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="37" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1070.76,880.20)" id="38">
             <desc>VL116</desc>
-            <circle r="27.50" id="39" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="39" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(783.39,-2129.92)" id="40">
             <desc>VL117</desc>
-            <circle r="27.50" id="41" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="41" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-668.39,-83.87)" id="42">
             <desc>VL118</desc>
-            <circle r="27.50" id="43" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="43" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(327.25,-2285.46)" id="44">
             <desc>VL12</desc>
-            <circle r="27.50" id="45" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="45" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-13.23,-1620.95)" id="46">
             <desc>VL13</desc>
-            <circle r="27.50" id="47" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="47" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(361.41,-1657.12)" id="48">
             <desc>VL14</desc>
-            <circle r="27.50" id="49" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="49" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-94.90,-1143.77)" id="50">
             <desc>VL15</desc>
-            <circle r="27.50" id="51" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="51" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-312.60,-1868.75)" id="52">
             <desc>VL16</desc>
-            <circle r="27.50" id="53" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="53" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-811.77,-1466.12)" id="54">
             <desc>VL17</desc>
-            <circle r="27.50" id="55" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="55" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-548.51,-1044.94)" id="56">
             <desc>VL18</desc>
-            <circle r="27.50" id="57" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="57" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-410.89,-569.38)" id="58">
             <desc>VL19</desc>
-            <circle r="27.50" id="59" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="59" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(795.95,-2616.31)" id="60">
             <desc>VL2</desc>
-            <circle r="27.50" id="61" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="61" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1002.04,-540.85)" id="62">
             <desc>VL20</desc>
-            <circle r="27.50" id="63" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="63" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1496.32,-509.09)" id="64">
             <desc>VL21</desc>
-            <circle r="27.50" id="65" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="65" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1926.57,-571.94)" id="66">
             <desc>VL22</desc>
-            <circle r="27.50" id="67" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="67" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2201.77,-810.71)" id="68">
             <desc>VL23</desc>
-            <circle r="27.50" id="69" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="69" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2121.97,-123.57)" id="70">
             <desc>VL24</desc>
-            <circle r="27.50" id="71" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="71" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2150.42,-1162.58)" id="72">
             <desc>VL25</desc>
-            <circle r="27.50" id="73" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="73" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1584.83,-1094.99)" id="74">
             <desc>VL26</desc>
-            <circle r="27.50" id="75" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="75" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-2396.03,-1575.73)" id="76">
             <desc>VL27</desc>
-            <circle r="27.50" id="77" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="77" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2282.12,-2114.64)" id="78">
             <desc>VL28</desc>
-            <circle r="27.50" id="79" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="79" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1895.57,-2216.66)" id="80">
             <desc>VL29</desc>
-            <circle r="27.50" id="81" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="81" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(348.88,-2691.09)" id="82">
             <desc>VL3</desc>
-            <circle r="27.50" id="83" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="83" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-967.99,-1064.51)" id="84">
             <desc>VL30</desc>
-            <circle r="27.50" id="85" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="85" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-1563.34,-1851.27)" id="86">
             <desc>VL31</desc>
-            <circle r="27.50" id="87" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="87" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2016.14,-1543.90)" id="88">
             <desc>VL32</desc>
-            <circle r="27.50" id="89" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="89" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(140.90,-456.36)" id="90">
             <desc>VL33</desc>
-            <circle r="27.50" id="91" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="91" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-87.82,499.20)" id="92">
             <desc>VL34</desc>
-            <circle r="27.50" id="93" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="93" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(523.57,737.58)" id="94">
             <desc>VL35</desc>
-            <circle r="27.50" id="95" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="95" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(165.15,857.17)" id="96">
             <desc>VL36</desc>
-            <circle r="27.50" id="97" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="97" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(241.65,538.50)" id="98">
             <desc>VL37</desc>
-            <circle r="27.50" id="99" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="99" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-515.99,257.27)" id="100">
             <desc>VL38</desc>
-            <circle r="27.50" id="101" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="101" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(707.42,1039.26)" id="102">
             <desc>VL39</desc>
-            <circle r="27.50" id="103" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="103" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-456.43,-2436.67)" id="104">
             <desc>VL4</desc>
-            <circle r="27.50" id="105" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="105" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(512.74,1337.72)" id="106">
             <desc>VL40</desc>
-            <circle r="27.50" id="107" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="107" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(634.21,1767.75)" id="108">
             <desc>VL41</desc>
-            <circle r="27.50" id="109" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="109" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(149.99,1701.48)" id="110">
             <desc>VL42</desc>
-            <circle r="27.50" id="111" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="111" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(55.03,1306.70)" id="112">
             <desc>VL43</desc>
-            <circle r="27.50" id="113" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="113" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(202.50,2053.81)" id="114">
             <desc>VL44</desc>
-            <circle r="27.50" id="115" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="115" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-204.25,2143.02)" id="116">
             <desc>VL45</desc>
-            <circle r="27.50" id="117" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="117" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-307.65,1800.48)" id="118">
             <desc>VL46</desc>
-            <circle r="27.50" id="119" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="119" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-561.68,1442.10)" id="120">
             <desc>VL47</desc>
-            <circle r="27.50" id="121" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="121" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-567.75,1972.26)" id="122">
             <desc>VL48</desc>
-            <circle r="27.50" id="123" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="123" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-865.91,1803.56)" id="124">
             <desc>VL49</desc>
-            <circle r="27.50" id="125" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="125" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-226.14,-2597.43)" id="126">
             <desc>VL5</desc>
-            <circle r="27.50" id="127" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="127" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1216.28,2348.42)" id="128">
             <desc>VL50</desc>
-            <circle r="27.50" id="129" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="129" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1735.70,1570.73)" id="130">
             <desc>VL51</desc>
-            <circle r="27.50" id="131" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="131" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2270.25,1451.22)" id="132">
             <desc>VL52</desc>
-            <circle r="27.50" id="133" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="133" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2450.66,1826.24)" id="134">
             <desc>VL53</desc>
-            <circle r="27.50" id="135" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="135" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1871.19,2164.77)" id="136">
             <desc>VL54</desc>
-            <circle r="27.50" id="137" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="137" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2172.24,2632.80)" id="138">
             <desc>VL55</desc>
-            <circle r="27.50" id="139" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="139" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2047.32,2402.77)" id="140">
             <desc>VL56</desc>
-            <circle r="27.50" id="141" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="141" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1757.65,2835.12)" id="142">
             <desc>VL57</desc>
-            <circle r="27.50" id="143" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="143" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2080.07,1873.46)" id="144">
             <desc>VL58</desc>
-            <circle r="27.50" id="145" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="145" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1684.36,2545.40)" id="146">
             <desc>VL59</desc>
-            <circle r="27.50" id="147" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="147" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-227.75,-3078.89)" id="148">
             <desc>VL6</desc>
-            <circle r="27.50" id="149" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="149" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1272.84,2998.10)" id="150">
             <desc>VL60</desc>
-            <circle r="27.50" id="151" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="151" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1237.34,2662.22)" id="152">
             <desc>VL61</desc>
-            <circle r="27.50" id="153" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="153" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-856.69,2833.88)" id="154">
             <desc>VL62</desc>
-            <circle r="27.50" id="155" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="155" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1522.71,2138.63)" id="156">
             <desc>VL63</desc>
-            <circle r="27.50" id="157" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="157" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-1223.07,1924.77)" id="158">
             <desc>VL64</desc>
-            <circle r="27.50" id="159" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="159" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-838.01,1302.47)" id="160">
             <desc>VL65</desc>
-            <circle r="27.50" id="161" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="161" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-724.94,2291.00)" id="162">
             <desc>VL66</desc>
-            <circle r="27.50" id="163" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="163" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-485.47,2800.21)" id="164">
             <desc>VL67</desc>
-            <circle r="27.50" id="165" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="165" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-432.82,839.16)" id="166">
             <desc>VL68</desc>
-            <circle r="27.50" id="167" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="167" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-737.13,811.74)" id="168">
             <desc>VL69</desc>
-            <circle r="27.50" id="169" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="169" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(119.58,-2950.52)" id="170">
             <desc>VL7</desc>
-            <circle r="27.50" id="171" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="171" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1569.94,376.64)" id="172">
             <desc>VL70</desc>
-            <circle r="27.50" id="173" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="173" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2262.47,427.94)" id="174">
             <desc>VL71</desc>
-            <circle r="27.50" id="175" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="175" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2481.37,82.57)" id="176">
             <desc>VL72</desc>
-            <circle r="27.50" id="177" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="177" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-2719.03,566.35)" id="178">
             <desc>VL73</desc>
-            <circle r="27.50" id="179" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="179" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1291.18,229.09)" id="180">
             <desc>VL74</desc>
-            <circle r="27.50" id="181" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="181" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-873.64,301.84)" id="182">
             <desc>VL75</desc>
-            <circle r="27.50" id="183" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="183" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-207.79,-92.40)" id="184">
             <desc>VL76</desc>
-            <circle r="27.50" id="185" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="185" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(183.20,161.49)" id="186">
             <desc>VL77</desc>
-            <circle r="27.50" id="187" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="187" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(565.97,-268.02)" id="188">
             <desc>VL78</desc>
-            <circle r="27.50" id="189" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="189" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(911.14,-480.58)" id="190">
             <desc>VL79</desc>
-            <circle r="27.50" id="191" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="191" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-822.77,-2072.63)" id="192">
             <desc>VL8</desc>
-            <circle r="27.50" id="193" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="193" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(1115.02,-106.19)" id="194">
             <desc>VL80</desc>
-            <circle r="27.50" id="195" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="195" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(555.40,284.23)" id="196">
             <desc>VL81</desc>
-            <circle r="27.50" id="197" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="197" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(1185.49,633.29)" id="198">
             <desc>VL82</desc>
-            <circle r="27.50" id="199" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="199" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1720.46,1225.26)" id="200">
             <desc>VL83</desc>
-            <circle r="27.50" id="201" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="201" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1872.65,1592.24)" id="202">
             <desc>VL84</desc>
-            <circle r="27.50" id="203" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="203" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2254.32,1505.38)" id="204">
             <desc>VL85</desc>
-            <circle r="27.50" id="205" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="205" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2297.43,2057.25)" id="206">
             <desc>VL86</desc>
-            <circle r="27.50" id="207" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="207" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2281.30,2465.48)" id="208">
             <desc>VL87</desc>
-            <circle r="27.50" id="209" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="209" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2651.27,1470.48)" id="210">
             <desc>VL88</desc>
-            <circle r="27.50" id="211" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="211" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2679.94,1059.28)" id="212">
             <desc>VL89</desc>
-            <circle r="27.50" id="213" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="213" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-1110.36,-2546.02)" id="214">
             <desc>VL9</desc>
-            <circle r="27.50" id="215" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="215" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(3119.18,992.09)" id="216">
             <desc>VL90</desc>
-            <circle r="27.50" id="217" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="217" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(3112.24,597.31)" id="218">
             <desc>VL91</desc>
-            <circle r="27.50" id="219" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="219" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2692.64,288.03)" id="220">
             <desc>VL92</desc>
-            <circle r="27.50" id="221" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="221" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2425.16,462.49)" id="222">
             <desc>VL93</desc>
-            <circle r="27.50" id="223" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="223" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(2198.12,143.57)" id="224">
             <desc>VL94</desc>
-            <circle r="27.50" id="225" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="225" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1924.07,428.77)" id="226">
             <desc>VL95</desc>
-            <circle r="27.50" id="227" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="227" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1578.37,285.28)" id="228">
             <desc>VL96</desc>
-            <circle r="27.50" id="229" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="229" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1406.49,11.44)" id="230">
             <desc>VL97</desc>
-            <circle r="27.50" id="231" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="231" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1634.60,-576.38)" id="232">
             <desc>VL98</desc>
-            <circle r="27.50" id="233" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="233" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1794.79,-295.58)" id="234">
             <desc>VL99</desc>
-            <circle r="27.50" id="235" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="235" class="nad-vl120to180-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="236">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="741.14,-2948.08 766.47,-2794.78"/>
+                <polyline class="nad-edge-path" points="741.14,-2948.08 766.47,-2794.78"/>
                 <g class="nad-edge-infos" transform="translate(746.44,-2916.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.62)">
@@ -1042,7 +1040,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="791.80,-2641.47 766.47,-2794.78"/>
+                <polyline class="nad-edge-path" points="791.80,-2641.47 766.47,-2794.78"/>
                 <g class="nad-edge-infos" transform="translate(786.50,-2673.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.38)">
@@ -1064,7 +1062,7 @@
         <g id="237">
             <desc>L1-3-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="716.36,-2958.25 542.93,-2832.17"/>
+                <polyline class="nad-edge-path" points="716.36,-2958.25 542.93,-2832.17"/>
                 <g class="nad-edge-infos" transform="translate(690.07,-2939.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.02)">
@@ -1083,7 +1081,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="369.50,-2706.08 542.93,-2832.17"/>
+                <polyline class="nad-edge-path" points="369.50,-2706.08 542.93,-2832.17"/>
                 <g class="nad-edge-infos" transform="translate(395.79,-2725.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.98)">
@@ -1105,7 +1103,7 @@
         <g id="238">
             <desc>L9-10-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1122.28,-2568.56 -1208.91,-2732.35"/>
+                <polyline class="nad-edge-path" points="-1122.28,-2568.56 -1208.91,-2732.35"/>
                 <g class="nad-edge-infos" transform="translate(-1137.48,-2597.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.87)">
@@ -1124,7 +1122,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-1295.53,-2896.14 -1208.91,-2732.35"/>
+                <polyline class="nad-edge-path" points="-1295.53,-2896.14 -1208.91,-2732.35"/>
                 <g class="nad-edge-infos" transform="translate(-1280.34,-2867.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.13)">
@@ -1146,7 +1144,7 @@
         <g id="239">
             <desc>L92-100-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2681.48,265.10 2508.24,-90.81"/>
+                <polyline class="nad-edge-path" points="2681.48,265.10 2508.24,-90.81"/>
                 <g class="nad-edge-infos" transform="translate(2667.25,235.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.95)">
@@ -1165,7 +1163,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2335.01,-446.73 2508.24,-90.81"/>
+                <polyline class="nad-edge-path" points="2335.01,-446.73 2508.24,-90.81"/>
                 <g class="nad-edge-infos" transform="translate(2349.23,-417.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.05)">
@@ -1187,7 +1185,7 @@
         <g id="240">
             <desc>L94-100-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2203.24,118.59 2260.98,-163.04"/>
+                <polyline class="nad-edge-path" points="2203.24,118.59 2260.98,-163.04"/>
                 <g class="nad-edge-infos" transform="translate(2209.77,86.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.59)">
@@ -1206,7 +1204,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2318.72,-444.68 2260.98,-163.04"/>
+                <polyline class="nad-edge-path" points="2318.72,-444.68 2260.98,-163.04"/>
                 <g class="nad-edge-infos" transform="translate(2312.20,-412.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.41)">
@@ -1228,7 +1226,7 @@
         <g id="241">
             <desc>L98-100-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1659.80,-572.48 1979.22,-523.02"/>
+                <polyline class="nad-edge-path" points="1659.80,-572.48 1979.22,-523.02"/>
                 <g class="nad-edge-infos" transform="translate(1691.91,-567.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.80)">
@@ -1247,7 +1245,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2298.65,-473.56 1979.22,-523.02"/>
+                <polyline class="nad-edge-path" points="2298.65,-473.56 1979.22,-523.02"/>
                 <g class="nad-edge-infos" transform="translate(2266.53,-478.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.20)">
@@ -1269,7 +1267,7 @@
         <g id="242">
             <desc>L99-100-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1819.01,-303.55 2059.32,-382.62"/>
+                <polyline class="nad-edge-path" points="1819.01,-303.55 2059.32,-382.62"/>
                 <g class="nad-edge-infos" transform="translate(1849.89,-313.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.79)">
@@ -1288,7 +1286,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2299.62,-461.69 2059.32,-382.62"/>
+                <polyline class="nad-edge-path" points="2299.62,-461.69 2059.32,-382.62"/>
                 <g class="nad-edge-infos" transform="translate(2268.75,-451.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.21)">
@@ -1310,7 +1308,7 @@
         <g id="243">
             <desc>L100-101-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2347.83,-460.99 2555.79,-385.77"/>
+                <polyline class="nad-edge-path" points="2347.83,-460.99 2555.79,-385.77"/>
                 <g class="nad-edge-infos" transform="translate(2378.39,-449.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.88)">
@@ -1329,7 +1327,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2763.76,-310.56 2555.79,-385.77"/>
+                <polyline class="nad-edge-path" points="2763.76,-310.56 2555.79,-385.77"/>
                 <g class="nad-edge-infos" transform="translate(2733.20,-321.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.12)">
@@ -1351,7 +1349,7 @@
         <g id="244">
             <desc>L100-103-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2323.65,-495.16 2320.89,-858.25"/>
+                <polyline class="nad-edge-path" points="2323.65,-495.16 2320.89,-858.25"/>
                 <g class="nad-edge-infos" transform="translate(2323.40,-527.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.44)">
@@ -1370,7 +1368,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2318.12,-1221.35 2320.89,-858.25"/>
+                <polyline class="nad-edge-path" points="2318.12,-1221.35 2320.89,-858.25"/>
                 <g class="nad-edge-infos" transform="translate(2318.37,-1188.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.56)">
@@ -1392,7 +1390,7 @@
         <g id="245">
             <desc>L100-104-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2327.50,-494.89 2357.25,-700.06"/>
+                <polyline class="nad-edge-path" points="2327.50,-494.89 2357.25,-700.06"/>
                 <g class="nad-edge-infos" transform="translate(2332.17,-527.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.25)">
@@ -1411,7 +1409,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2387.00,-905.22 2357.25,-700.06"/>
+                <polyline class="nad-edge-path" points="2387.00,-905.22 2357.25,-700.06"/>
                 <g class="nad-edge-infos" transform="translate(2382.34,-873.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.75)">
@@ -1433,7 +1431,7 @@
         <g id="246">
             <desc>L100-106-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2344.33,-484.84 2570.70,-652.59"/>
+                <polyline class="nad-edge-path" points="2344.33,-484.84 2570.70,-652.59"/>
                 <g class="nad-edge-infos" transform="translate(2370.44,-504.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(53.46)">
@@ -1452,7 +1450,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2797.07,-820.34 2570.70,-652.59"/>
+                <polyline class="nad-edge-path" points="2797.07,-820.34 2570.70,-652.59"/>
                 <g class="nad-edge-infos" transform="translate(2770.96,-800.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-126.54)">
@@ -1474,7 +1472,7 @@
         <g id="247">
             <desc>L101-102-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2804.03,-282.27 2912.83,-151.25"/>
+                <polyline class="nad-edge-path" points="2804.03,-282.27 2912.83,-151.25"/>
                 <g class="nad-edge-infos" transform="translate(2824.80,-257.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.30)">
@@ -1493,7 +1491,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3021.62,-20.23 2912.83,-151.25"/>
+                <polyline class="nad-edge-path" points="3021.62,-20.23 2912.83,-151.25"/>
                 <g class="nad-edge-infos" transform="translate(3000.86,-45.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.70)">
@@ -1515,7 +1513,7 @@
         <g id="248">
             <desc>L92-102-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2712.20,271.67 2865.27,143.71"/>
+                <polyline class="nad-edge-path" points="2712.20,271.67 2865.27,143.71"/>
                 <g class="nad-edge-infos" transform="translate(2737.13,250.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.11)">
@@ -1534,7 +1532,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3018.35,15.75 2865.27,143.71"/>
+                <polyline class="nad-edge-path" points="3018.35,15.75 2865.27,143.71"/>
                 <g class="nad-edge-infos" transform="translate(2993.41,36.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.89)">
@@ -1556,7 +1554,7 @@
         <g id="249">
             <desc>L103-104-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2323.64,-1222.00 2354.29,-1088.65"/>
+                <polyline class="nad-edge-path" points="2323.64,-1222.00 2354.29,-1088.65"/>
                 <g class="nad-edge-infos" transform="translate(2330.92,-1190.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.05)">
@@ -1575,7 +1573,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2384.95,-955.31 2354.29,-1088.65"/>
+                <polyline class="nad-edge-path" points="2384.95,-955.31 2354.29,-1088.65"/>
                 <g class="nad-edge-infos" transform="translate(2377.67,-986.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.95)">
@@ -1597,7 +1595,7 @@
         <g id="250">
             <desc>L103-105-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2343.41,-1245.84 2529.69,-1238.49"/>
+                <polyline class="nad-edge-path" points="2343.41,-1245.84 2529.69,-1238.49"/>
                 <g class="nad-edge-infos" transform="translate(2375.88,-1244.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.26)">
@@ -1616,7 +1614,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2715.97,-1231.14 2529.69,-1238.49"/>
+                <polyline class="nad-edge-path" points="2715.97,-1231.14 2529.69,-1238.49"/>
                 <g class="nad-edge-infos" transform="translate(2683.50,-1232.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.74)">
@@ -1638,7 +1636,7 @@
         <g id="251">
             <desc>L103-110-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2315.19,-1272.20 2282.78,-1572.97"/>
+                <polyline class="nad-edge-path" points="2315.19,-1272.20 2282.78,-1572.97"/>
                 <g class="nad-edge-infos" transform="translate(2311.71,-1304.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.15)">
@@ -1657,7 +1655,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2250.36,-1873.74 2282.78,-1572.97"/>
+                <polyline class="nad-edge-path" points="2250.36,-1873.74 2282.78,-1572.97"/>
                 <g class="nad-edge-infos" transform="translate(2253.84,-1841.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.85)">
@@ -1679,7 +1677,7 @@
         <g id="252">
             <desc>L104-105-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2410.05,-947.02 2566.06,-1080.30"/>
+                <polyline class="nad-edge-path" points="2410.05,-947.02 2566.06,-1080.30"/>
                 <g class="nad-edge-infos" transform="translate(2434.76,-968.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.49)">
@@ -1698,7 +1696,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2722.06,-1213.57 2566.06,-1080.30"/>
+                <polyline class="nad-edge-path" points="2722.06,-1213.57 2566.06,-1080.30"/>
                 <g class="nad-edge-infos" transform="translate(2697.35,-1192.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.51)">
@@ -1720,7 +1718,7 @@
         <g id="253">
             <desc>L105-106-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2746.28,-1205.10 2779.50,-1032.83"/>
+                <polyline class="nad-edge-path" points="2746.28,-1205.10 2779.50,-1032.83"/>
                 <g class="nad-edge-infos" transform="translate(2752.43,-1173.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.08)">
@@ -1739,7 +1737,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2812.73,-860.56 2779.50,-1032.83"/>
+                <polyline class="nad-edge-path" points="2812.73,-860.56 2779.50,-1032.83"/>
                 <g class="nad-edge-infos" transform="translate(2806.57,-892.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.92)">
@@ -1761,7 +1759,7 @@
         <g id="254">
             <desc>L105-107-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2765.28,-1221.07 2934.23,-1156.75"/>
+                <polyline class="nad-edge-path" points="2765.28,-1221.07 2934.23,-1156.75"/>
                 <g class="nad-edge-infos" transform="translate(2795.66,-1209.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.84)">
@@ -1780,7 +1778,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3103.19,-1092.44 2934.23,-1156.75"/>
+                <polyline class="nad-edge-path" points="3103.19,-1092.44 2934.23,-1156.75"/>
                 <g class="nad-edge-infos" transform="translate(3072.81,-1104.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.16)">
@@ -1802,7 +1800,7 @@
         <g id="255">
             <desc>L105-108-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2749.57,-1254.31 2818.75,-1460.35"/>
+                <polyline class="nad-edge-path" points="2749.57,-1254.31 2818.75,-1460.35"/>
                 <g class="nad-edge-infos" transform="translate(2759.91,-1285.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.56)">
@@ -1821,7 +1819,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2887.94,-1666.39 2818.75,-1460.35"/>
+                <polyline class="nad-edge-path" points="2887.94,-1666.39 2818.75,-1460.35"/>
                 <g class="nad-edge-infos" transform="translate(2877.59,-1635.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.44)">
@@ -1843,7 +1841,7 @@
         <g id="256">
             <desc>L106-107-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2837.46,-851.46 2972.29,-959.44"/>
+                <polyline class="nad-edge-path" points="2837.46,-851.46 2972.29,-959.44"/>
                 <g class="nad-edge-infos" transform="translate(2862.83,-871.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.31)">
@@ -1862,7 +1860,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3107.12,-1067.43 2972.29,-959.44"/>
+                <polyline class="nad-edge-path" points="3107.12,-1067.43 2972.29,-959.44"/>
                 <g class="nad-edge-infos" transform="translate(3081.75,-1047.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.69)">
@@ -1884,7 +1882,7 @@
         <g id="257">
             <desc>L108-109-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2881.02,-1711.16 2780.68,-1848.59"/>
+                <polyline class="nad-edge-path" points="2881.02,-1711.16 2780.68,-1848.59"/>
                 <g class="nad-edge-infos" transform="translate(2861.85,-1737.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.13)">
@@ -1903,7 +1901,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2680.34,-1986.03 2780.68,-1848.59"/>
+                <polyline class="nad-edge-path" points="2680.34,-1986.03 2780.68,-1848.59"/>
                 <g class="nad-edge-infos" transform="translate(2699.51,-1959.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.87)">
@@ -1925,7 +1923,7 @@
         <g id="258">
             <desc>L109-110-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2640.61,-2000.27 2456.47,-1952.86"/>
+                <polyline class="nad-edge-path" points="2640.61,-2000.27 2456.47,-1952.86"/>
                 <g class="nad-edge-infos" transform="translate(2609.14,-1992.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.44)">
@@ -1944,7 +1942,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2272.32,-1905.45 2456.47,-1952.86"/>
+                <polyline class="nad-edge-path" points="2272.32,-1905.45 2456.47,-1952.86"/>
                 <g class="nad-edge-infos" transform="translate(2303.79,-1913.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.56)">
@@ -1966,7 +1964,7 @@
         <g id="259">
             <desc>L4-11-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-434.35,-2423.92 -261.80,-2324.23"/>
+                <polyline class="nad-edge-path" points="-434.35,-2423.92 -261.80,-2324.23"/>
                 <g class="nad-edge-infos" transform="translate(-406.21,-2407.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.01)">
@@ -1985,7 +1983,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-89.24,-2224.55 -261.80,-2324.23"/>
+                <polyline class="nad-edge-path" points="-89.24,-2224.55 -261.80,-2324.23"/>
                 <g class="nad-edge-infos" transform="translate(-117.38,-2240.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.99)">
@@ -2007,7 +2005,7 @@
         <g id="260">
             <desc>L5-11-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-216.42,-2573.85 -146.65,-2404.61"/>
+                <polyline class="nad-edge-path" points="-216.42,-2573.85 -146.65,-2404.61"/>
                 <g class="nad-edge-infos" transform="translate(-204.03,-2543.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.60)">
@@ -2026,7 +2024,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-76.88,-2235.37 -146.65,-2404.61"/>
+                <polyline class="nad-edge-path" points="-76.88,-2235.37 -146.65,-2404.61"/>
                 <g class="nad-edge-infos" transform="translate(-89.27,-2265.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.40)">
@@ -2048,7 +2046,7 @@
         <g id="261">
             <desc>L11-12-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-42.09,-2216.48 130.04,-2248.63"/>
+                <polyline class="nad-edge-path" points="-42.09,-2216.48 130.04,-2248.63"/>
                 <g class="nad-edge-infos" transform="translate(-10.15,-2222.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
@@ -2067,7 +2065,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="302.18,-2280.78 130.04,-2248.63"/>
+                <polyline class="nad-edge-path" points="302.18,-2280.78 130.04,-2248.63"/>
                 <g class="nad-edge-infos" transform="translate(270.23,-2274.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
@@ -2089,7 +2087,7 @@
         <g id="262">
             <desc>L11-13-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-64.84,-2186.40 -40.19,-1916.37"/>
+                <polyline class="nad-edge-path" points="-64.84,-2186.40 -40.19,-1916.37"/>
                 <g class="nad-edge-infos" transform="translate(-61.89,-2154.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.78)">
@@ -2108,7 +2106,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-15.55,-1646.34 -40.19,-1916.37"/>
+                <polyline class="nad-edge-path" points="-15.55,-1646.34 -40.19,-1916.37"/>
                 <g class="nad-edge-infos" transform="translate(-18.50,-1678.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.22)">
@@ -2130,7 +2128,7 @@
         <g id="263">
             <desc>L110-111-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2223.48,-1907.29 2053.03,-1965.10"/>
+                <polyline class="nad-edge-path" points="2223.48,-1907.29 2053.03,-1965.10"/>
                 <g class="nad-edge-infos" transform="translate(2192.70,-1917.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.26)">
@@ -2149,7 +2147,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1882.59,-2022.92 2053.03,-1965.10"/>
+                <polyline class="nad-edge-path" points="1882.59,-2022.92 2053.03,-1965.10"/>
                 <g class="nad-edge-infos" transform="translate(1913.37,-2012.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.74)">
@@ -2171,7 +2169,7 @@
         <g id="264">
             <desc>L110-112-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2246.95,-1924.59 2241.32,-2135.72"/>
+                <polyline class="nad-edge-path" points="2246.95,-1924.59 2241.32,-2135.72"/>
                 <g class="nad-edge-infos" transform="translate(2246.08,-1957.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.53)">
@@ -2190,7 +2188,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2235.69,-2346.85 2241.32,-2135.72"/>
+                <polyline class="nad-edge-path" points="2235.69,-2346.85 2241.32,-2135.72"/>
                 <g class="nad-edge-infos" transform="translate(2236.55,-2314.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.47)">
@@ -2212,7 +2210,7 @@
         <g id="265">
             <desc>L17-113-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-837.13,-1468.79 -1098.76,-1496.41"/>
+                <polyline class="nad-edge-path" points="-837.13,-1468.79 -1098.76,-1496.41"/>
                 <g class="nad-edge-infos" transform="translate(-869.45,-1472.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.98)">
@@ -2231,7 +2229,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1360.40,-1524.02 -1098.76,-1496.41"/>
+                <polyline class="nad-edge-path" points="-1360.40,-1524.02 -1098.76,-1496.41"/>
                 <g class="nad-edge-infos" transform="translate(-1328.08,-1520.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.02)">
@@ -2253,7 +2251,7 @@
         <g id="266">
             <desc>L32-113-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1990.65,-1543.21 -1700.95,-1535.30"/>
+                <polyline class="nad-edge-path" points="-1990.65,-1543.21 -1700.95,-1535.30"/>
                 <g class="nad-edge-infos" transform="translate(-1958.17,-1542.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(91.56)">
@@ -2272,7 +2270,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1411.25,-1527.39 -1700.95,-1535.30"/>
+                <polyline class="nad-edge-path" points="-1411.25,-1527.39 -1700.95,-1535.30"/>
                 <g class="nad-edge-infos" transform="translate(-1443.74,-1528.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-88.44)">
@@ -2294,7 +2292,7 @@
         <g id="267">
             <desc>L32-114-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2039.26,-1554.67 -2315.77,-1683.48"/>
+                <polyline class="nad-edge-path" points="-2039.26,-1554.67 -2315.77,-1683.48"/>
                 <g class="nad-edge-infos" transform="translate(-2068.72,-1568.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -2313,7 +2311,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2592.28,-1812.29 -2315.77,-1683.48"/>
+                <polyline class="nad-edge-path" points="-2592.28,-1812.29 -2315.77,-1683.48"/>
                 <g class="nad-edge-infos" transform="translate(-2562.82,-1798.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">
@@ -2335,7 +2333,7 @@
         <g id="268">
             <desc>L114-115-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2634.46,-1806.13 -2741.72,-1710.82"/>
+                <polyline class="nad-edge-path" points="-2634.46,-1806.13 -2741.72,-1710.82"/>
                 <g class="nad-edge-infos" transform="translate(-2658.75,-1784.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.62)">
@@ -2354,7 +2352,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2848.98,-1615.52 -2741.72,-1710.82"/>
+                <polyline class="nad-edge-path" points="-2848.98,-1615.52 -2741.72,-1710.82"/>
                 <g class="nad-edge-infos" transform="translate(-2824.69,-1637.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.38)">
@@ -2376,7 +2374,7 @@
         <g id="269">
             <desc>L27-115-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2421.50,-1576.96 -2632.04,-1587.16"/>
+                <polyline class="nad-edge-path" points="-2421.50,-1576.96 -2632.04,-1587.16"/>
                 <g class="nad-edge-infos" transform="translate(-2453.96,-1578.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.23)">
@@ -2395,7 +2393,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2842.58,-1597.35 -2632.04,-1587.16"/>
+                <polyline class="nad-edge-path" points="-2842.58,-1597.35 -2632.04,-1587.16"/>
                 <g class="nad-edge-infos" transform="translate(-2810.12,-1595.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.77)">
@@ -2417,7 +2415,7 @@
         <g id="270">
             <desc>L68-116-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-458.27,840.80 -751.79,859.68"/>
+                <polyline class="nad-edge-path" points="-458.27,840.80 -751.79,859.68"/>
                 <g class="nad-edge-infos" transform="translate(-490.70,842.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
@@ -2436,7 +2434,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-1045.31,878.56 -751.79,859.68"/>
+                <polyline class="nad-edge-path" points="-1045.31,878.56 -751.79,859.68"/>
                 <g class="nad-edge-infos" transform="translate(-1012.88,876.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
@@ -2458,7 +2456,7 @@
         <g id="271">
             <desc>L12-117-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="351.38,-2277.23 555.32,-2207.69"/>
+                <polyline class="nad-edge-path" points="351.38,-2277.23 555.32,-2207.69"/>
                 <g class="nad-edge-infos" transform="translate(382.14,-2266.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.83)">
@@ -2477,7 +2475,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="759.26,-2138.15 555.32,-2207.69"/>
+                <polyline class="nad-edge-path" points="759.26,-2138.15 555.32,-2207.69"/>
                 <g class="nad-edge-infos" transform="translate(728.50,-2148.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.17)">
@@ -2499,7 +2497,7 @@
         <g id="272">
             <desc>L75-118-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-861.66,279.33 -771.02,108.98"/>
+                <polyline class="nad-edge-path" points="-861.66,279.33 -771.02,108.98"/>
                 <g class="nad-edge-infos" transform="translate(-846.40,250.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.02)">
@@ -2518,7 +2516,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-680.37,-61.36 -771.02,108.98"/>
+                <polyline class="nad-edge-path" points="-680.37,-61.36 -771.02,108.98"/>
                 <g class="nad-edge-infos" transform="translate(-695.64,-32.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.98)">
@@ -2540,7 +2538,7 @@
         <g id="273">
             <desc>L76-118-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-233.29,-91.93 -438.09,-88.14"/>
+                <polyline class="nad-edge-path" points="-233.29,-91.93 -438.09,-88.14"/>
                 <g class="nad-edge-infos" transform="translate(-265.78,-91.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.06)">
@@ -2559,7 +2557,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-642.89,-84.35 -438.09,-88.14"/>
+                <polyline class="nad-edge-path" points="-642.89,-84.35 -438.09,-88.14"/>
                 <g class="nad-edge-infos" transform="translate(-610.40,-84.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.94)">
@@ -2581,7 +2579,7 @@
         <g id="274">
             <desc>L2-12-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="775.12,-2601.61 561.60,-2450.89"/>
+                <polyline class="nad-edge-path" points="775.12,-2601.61 561.60,-2450.89"/>
                 <g class="nad-edge-infos" transform="translate(748.57,-2582.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.22)">
@@ -2600,7 +2598,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="348.08,-2300.16 561.60,-2450.89"/>
+                <polyline class="nad-edge-path" points="348.08,-2300.16 561.60,-2450.89"/>
                 <g class="nad-edge-infos" transform="translate(374.63,-2318.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.78)">
@@ -2622,7 +2620,7 @@
         <g id="275">
             <desc>L3-12-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="347.52,-2665.63 338.06,-2488.27"/>
+                <polyline class="nad-edge-path" points="347.52,-2665.63 338.06,-2488.27"/>
                 <g class="nad-edge-infos" transform="translate(345.79,-2633.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.95)">
@@ -2641,7 +2639,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="328.60,-2310.92 338.06,-2488.27"/>
+                <polyline class="nad-edge-path" points="328.60,-2310.92 338.06,-2488.27"/>
                 <g class="nad-edge-infos" transform="translate(330.33,-2343.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.05)">
@@ -2663,7 +2661,7 @@
         <g id="276">
             <desc>L7-12-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="127.18,-2926.18 223.42,-2617.99"/>
+                <polyline class="nad-edge-path" points="127.18,-2926.18 223.42,-2617.99"/>
                 <g class="nad-edge-infos" transform="translate(136.87,-2895.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(162.66)">
@@ -2682,7 +2680,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="319.65,-2309.80 223.42,-2617.99"/>
+                <polyline class="nad-edge-path" points="319.65,-2309.80 223.42,-2617.99"/>
                 <g class="nad-edge-infos" transform="translate(309.96,-2340.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.34)">
@@ -2704,7 +2702,7 @@
         <g id="277">
             <desc>L12-14-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="328.63,-2260.00 344.33,-1971.29"/>
+                <polyline class="nad-edge-path" points="328.63,-2260.00 344.33,-1971.29"/>
                 <g class="nad-edge-infos" transform="translate(330.40,-2227.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.89)">
@@ -2723,7 +2721,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="360.03,-1682.58 344.33,-1971.29"/>
+                <polyline class="nad-edge-path" points="360.03,-1682.58 344.33,-1971.29"/>
                 <g class="nad-edge-infos" transform="translate(358.26,-1715.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.11)">
@@ -2745,7 +2743,7 @@
         <g id="278">
             <desc>L12-16-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="305.88,-2271.54 7.32,-2077.10"/>
+                <polyline class="nad-edge-path" points="305.88,-2271.54 7.32,-2077.10"/>
                 <g class="nad-edge-infos" transform="translate(278.64,-2253.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.07)">
@@ -2764,7 +2762,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-291.23,-1882.66 7.32,-2077.10"/>
+                <polyline class="nad-edge-path" points="-291.23,-1882.66 7.32,-2077.10"/>
                 <g class="nad-edge-infos" transform="translate(-264.00,-1900.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.93)">
@@ -2786,7 +2784,7 @@
         <g id="279">
             <desc>L13-15-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-17.53,-1595.82 -54.07,-1382.36"/>
+                <polyline class="nad-edge-path" points="-17.53,-1595.82 -54.07,-1382.36"/>
                 <g class="nad-edge-infos" transform="translate(-23.01,-1563.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.29)">
@@ -2805,7 +2803,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-90.60,-1168.90 -54.07,-1382.36"/>
+                <polyline class="nad-edge-path" points="-90.60,-1168.90 -54.07,-1382.36"/>
                 <g class="nad-edge-infos" transform="translate(-85.12,-1200.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.71)">
@@ -2827,7 +2825,7 @@
         <g id="280">
             <desc>L14-15-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="344.47,-1638.06 133.25,-1400.44"/>
+                <polyline class="nad-edge-path" points="344.47,-1638.06 133.25,-1400.44"/>
                 <g class="nad-edge-infos" transform="translate(322.88,-1613.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.37)">
@@ -2846,7 +2844,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-77.96,-1162.82 133.25,-1400.44"/>
+                <polyline class="nad-edge-path" points="-77.96,-1162.82 133.25,-1400.44"/>
                 <g class="nad-edge-infos" transform="translate(-56.37,-1187.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.63)">
@@ -2868,7 +2866,7 @@
         <g id="281">
             <desc>L15-17-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-118.16,-1154.22 -453.34,-1304.94"/>
+                <polyline class="nad-edge-path" points="-118.16,-1154.22 -453.34,-1304.94"/>
                 <g class="nad-edge-infos" transform="translate(-147.80,-1167.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.79)">
@@ -2887,7 +2885,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-788.51,-1455.66 -453.34,-1304.94"/>
+                <polyline class="nad-edge-path" points="-788.51,-1455.66 -453.34,-1304.94"/>
                 <g class="nad-edge-infos" transform="translate(-758.87,-1442.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.21)">
@@ -2909,7 +2907,7 @@
         <g id="282">
             <desc>L15-19-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-107.20,-1121.42 -252.89,-856.57"/>
+                <polyline class="nad-edge-path" points="-107.20,-1121.42 -252.89,-856.57"/>
                 <g class="nad-edge-infos" transform="translate(-122.86,-1092.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.18)">
@@ -2928,7 +2926,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-398.59,-591.72 -252.89,-856.57"/>
+                <polyline class="nad-edge-path" points="-398.59,-591.72 -252.89,-856.57"/>
                 <g class="nad-edge-infos" transform="translate(-382.93,-620.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.82)">
@@ -2950,7 +2948,7 @@
         <g id="283">
             <desc>L15-33-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-86.63,-1119.64 23.00,-800.06"/>
+                <polyline class="nad-edge-path" points="-86.63,-1119.64 23.00,-800.06"/>
                 <g class="nad-edge-infos" transform="translate(-76.09,-1088.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.07)">
@@ -2969,7 +2967,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="132.62,-480.48 23.00,-800.06"/>
+                <polyline class="nad-edge-path" points="132.62,-480.48 23.00,-800.06"/>
                 <g class="nad-edge-infos" transform="translate(122.08,-511.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.93)">
@@ -2991,7 +2989,7 @@
         <g id="284">
             <desc>L16-17-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-332.45,-1852.74 -562.18,-1667.43"/>
+                <polyline class="nad-edge-path" points="-332.45,-1852.74 -562.18,-1667.43"/>
                 <g class="nad-edge-infos" transform="translate(-357.75,-1832.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-128.89)">
@@ -3010,7 +3008,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-791.92,-1482.12 -562.18,-1667.43"/>
+                <polyline class="nad-edge-path" points="-791.92,-1482.12 -562.18,-1667.43"/>
                 <g class="nad-edge-infos" transform="translate(-766.62,-1502.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(51.11)">
@@ -3032,7 +3030,7 @@
         <g id="285">
             <desc>L17-18-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-798.25,-1444.49 -680.14,-1255.53"/>
+                <polyline class="nad-edge-path" points="-798.25,-1444.49 -680.14,-1255.53"/>
                 <g class="nad-edge-infos" transform="translate(-781.03,-1416.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.99)">
@@ -3051,7 +3049,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-562.03,-1066.57 -680.14,-1255.53"/>
+                <polyline class="nad-edge-path" points="-562.03,-1066.57 -680.14,-1255.53"/>
                 <g class="nad-edge-infos" transform="translate(-579.26,-1094.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.01)">
@@ -3073,7 +3071,7 @@
         <g id="286">
             <desc>L17-31-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-834.46,-1477.75 -1187.55,-1658.70"/>
+                <polyline class="nad-edge-path" points="-834.46,-1477.75 -1187.55,-1658.70"/>
                 <g class="nad-edge-infos" transform="translate(-863.38,-1492.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.87)">
@@ -3092,7 +3090,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1540.65,-1839.64 -1187.55,-1658.70"/>
+                <polyline class="nad-edge-path" points="-1540.65,-1839.64 -1187.55,-1658.70"/>
                 <g class="nad-edge-infos" transform="translate(-1511.72,-1824.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.13)">
@@ -3114,7 +3112,7 @@
         <g id="287">
             <desc>T30-17-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-958.74,-1088.27 -900.75,-1237.35"/>
+                <polyline class="nad-edge-path" points="-958.74,-1088.27 -900.75,-1237.35"/>
                 <g class="nad-edge-infos" transform="translate(-946.96,-1118.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.26)">
@@ -3131,10 +3129,10 @@
                         <text transform="rotate(-68.74)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-893.50" cy="-1255.99" r="20.00"/>
+                <circle class="nad-winding" cx="-893.50" cy="-1255.99" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-821.01,-1442.35 -879.00,-1293.27"/>
+                <polyline class="nad-edge-path" points="-821.01,-1442.35 -879.00,-1293.27"/>
                 <g class="nad-edge-infos" transform="translate(-832.79,-1412.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.74)">
@@ -3151,13 +3149,13 @@
                         <text transform="rotate(-68.74)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-886.25" cy="-1274.63" r="20.00"/>
+                <circle class="nad-winding" cx="-886.25" cy="-1274.63" r="20.00"/>
             </g>
         </g>
         <g id="288">
             <desc>L18-19-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-541.42,-1020.45 -479.70,-807.16"/>
+                <polyline class="nad-edge-path" points="-541.42,-1020.45 -479.70,-807.16"/>
                 <g class="nad-edge-infos" transform="translate(-532.39,-989.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.86)">
@@ -3176,7 +3174,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-417.97,-593.87 -479.70,-807.16"/>
+                <polyline class="nad-edge-path" points="-417.97,-593.87 -479.70,-807.16"/>
                 <g class="nad-edge-infos" transform="translate(-427.01,-625.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.14)">
@@ -3198,7 +3196,7 @@
         <g id="289">
             <desc>L19-20-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-436.36,-568.15 -706.46,-555.11"/>
+                <polyline class="nad-edge-path" points="-436.36,-568.15 -706.46,-555.11"/>
                 <g class="nad-edge-infos" transform="translate(-468.82,-566.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.76)">
@@ -3217,7 +3215,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-976.57,-542.08 -706.46,-555.11"/>
+                <polyline class="nad-edge-path" points="-976.57,-542.08 -706.46,-555.11"/>
                 <g class="nad-edge-infos" transform="translate(-944.11,-543.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.24)">
@@ -3239,7 +3237,7 @@
         <g id="290">
             <desc>L19-34-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-403.51,-544.97 -249.35,-35.09"/>
+                <polyline class="nad-edge-path" points="-403.51,-544.97 -249.35,-35.09"/>
                 <g class="nad-edge-infos" transform="translate(-394.10,-513.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.18)">
@@ -3258,7 +3256,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-95.20,474.80 -249.35,-35.09"/>
+                <polyline class="nad-edge-path" points="-95.20,474.80 -249.35,-35.09"/>
                 <g class="nad-edge-infos" transform="translate(-104.60,443.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.82)">
@@ -3280,7 +3278,7 @@
         <g id="291">
             <desc>L20-21-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1027.49,-539.21 -1249.18,-524.97"/>
+                <polyline class="nad-edge-path" points="-1027.49,-539.21 -1249.18,-524.97"/>
                 <g class="nad-edge-infos" transform="translate(-1059.92,-537.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.68)">
@@ -3299,7 +3297,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1470.87,-510.72 -1249.18,-524.97"/>
+                <polyline class="nad-edge-path" points="-1470.87,-510.72 -1249.18,-524.97"/>
                 <g class="nad-edge-infos" transform="translate(-1438.43,-512.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(86.32)">
@@ -3321,7 +3319,7 @@
         <g id="292">
             <desc>L21-22-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1521.55,-512.77 -1711.44,-540.51"/>
+                <polyline class="nad-edge-path" points="-1521.55,-512.77 -1711.44,-540.51"/>
                 <g class="nad-edge-infos" transform="translate(-1553.71,-517.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.69)">
@@ -3340,7 +3338,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1901.34,-568.25 -1711.44,-540.51"/>
+                <polyline class="nad-edge-path" points="-1901.34,-568.25 -1711.44,-540.51"/>
                 <g class="nad-edge-infos" transform="translate(-1869.18,-563.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.31)">
@@ -3362,7 +3360,7 @@
         <g id="293">
             <desc>L22-23-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1945.83,-588.65 -2064.17,-691.32"/>
+                <polyline class="nad-edge-path" points="-1945.83,-588.65 -2064.17,-691.32"/>
                 <g class="nad-edge-infos" transform="translate(-1970.38,-609.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.05)">
@@ -3381,7 +3379,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2182.51,-793.99 -2064.17,-691.32"/>
+                <polyline class="nad-edge-path" points="-2182.51,-793.99 -2064.17,-691.32"/>
                 <g class="nad-edge-infos" transform="translate(-2157.97,-772.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.95)">
@@ -3403,7 +3401,7 @@
         <g id="294">
             <desc>L23-24-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2198.83,-785.38 -2161.87,-467.14"/>
+                <polyline class="nad-edge-path" points="-2198.83,-785.38 -2161.87,-467.14"/>
                 <g class="nad-edge-infos" transform="translate(-2195.08,-753.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.38)">
@@ -3422,7 +3420,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2124.91,-148.90 -2161.87,-467.14"/>
+                <polyline class="nad-edge-path" points="-2124.91,-148.90 -2161.87,-467.14"/>
                 <g class="nad-edge-infos" transform="translate(-2128.66,-181.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.62)">
@@ -3444,7 +3442,7 @@
         <g id="295">
             <desc>L23-25-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2198.09,-835.94 -2176.10,-986.64"/>
+                <polyline class="nad-edge-path" points="-2198.09,-835.94 -2176.10,-986.64"/>
                 <g class="nad-edge-infos" transform="translate(-2193.40,-868.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.30)">
@@ -3463,7 +3461,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2154.10,-1137.35 -2176.10,-986.64"/>
+                <polyline class="nad-edge-path" points="-2154.10,-1137.35 -2176.10,-986.64"/>
                 <g class="nad-edge-infos" transform="translate(-2158.79,-1105.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.70)">
@@ -3485,7 +3483,7 @@
         <g id="296">
             <desc>L23-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2195.52,-835.43 -2108.96,-1177.30"/>
+                <polyline class="nad-edge-path" points="-2195.52,-835.43 -2108.96,-1177.30"/>
                 <g class="nad-edge-infos" transform="translate(-2187.54,-866.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(14.21)">
@@ -3504,7 +3502,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2022.40,-1519.18 -2108.96,-1177.30"/>
+                <polyline class="nad-edge-path" points="-2022.40,-1519.18 -2108.96,-1177.30"/>
                 <g class="nad-edge-infos" transform="translate(-2030.38,-1487.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-165.79)">
@@ -3526,7 +3524,7 @@
         <g id="297">
             <desc>L24-70-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2103.07,-106.45 -1845.96,126.53"/>
+                <polyline class="nad-edge-path" points="-2103.07,-106.45 -1845.96,126.53"/>
                 <g class="nad-edge-infos" transform="translate(-2078.99,-84.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.18)">
@@ -3545,7 +3543,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1588.84,359.52 -1845.96,126.53"/>
+                <polyline class="nad-edge-path" points="-1588.84,359.52 -1845.96,126.53"/>
                 <g class="nad-edge-infos" transform="translate(-1612.92,337.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.82)">
@@ -3567,7 +3565,7 @@
         <g id="298">
             <desc>L24-72-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2144.09,-110.89 -2301.67,-20.50"/>
+                <polyline class="nad-edge-path" points="-2144.09,-110.89 -2301.67,-20.50"/>
                 <g class="nad-edge-infos" transform="translate(-2172.28,-94.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.84)">
@@ -3586,7 +3584,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2459.25,69.88 -2301.67,-20.50"/>
+                <polyline class="nad-edge-path" points="-2459.25,69.88 -2301.67,-20.50"/>
                 <g class="nad-edge-infos" transform="translate(-2431.05,53.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.16)">
@@ -3608,7 +3606,7 @@
         <g id="299">
             <desc>L25-27-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2163.45,-1184.50 -2273.22,-1369.16"/>
+                <polyline class="nad-edge-path" points="-2163.45,-1184.50 -2273.22,-1369.16"/>
                 <g class="nad-edge-infos" transform="translate(-2180.06,-1212.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.73)">
@@ -3627,7 +3625,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2383.00,-1553.81 -2273.22,-1369.16"/>
+                <polyline class="nad-edge-path" points="-2383.00,-1553.81 -2273.22,-1369.16"/>
                 <g class="nad-edge-infos" transform="translate(-2366.39,-1525.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.27)">
@@ -3649,7 +3647,7 @@
         <g id="300">
             <desc>T26-25-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1610.15,-1098.02 -1837.84,-1125.23"/>
+                <polyline class="nad-edge-path" points="-1610.15,-1098.02 -1837.84,-1125.23"/>
                 <g class="nad-edge-infos" transform="translate(-1642.42,-1101.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.18)">
@@ -3666,10 +3664,10 @@
                         <text transform="rotate(-353.18)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1857.70" cy="-1127.60" r="20.00"/>
+                <circle class="nad-winding" cx="-1857.70" cy="-1127.60" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2125.10,-1159.56 -1897.41,-1132.35"/>
+                <polyline class="nad-edge-path" points="-2125.10,-1159.56 -1897.41,-1132.35"/>
                 <g class="nad-edge-infos" transform="translate(-2092.83,-1155.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.82)">
@@ -3686,13 +3684,13 @@
                         <text transform="rotate(6.82)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1877.56" cy="-1129.97" r="20.00"/>
+                <circle class="nad-winding" cx="-1877.56" cy="-1129.97" r="20.00"/>
             </g>
         </g>
         <g id="301">
             <desc>L26-30-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1559.37,-1093.73 -1276.41,-1079.75"/>
+                <polyline class="nad-edge-path" points="-1559.37,-1093.73 -1276.41,-1079.75"/>
                 <g class="nad-edge-infos" transform="translate(-1526.90,-1092.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.83)">
@@ -3711,7 +3709,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-993.46,-1065.77 -1276.41,-1079.75"/>
+                <polyline class="nad-edge-path" points="-993.46,-1065.77 -1276.41,-1079.75"/>
                 <g class="nad-edge-infos" transform="translate(-1025.92,-1067.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.17)">
@@ -3733,7 +3731,7 @@
         <g id="302">
             <desc>L27-28-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2390.75,-1600.68 -2339.07,-1845.18"/>
+                <polyline class="nad-edge-path" points="-2390.75,-1600.68 -2339.07,-1845.18"/>
                 <g class="nad-edge-infos" transform="translate(-2384.03,-1632.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.93)">
@@ -3752,7 +3750,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2287.39,-2089.69 -2339.07,-1845.18"/>
+                <polyline class="nad-edge-path" points="-2287.39,-2089.69 -2339.07,-1845.18"/>
                 <g class="nad-edge-infos" transform="translate(-2294.11,-2057.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.07)">
@@ -3774,7 +3772,7 @@
         <g id="303">
             <desc>L27-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2370.62,-1573.60 -2206.09,-1559.82"/>
+                <polyline class="nad-edge-path" points="-2370.62,-1573.60 -2206.09,-1559.82"/>
                 <g class="nad-edge-infos" transform="translate(-2338.23,-1570.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(94.79)">
@@ -3793,7 +3791,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2041.56,-1546.03 -2206.09,-1559.82"/>
+                <polyline class="nad-edge-path" points="-2041.56,-1546.03 -2206.09,-1559.82"/>
                 <g class="nad-edge-infos" transform="translate(-2073.94,-1548.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-85.21)">
@@ -3815,7 +3813,7 @@
         <g id="304">
             <desc>L28-29-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2257.46,-2121.14 -2088.85,-2165.65"/>
+                <polyline class="nad-edge-path" points="-2257.46,-2121.14 -2088.85,-2165.65"/>
                 <g class="nad-edge-infos" transform="translate(-2226.04,-2129.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.22)">
@@ -3834,7 +3832,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1920.23,-2210.15 -2088.85,-2165.65"/>
+                <polyline class="nad-edge-path" points="-1920.23,-2210.15 -2088.85,-2165.65"/>
                 <g class="nad-edge-infos" transform="translate(-1951.65,-2201.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.78)">
@@ -3856,7 +3854,7 @@
         <g id="305">
             <desc>L29-31-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1878.42,-2197.79 -1729.46,-2033.97"/>
+                <polyline class="nad-edge-path" points="-1878.42,-2197.79 -1729.46,-2033.97"/>
                 <g class="nad-edge-infos" transform="translate(-1856.55,-2173.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.72)">
@@ -3875,7 +3873,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1580.50,-1870.14 -1729.46,-2033.97"/>
+                <polyline class="nad-edge-path" points="-1580.50,-1870.14 -1729.46,-2033.97"/>
                 <g class="nad-edge-infos" transform="translate(-1602.36,-1894.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.28)">
@@ -3897,7 +3895,7 @@
         <g id="306">
             <desc>L3-5-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="323.71,-2686.99 61.37,-2644.26"/>
+                <polyline class="nad-edge-path" points="323.71,-2686.99 61.37,-2644.26"/>
                 <g class="nad-edge-infos" transform="translate(291.63,-2681.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.25)">
@@ -3916,7 +3914,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-200.97,-2601.53 61.37,-2644.26"/>
+                <polyline class="nad-edge-path" points="-200.97,-2601.53 61.37,-2644.26"/>
                 <g class="nad-edge-infos" transform="translate(-168.89,-2606.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.75)">
@@ -3938,7 +3936,7 @@
         <g id="307">
             <desc>L8-30-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-826.41,-2047.39 -895.38,-1568.57"/>
+                <polyline class="nad-edge-path" points="-826.41,-2047.39 -895.38,-1568.57"/>
                 <g class="nad-edge-infos" transform="translate(-831.04,-2015.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.80)">
@@ -3957,7 +3955,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-964.35,-1089.75 -895.38,-1568.57"/>
+                <polyline class="nad-edge-path" points="-964.35,-1089.75 -895.38,-1568.57"/>
                 <g class="nad-edge-infos" transform="translate(-959.72,-1121.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.20)">
@@ -3979,7 +3977,7 @@
         <g id="308">
             <desc>L30-38-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-959.74,-1040.38 -741.99,-403.62"/>
+                <polyline class="nad-edge-path" points="-959.74,-1040.38 -741.99,-403.62"/>
                 <g class="nad-edge-infos" transform="translate(-949.22,-1009.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.12)">
@@ -3998,7 +3996,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-524.24,233.14 -741.99,-403.62"/>
+                <polyline class="nad-edge-path" points="-524.24,233.14 -741.99,-403.62"/>
                 <g class="nad-edge-infos" transform="translate(-534.76,202.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.88)">
@@ -4020,7 +4018,7 @@
         <g id="309">
             <desc>L31-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1584.44,-1836.95 -1789.74,-1697.59"/>
+                <polyline class="nad-edge-path" points="-1584.44,-1836.95 -1789.74,-1697.59"/>
                 <g class="nad-edge-infos" transform="translate(-1611.33,-1818.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.17)">
@@ -4039,7 +4037,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1995.05,-1558.23 -1789.74,-1697.59"/>
+                <polyline class="nad-edge-path" points="-1995.05,-1558.23 -1789.74,-1697.59"/>
                 <g class="nad-edge-infos" transform="translate(-1968.16,-1576.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.83)">
@@ -4061,7 +4059,7 @@
         <g id="310">
             <desc>L33-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="143.47,-430.99 191.27,41.07"/>
+                <polyline class="nad-edge-path" points="143.47,-430.99 191.27,41.07"/>
                 <g class="nad-edge-infos" transform="translate(146.74,-398.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.22)">
@@ -4080,7 +4078,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="239.08,513.13 191.27,41.07"/>
+                <polyline class="nad-edge-path" points="239.08,513.13 191.27,41.07"/>
                 <g class="nad-edge-infos" transform="translate(235.80,480.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.78)">
@@ -4102,7 +4100,7 @@
         <g id="311">
             <desc>L34-36-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-73.10,520.03 38.67,678.19"/>
+                <polyline class="nad-edge-path" points="-73.10,520.03 38.67,678.19"/>
                 <g class="nad-edge-infos" transform="translate(-54.35,546.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.75)">
@@ -4121,7 +4119,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="150.43,836.34 38.67,678.19"/>
+                <polyline class="nad-edge-path" points="150.43,836.34 38.67,678.19"/>
                 <g class="nad-edge-infos" transform="translate(131.68,809.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.25)">
@@ -4143,7 +4141,7 @@
         <g id="312">
             <desc>L34-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-62.50,502.22 76.91,518.85"/>
+                <polyline class="nad-edge-path" points="-62.50,502.22 76.91,518.85"/>
                 <g class="nad-edge-infos" transform="translate(-30.23,506.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.80)">
@@ -4162,7 +4160,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="216.33,535.48 76.91,518.85"/>
+                <polyline class="nad-edge-path" points="216.33,535.48 76.91,518.85"/>
                 <g class="nad-edge-infos" transform="translate(184.06,531.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-83.20)">
@@ -4184,7 +4182,7 @@
         <g id="313">
             <desc>L34-43-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-83.38,524.31 -16.39,902.95"/>
+                <polyline class="nad-edge-path" points="-83.38,524.31 -16.39,902.95"/>
                 <g class="nad-edge-infos" transform="translate(-77.71,556.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.97)">
@@ -4203,7 +4201,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="50.59,1281.59 -16.39,902.95"/>
+                <polyline class="nad-edge-path" points="50.59,1281.59 -16.39,902.95"/>
                 <g class="nad-edge-infos" transform="translate(44.93,1249.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.03)">
@@ -4225,7 +4223,7 @@
         <g id="314">
             <desc>L35-36-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="499.38,745.65 344.36,797.37"/>
+                <polyline class="nad-edge-path" points="499.38,745.65 344.36,797.37"/>
                 <g class="nad-edge-infos" transform="translate(468.55,755.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.45)">
@@ -4244,7 +4242,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="189.34,849.10 344.36,797.37"/>
+                <polyline class="nad-edge-path" points="189.34,849.10 344.36,797.37"/>
                 <g class="nad-edge-infos" transform="translate(220.17,838.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.55)">
@@ -4266,7 +4264,7 @@
         <g id="315">
             <desc>L35-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="502.74,722.87 382.61,638.04"/>
+                <polyline class="nad-edge-path" points="502.74,722.87 382.61,638.04"/>
                 <g class="nad-edge-infos" transform="translate(476.19,704.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.77)">
@@ -4285,7 +4283,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="262.48,553.21 382.61,638.04"/>
+                <polyline class="nad-edge-path" points="262.48,553.21 382.61,638.04"/>
                 <g class="nad-edge-infos" transform="translate(289.03,571.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.23)">
@@ -4307,7 +4305,7 @@
         <g id="316">
             <desc>L37-39-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="259.02,557.17 474.53,788.88"/>
+                <polyline class="nad-edge-path" points="259.02,557.17 474.53,788.88"/>
                 <g class="nad-edge-infos" transform="translate(281.15,580.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.07)">
@@ -4326,7 +4324,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="690.05,1020.59 474.53,788.88"/>
+                <polyline class="nad-edge-path" points="690.05,1020.59 474.53,788.88"/>
                 <g class="nad-edge-infos" transform="translate(667.92,996.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.93)">
@@ -4348,7 +4346,7 @@
         <g id="317">
             <desc>L37-40-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="249.84,562.65 377.19,938.11"/>
+                <polyline class="nad-edge-path" points="249.84,562.65 377.19,938.11"/>
                 <g class="nad-edge-infos" transform="translate(260.28,593.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(161.26)">
@@ -4367,7 +4365,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="504.55,1313.57 377.19,938.11"/>
+                <polyline class="nad-edge-path" points="504.55,1313.57 377.19,938.11"/>
                 <g class="nad-edge-infos" transform="translate(494.11,1282.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-18.74)">
@@ -4389,7 +4387,7 @@
         <g id="318">
             <desc>T38-37-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-492.08,266.14 -165.30,387.44"/>
+                <polyline class="nad-edge-path" points="-492.08,266.14 -165.30,387.44"/>
                 <g class="nad-edge-infos" transform="translate(-461.62,277.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.36)">
@@ -4406,10 +4404,10 @@
                         <text transform="rotate(20.36)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-146.55" cy="394.40" r="20.00"/>
+                <circle class="nad-winding" cx="-146.55" cy="394.40" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="217.74,529.62 -109.05,408.32"/>
+                <polyline class="nad-edge-path" points="217.74,529.62 -109.05,408.32"/>
                 <g class="nad-edge-infos" transform="translate(187.27,518.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.64)">
@@ -4426,13 +4424,13 @@
                         <text transform="rotate(-339.64)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-127.80" cy="401.36" r="20.00"/>
+                <circle class="nad-winding" cx="-127.80" cy="401.36" r="20.00"/>
             </g>
         </g>
         <g id="319">
             <desc>L38-65-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-523.50,281.64 -677.00,779.87"/>
+                <polyline class="nad-edge-path" points="-523.50,281.64 -677.00,779.87"/>
                 <g class="nad-edge-infos" transform="translate(-533.07,312.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.88)">
@@ -4451,7 +4449,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-830.51,1278.10 -677.00,779.87"/>
+                <polyline class="nad-edge-path" points="-830.51,1278.10 -677.00,779.87"/>
                 <g class="nad-edge-infos" transform="translate(-820.94,1247.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.12)">
@@ -4473,7 +4471,7 @@
         <g id="320">
             <desc>L39-40-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="693.49,1060.62 610.08,1188.49"/>
+                <polyline class="nad-edge-path" points="693.49,1060.62 610.08,1188.49"/>
                 <g class="nad-edge-infos" transform="translate(675.73,1087.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-146.88)">
@@ -4492,7 +4490,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="526.67,1316.36 610.08,1188.49"/>
+                <polyline class="nad-edge-path" points="526.67,1316.36 610.08,1188.49"/>
                 <g class="nad-edge-infos" transform="translate(544.43,1289.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(33.12)">
@@ -4514,7 +4512,7 @@
         <g id="321">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-435.52,-2451.27 -341.29,-2517.05"/>
+                <polyline class="nad-edge-path" points="-435.52,-2451.27 -341.29,-2517.05"/>
                 <g class="nad-edge-infos" transform="translate(-408.88,-2469.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.08)">
@@ -4533,7 +4531,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-247.05,-2582.83 -341.29,-2517.05"/>
+                <polyline class="nad-edge-path" points="-247.05,-2582.83 -341.29,-2517.05"/>
                 <g class="nad-edge-infos" transform="translate(-273.70,-2564.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.92)">
@@ -4555,7 +4553,7 @@
         <g id="322">
             <desc>L40-41-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="519.67,1362.26 573.48,1552.73"/>
+                <polyline class="nad-edge-path" points="519.67,1362.26 573.48,1552.73"/>
                 <g class="nad-edge-infos" transform="translate(528.51,1393.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.23)">
@@ -4574,7 +4572,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="627.28,1743.21 573.48,1552.73"/>
+                <polyline class="nad-edge-path" points="627.28,1743.21 573.48,1552.73"/>
                 <g class="nad-edge-infos" transform="translate(618.44,1711.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.77)">
@@ -4596,7 +4594,7 @@
         <g id="323">
             <desc>L40-42-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="494.73,1355.77 331.36,1519.60"/>
+                <polyline class="nad-edge-path" points="494.73,1355.77 331.36,1519.60"/>
                 <g class="nad-edge-infos" transform="translate(471.79,1378.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.08)">
@@ -4615,7 +4613,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="167.99,1683.42 331.36,1519.60"/>
+                <polyline class="nad-edge-path" points="167.99,1683.42 331.36,1519.60"/>
                 <g class="nad-edge-infos" transform="translate(190.94,1660.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.92)">
@@ -4637,7 +4635,7 @@
         <g id="324">
             <desc>L41-42-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="608.95,1764.29 392.10,1734.62"/>
+                <polyline class="nad-edge-path" points="608.95,1764.29 392.10,1734.62"/>
                 <g class="nad-edge-infos" transform="translate(576.75,1759.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.21)">
@@ -4656,7 +4654,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="175.25,1704.94 392.10,1734.62"/>
+                <polyline class="nad-edge-path" points="175.25,1704.94 392.10,1734.62"/>
                 <g class="nad-edge-infos" transform="translate(207.45,1709.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.79)">
@@ -4678,7 +4676,7 @@
         <g id="325">
             <desc>L42-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="126.74,1691.00 77.05,1668.61 -361.96,1712.72"/>
+                <polyline class="nad-edge-path" points="126.74,1691.00 77.05,1668.61 -361.96,1712.72"/>
                 <g class="nad-edge-infos" transform="translate(47.20,1671.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
@@ -4697,7 +4695,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-845.21,1788.67 -800.97,1756.83 -361.96,1712.72"/>
+                <polyline class="nad-edge-path" points="-845.21,1788.67 -800.97,1756.83 -361.96,1712.72"/>
                 <g class="nad-edge-infos" transform="translate(-771.12,1753.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
@@ -4719,7 +4717,7 @@
         <g id="326">
             <desc>L42-49-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="129.29,1716.37 85.05,1748.21 -353.96,1792.32"/>
+                <polyline class="nad-edge-path" points="129.29,1716.37 85.05,1748.21 -353.96,1792.32"/>
                 <g class="nad-edge-infos" transform="translate(55.20,1751.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.74)">
@@ -4738,7 +4736,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-842.66,1814.04 -792.97,1836.43 -353.96,1792.32"/>
+                <polyline class="nad-edge-path" points="-842.66,1814.04 -792.97,1836.43 -353.96,1792.32"/>
                 <g class="nad-edge-infos" transform="translate(-763.12,1833.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.26)">
@@ -4760,7 +4758,7 @@
         <g id="327">
             <desc>L43-44-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="59.97,1331.72 128.77,1680.25"/>
+                <polyline class="nad-edge-path" points="59.97,1331.72 128.77,1680.25"/>
                 <g class="nad-edge-infos" transform="translate(66.26,1363.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.83)">
@@ -4779,7 +4777,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="197.56,2028.79 128.77,1680.25"/>
+                <polyline class="nad-edge-path" points="197.56,2028.79 128.77,1680.25"/>
                 <g class="nad-edge-infos" transform="translate(191.27,1996.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.17)">
@@ -4801,7 +4799,7 @@
         <g id="328">
             <desc>L44-45-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="177.59,2059.27 -0.88,2098.41"/>
+                <polyline class="nad-edge-path" points="177.59,2059.27 -0.88,2098.41"/>
                 <g class="nad-edge-infos" transform="translate(145.84,2066.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.37)">
@@ -4820,7 +4818,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-179.34,2137.55 -0.88,2098.41"/>
+                <polyline class="nad-edge-path" points="-179.34,2137.55 -0.88,2098.41"/>
                 <g class="nad-edge-infos" transform="translate(-147.60,2130.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.63)">
@@ -4842,7 +4840,7 @@
         <g id="329">
             <desc>L45-46-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-211.62,2118.60 -255.95,1971.75"/>
+                <polyline class="nad-edge-path" points="-211.62,2118.60 -255.95,1971.75"/>
                 <g class="nad-edge-infos" transform="translate(-221.01,2087.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.80)">
@@ -4861,7 +4859,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-300.28,1824.89 -255.95,1971.75"/>
+                <polyline class="nad-edge-path" points="-300.28,1824.89 -255.95,1971.75"/>
                 <g class="nad-edge-infos" transform="translate(-290.89,1856.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.20)">
@@ -4883,7 +4881,7 @@
         <g id="330">
             <desc>L45-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-226.94,2131.38 -535.08,1973.29"/>
+                <polyline class="nad-edge-path" points="-226.94,2131.38 -535.08,1973.29"/>
                 <g class="nad-edge-infos" transform="translate(-255.85,2116.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.84)">
@@ -4902,7 +4900,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-843.22,1815.20 -535.08,1973.29"/>
+                <polyline class="nad-edge-path" points="-843.22,1815.20 -535.08,1973.29"/>
                 <g class="nad-edge-infos" transform="translate(-814.30,1830.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.16)">
@@ -4924,7 +4922,7 @@
         <g id="331">
             <desc>L46-47-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-322.39,1779.68 -434.67,1621.29"/>
+                <polyline class="nad-edge-path" points="-322.39,1779.68 -434.67,1621.29"/>
                 <g class="nad-edge-infos" transform="translate(-341.19,1753.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.33)">
@@ -4943,7 +4941,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-546.94,1462.90 -434.67,1621.29"/>
+                <polyline class="nad-edge-path" points="-546.94,1462.90 -434.67,1621.29"/>
                 <g class="nad-edge-infos" transform="translate(-528.14,1489.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.67)">
@@ -4965,7 +4963,7 @@
         <g id="332">
             <desc>L46-48-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-328.92,1814.53 -437.70,1886.37"/>
+                <polyline class="nad-edge-path" points="-328.92,1814.53 -437.70,1886.37"/>
                 <g class="nad-edge-infos" transform="translate(-356.04,1832.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.44)">
@@ -4984,7 +4982,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-546.47,1958.20 -437.70,1886.37"/>
+                <polyline class="nad-edge-path" points="-546.47,1958.20 -437.70,1886.37"/>
                 <g class="nad-edge-infos" transform="translate(-519.35,1940.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.56)">
@@ -5006,7 +5004,7 @@
         <g id="333">
             <desc>L47-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-578.11,1461.61 -713.80,1622.83"/>
+                <polyline class="nad-edge-path" points="-578.11,1461.61 -713.80,1622.83"/>
                 <g class="nad-edge-infos" transform="translate(-599.03,1486.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.91)">
@@ -5025,7 +5023,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-849.48,1784.05 -713.80,1622.83"/>
+                <polyline class="nad-edge-path" points="-849.48,1784.05 -713.80,1622.83"/>
                 <g class="nad-edge-infos" transform="translate(-828.56,1759.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.09)">
@@ -5047,7 +5045,7 @@
         <g id="334">
             <desc>L47-69-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-568.52,1417.54 -649.41,1126.92"/>
+                <polyline class="nad-edge-path" points="-568.52,1417.54 -649.41,1126.92"/>
                 <g class="nad-edge-infos" transform="translate(-577.24,1386.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-15.55)">
@@ -5066,7 +5064,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-730.29,836.30 -649.41,1126.92"/>
+                <polyline class="nad-edge-path" points="-730.29,836.30 -649.41,1126.92"/>
                 <g class="nad-edge-infos" transform="translate(-721.58,867.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(164.45)">
@@ -5088,7 +5086,7 @@
         <g id="335">
             <desc>L48-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-589.94,1959.70 -716.83,1887.91"/>
+                <polyline class="nad-edge-path" points="-589.94,1959.70 -716.83,1887.91"/>
                 <g class="nad-edge-infos" transform="translate(-618.23,1943.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.50)">
@@ -5107,7 +5105,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-843.71,1816.12 -716.83,1887.91"/>
+                <polyline class="nad-edge-path" points="-843.71,1816.12 -716.83,1887.91"/>
                 <g class="nad-edge-infos" transform="translate(-815.42,1832.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.50)">
@@ -5129,7 +5127,7 @@
         <g id="336">
             <desc>L49-50-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-879.70,1825.01 -1041.09,2075.99"/>
+                <polyline class="nad-edge-path" points="-879.70,1825.01 -1041.09,2075.99"/>
                 <g class="nad-edge-infos" transform="translate(-897.28,1852.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.26)">
@@ -5148,7 +5146,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1202.49,2326.97 -1041.09,2075.99"/>
+                <polyline class="nad-edge-path" points="-1202.49,2326.97 -1041.09,2075.99"/>
                 <g class="nad-edge-infos" transform="translate(-1184.91,2299.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.74)">
@@ -5170,7 +5168,7 @@
         <g id="337">
             <desc>L49-51-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-890.54,1796.97 -1300.80,1687.14"/>
+                <polyline class="nad-edge-path" points="-890.54,1796.97 -1300.80,1687.14"/>
                 <g class="nad-edge-infos" transform="translate(-921.93,1788.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.01)">
@@ -5189,7 +5187,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1711.06,1577.32 -1300.80,1687.14"/>
+                <polyline class="nad-edge-path" points="-1711.06,1577.32 -1300.80,1687.14"/>
                 <g class="nad-edge-infos" transform="translate(-1679.67,1585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.99)">
@@ -5211,7 +5209,7 @@
         <g id="338">
             <desc>L49-54-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-891.00,1799.03 -944.63,1789.34 -1382.08,1946.52"/>
+                <polyline class="nad-edge-path" points="-891.00,1799.03 -944.63,1789.34 -1382.08,1946.52"/>
                 <g class="nad-edge-infos" transform="translate(-972.86,1799.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
@@ -5230,7 +5228,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1854.72,2145.30 -1819.52,2103.70 -1382.08,1946.52"/>
+                <polyline class="nad-edge-path" points="-1854.72,2145.30 -1819.52,2103.70 -1382.08,1946.52"/>
                 <g class="nad-edge-infos" transform="translate(-1791.29,2093.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
@@ -5252,7 +5250,7 @@
         <g id="339">
             <desc>L49-54-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-882.38,1823.03 -917.58,1864.63 -1355.02,2021.81"/>
+                <polyline class="nad-edge-path" points="-882.38,1823.03 -917.58,1864.63 -1355.02,2021.81"/>
                 <g class="nad-edge-infos" transform="translate(-945.81,1874.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.76)">
@@ -5271,7 +5269,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1846.10,2169.30 -1792.47,2178.98 -1355.02,2021.81"/>
+                <polyline class="nad-edge-path" points="-1846.10,2169.30 -1792.47,2178.98 -1355.02,2021.81"/>
                 <g class="nad-edge-infos" transform="translate(-1764.23,2168.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.24)">
@@ -5293,7 +5291,7 @@
         <g id="340">
             <desc>L49-66-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-872.02,1828.32 -885.08,1881.23 -833.85,2058.39"/>
+                <polyline class="nad-edge-path" points="-872.02,1828.32 -885.08,1881.23 -833.85,2058.39"/>
                 <g class="nad-edge-infos" transform="translate(-876.75,1910.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
@@ -5312,7 +5310,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-743.32,2273.33 -782.61,2235.56 -833.85,2058.39"/>
+                <polyline class="nad-edge-path" points="-743.32,2273.33 -782.61,2235.56 -833.85,2058.39"/>
                 <g class="nad-edge-infos" transform="translate(-790.94,2206.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
@@ -5334,7 +5332,7 @@
         <g id="341">
             <desc>L49-66-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-847.52,1821.23 -808.23,1859.00 -757.00,2036.17"/>
+                <polyline class="nad-edge-path" points="-847.52,1821.23 -808.23,1859.00 -757.00,2036.17"/>
                 <g class="nad-edge-infos" transform="translate(-799.90,1887.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.87)">
@@ -5353,7 +5351,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-718.82,2266.24 -705.76,2213.33 -757.00,2036.17"/>
+                <polyline class="nad-edge-path" points="-718.82,2266.24 -705.76,2213.33 -757.00,2036.17"/>
                 <g class="nad-edge-infos" transform="translate(-714.09,2184.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.13)">
@@ -5375,7 +5373,7 @@
         <g id="342">
             <desc>L49-69-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-862.62,1778.27 -801.52,1307.65"/>
+                <polyline class="nad-edge-path" points="-862.62,1778.27 -801.52,1307.65"/>
                 <g class="nad-edge-infos" transform="translate(-858.44,1746.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(7.40)">
@@ -5394,7 +5392,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-740.41,837.03 -801.52,1307.65"/>
+                <polyline class="nad-edge-path" points="-740.41,837.03 -801.52,1307.65"/>
                 <g class="nad-edge-infos" transform="translate(-744.60,869.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-172.60)">
@@ -5416,7 +5414,7 @@
         <g id="343">
             <desc>L5-6-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-226.22,-2622.93 -226.94,-2838.16"/>
+                <polyline class="nad-edge-path" points="-226.22,-2622.93 -226.94,-2838.16"/>
                 <g class="nad-edge-infos" transform="translate(-226.33,-2655.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.19)">
@@ -5435,7 +5433,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-227.66,-3053.39 -226.94,-2838.16"/>
+                <polyline class="nad-edge-path" points="-227.66,-3053.39 -226.94,-2838.16"/>
                 <g class="nad-edge-infos" transform="translate(-227.55,-3020.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.81)">
@@ -5457,7 +5455,7 @@
         <g id="344">
             <desc>T8-5-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-803.63,-2089.47 -546.98,-2315.22"/>
+                <polyline class="nad-edge-path" points="-803.63,-2089.47 -546.98,-2315.22"/>
                 <g class="nad-edge-infos" transform="translate(-779.22,-2110.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.67)">
@@ -5474,10 +5472,10 @@
                         <text transform="rotate(-41.33)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-531.96" cy="-2328.43" r="20.00"/>
+                <circle class="nad-winding" cx="-531.96" cy="-2328.43" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-245.29,-2580.59 -501.93,-2354.84"/>
+                <polyline class="nad-edge-path" points="-245.29,-2580.59 -501.93,-2354.84"/>
                 <g class="nad-edge-infos" transform="translate(-269.69,-2559.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.33)">
@@ -5494,13 +5492,13 @@
                         <text transform="rotate(-41.33)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-516.95" cy="-2341.64" r="20.00"/>
+                <circle class="nad-winding" cx="-516.95" cy="-2341.64" r="20.00"/>
             </g>
         </g>
         <g id="345">
             <desc>L50-57-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1235.24,2365.47 -1486.97,2591.77"/>
+                <polyline class="nad-edge-path" points="-1235.24,2365.47 -1486.97,2591.77"/>
                 <g class="nad-edge-infos" transform="translate(-1259.41,2387.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.96)">
@@ -5519,7 +5517,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1738.69,2818.07 -1486.97,2591.77"/>
+                <polyline class="nad-edge-path" points="-1738.69,2818.07 -1486.97,2591.77"/>
                 <g class="nad-edge-infos" transform="translate(-1714.52,2796.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.04)">
@@ -5541,7 +5539,7 @@
         <g id="346">
             <desc>L51-52-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1760.58,1565.16 -2002.97,1510.97"/>
+                <polyline class="nad-edge-path" points="-1760.58,1565.16 -2002.97,1510.97"/>
                 <g class="nad-edge-infos" transform="translate(-1792.30,1558.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.40)">
@@ -5560,7 +5558,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2245.36,1456.78 -2002.97,1510.97"/>
+                <polyline class="nad-edge-path" points="-2245.36,1456.78 -2002.97,1510.97"/>
                 <g class="nad-edge-infos" transform="translate(-2213.64,1463.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.60)">
@@ -5582,7 +5580,7 @@
         <g id="347">
             <desc>L51-58-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1754.85,1587.56 -1907.88,1722.09"/>
+                <polyline class="nad-edge-path" points="-1754.85,1587.56 -1907.88,1722.09"/>
                 <g class="nad-edge-infos" transform="translate(-1779.26,1609.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.32)">
@@ -5601,7 +5599,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2060.92,1856.62 -1907.88,1722.09"/>
+                <polyline class="nad-edge-path" points="-2060.92,1856.62 -1907.88,1722.09"/>
                 <g class="nad-edge-infos" transform="translate(-2036.51,1835.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.68)">
@@ -5623,7 +5621,7 @@
         <g id="348">
             <desc>L52-53-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2281.30,1474.19 -2360.45,1638.73"/>
+                <polyline class="nad-edge-path" points="-2281.30,1474.19 -2360.45,1638.73"/>
                 <g class="nad-edge-infos" transform="translate(-2295.39,1503.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.31)">
@@ -5642,7 +5640,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2439.61,1803.26 -2360.45,1638.73"/>
+                <polyline class="nad-edge-path" points="-2439.61,1803.26 -2360.45,1638.73"/>
                 <g class="nad-edge-infos" transform="translate(-2425.52,1773.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.69)">
@@ -5664,7 +5662,7 @@
         <g id="349">
             <desc>L53-54-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2428.64,1839.11 -2160.93,1995.51"/>
+                <polyline class="nad-edge-path" points="-2428.64,1839.11 -2160.93,1995.51"/>
                 <g class="nad-edge-infos" transform="translate(-2400.58,1855.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.29)">
@@ -5683,7 +5681,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1893.21,2151.91 -2160.93,1995.51"/>
+                <polyline class="nad-edge-path" points="-1893.21,2151.91 -2160.93,1995.51"/>
                 <g class="nad-edge-infos" transform="translate(-1921.27,2135.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.71)">
@@ -5705,7 +5703,7 @@
         <g id="350">
             <desc>L54-55-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1884.99,2186.21 -2021.72,2398.78"/>
+                <polyline class="nad-edge-path" points="-1884.99,2186.21 -2021.72,2398.78"/>
                 <g class="nad-edge-infos" transform="translate(-1902.57,2213.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-147.25)">
@@ -5724,7 +5722,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2158.44,2611.35 -2021.72,2398.78"/>
+                <polyline class="nad-edge-path" points="-2158.44,2611.35 -2021.72,2398.78"/>
                 <g class="nad-edge-infos" transform="translate(-2140.86,2584.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(32.75)">
@@ -5746,7 +5744,7 @@
         <g id="351">
             <desc>L54-56-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1886.36,2185.27 -1959.26,2283.77"/>
+                <polyline class="nad-edge-path" points="-1886.36,2185.27 -1959.26,2283.77"/>
                 <g class="nad-edge-infos" transform="translate(-1905.70,2211.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-143.50)">
@@ -5765,7 +5763,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2032.15,2382.28 -1959.26,2283.77"/>
+                <polyline class="nad-edge-path" points="-2032.15,2382.28 -1959.26,2283.77"/>
                 <g class="nad-edge-infos" transform="translate(-2012.82,2356.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(36.50)">
@@ -5787,7 +5785,7 @@
         <g id="352">
             <desc>L54-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1859.96,2187.66 -1777.78,2355.09"/>
+                <polyline class="nad-edge-path" points="-1859.96,2187.66 -1777.78,2355.09"/>
                 <g class="nad-edge-infos" transform="translate(-1845.64,2216.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.86)">
@@ -5806,7 +5804,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1695.60,2522.51 -1777.78,2355.09"/>
+                <polyline class="nad-edge-path" points="-1695.60,2522.51 -1777.78,2355.09"/>
                 <g class="nad-edge-infos" transform="translate(-1709.92,2493.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.14)">
@@ -5828,7 +5826,7 @@
         <g id="353">
             <desc>L55-56-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2160.07,2610.39 -2109.78,2517.79"/>
+                <polyline class="nad-edge-path" points="-2160.07,2610.39 -2109.78,2517.79"/>
                 <g class="nad-edge-infos" transform="translate(-2144.56,2581.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.50)">
@@ -5847,7 +5845,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2059.49,2425.18 -2109.78,2517.79"/>
+                <polyline class="nad-edge-path" points="-2059.49,2425.18 -2109.78,2517.79"/>
                 <g class="nad-edge-infos" transform="translate(-2075.00,2453.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.50)">
@@ -5869,7 +5867,7 @@
         <g id="354">
             <desc>L55-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2147.14,2628.30 -1928.30,2589.10"/>
+                <polyline class="nad-edge-path" points="-2147.14,2628.30 -1928.30,2589.10"/>
                 <g class="nad-edge-infos" transform="translate(-2115.15,2622.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.84)">
@@ -5888,7 +5886,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1709.46,2549.90 -1928.30,2589.10"/>
+                <polyline class="nad-edge-path" points="-1709.46,2549.90 -1928.30,2589.10"/>
                 <g class="nad-edge-infos" transform="translate(-1741.45,2555.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.16)">
@@ -5910,7 +5908,7 @@
         <g id="355">
             <desc>L56-57-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2033.13,2423.96 -1902.49,2618.95"/>
+                <polyline class="nad-edge-path" points="-2033.13,2423.96 -1902.49,2618.95"/>
                 <g class="nad-edge-infos" transform="translate(-2015.04,2450.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.18)">
@@ -5929,7 +5927,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1771.84,2813.94 -1902.49,2618.95"/>
+                <polyline class="nad-edge-path" points="-1771.84,2813.94 -1902.49,2618.95"/>
                 <g class="nad-edge-infos" transform="translate(-1789.93,2786.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.82)">
@@ -5951,7 +5949,7 @@
         <g id="356">
             <desc>L56-58-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2048.89,2377.32 -2063.69,2138.11"/>
+                <polyline class="nad-edge-path" points="-2048.89,2377.32 -2063.69,2138.11"/>
                 <g class="nad-edge-infos" transform="translate(-2050.90,2344.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.54)">
@@ -5970,7 +5968,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2078.49,1898.91 -2063.69,2138.11"/>
+                <polyline class="nad-edge-path" points="-2078.49,1898.91 -2063.69,2138.11"/>
                 <g class="nad-edge-infos" transform="translate(-2076.49,1931.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.46)">
@@ -5992,7 +5990,7 @@
         <g id="357">
             <desc>L56-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2031.43,2422.72 -1997.47,2465.34 -1880.47,2511.32"/>
+                <polyline class="nad-edge-path" points="-2031.43,2422.72 -1997.47,2465.34 -1880.47,2511.32"/>
                 <g class="nad-edge-infos" transform="translate(-1969.55,2476.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
@@ -6011,7 +6009,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1709.58,2549.19 -1763.47,2557.29 -1880.47,2511.32"/>
+                <polyline class="nad-edge-path" points="-1709.58,2549.19 -1763.47,2557.29 -1880.47,2511.32"/>
                 <g class="nad-edge-infos" transform="translate(-1791.39,2546.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
@@ -6033,7 +6031,7 @@
         <g id="358">
             <desc>L56-59-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2022.10,2398.98 -1968.21,2390.88 -1851.21,2436.86"/>
+                <polyline class="nad-edge-path" points="-2022.10,2398.98 -1968.21,2390.88 -1851.21,2436.86"/>
                 <g class="nad-edge-infos" transform="translate(-1940.29,2401.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.45)">
@@ -6052,7 +6050,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1700.25,2525.46 -1734.21,2482.84 -1851.21,2436.86"/>
+                <polyline class="nad-edge-path" points="-1700.25,2525.46 -1734.21,2482.84 -1851.21,2436.86"/>
                 <g class="nad-edge-infos" transform="translate(-1762.14,2471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.55)">
@@ -6074,7 +6072,7 @@
         <g id="359">
             <desc>L59-60-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1667.21,2564.27 -1478.60,2771.75"/>
+                <polyline class="nad-edge-path" points="-1667.21,2564.27 -1478.60,2771.75"/>
                 <g class="nad-edge-infos" transform="translate(-1645.35,2588.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.73)">
@@ -6093,7 +6091,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1289.99,2979.23 -1478.60,2771.75"/>
+                <polyline class="nad-edge-path" points="-1289.99,2979.23 -1478.60,2771.75"/>
                 <g class="nad-edge-infos" transform="translate(-1311.86,2955.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.27)">
@@ -6115,7 +6113,7 @@
         <g id="360">
             <desc>L59-61-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1659.69,2551.85 -1460.85,2603.81"/>
+                <polyline class="nad-edge-path" points="-1659.69,2551.85 -1460.85,2603.81"/>
                 <g class="nad-edge-infos" transform="translate(-1628.25,2560.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.65)">
@@ -6134,7 +6132,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1262.01,2655.77 -1460.85,2603.81"/>
+                <polyline class="nad-edge-path" points="-1262.01,2655.77 -1460.85,2603.81"/>
                 <g class="nad-edge-infos" transform="translate(-1293.46,2647.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.35)">
@@ -6156,7 +6154,7 @@
         <g id="361">
             <desc>T63-59-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1532.12,2162.33 -1592.46,2314.14"/>
+                <polyline class="nad-edge-path" points="-1532.12,2162.33 -1592.46,2314.14"/>
                 <g class="nad-edge-infos" transform="translate(-1544.13,2192.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.33)">
@@ -6173,10 +6171,10 @@
                         <text transform="rotate(-68.33)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1599.84" cy="2332.72" r="20.00"/>
+                <circle class="nad-winding" cx="-1599.84" cy="2332.72" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1674.94,2521.71 -1614.61,2369.90"/>
+                <polyline class="nad-edge-path" points="-1674.94,2521.71 -1614.61,2369.90"/>
                 <g class="nad-edge-infos" transform="translate(-1662.94,2491.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.67)">
@@ -6193,13 +6191,13 @@
                         <text transform="rotate(-68.33)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1607.23" cy="2351.31" r="20.00"/>
+                <circle class="nad-winding" cx="-1607.23" cy="2351.31" r="20.00"/>
             </g>
         </g>
         <g id="362">
             <desc>L6-7-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-203.83,-3070.05 -54.08,-3014.71"/>
+                <polyline class="nad-edge-path" points="-203.83,-3070.05 -54.08,-3014.71"/>
                 <g class="nad-edge-infos" transform="translate(-173.34,-3058.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.28)">
@@ -6218,7 +6216,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="95.67,-2959.36 -54.08,-3014.71"/>
+                <polyline class="nad-edge-path" points="95.67,-2959.36 -54.08,-3014.71"/>
                 <g class="nad-edge-infos" transform="translate(65.18,-2970.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.72)">
@@ -6240,7 +6238,7 @@
         <g id="363">
             <desc>L60-61-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1270.16,2972.74 -1255.09,2830.16"/>
+                <polyline class="nad-edge-path" points="-1270.16,2972.74 -1255.09,2830.16"/>
                 <g class="nad-edge-infos" transform="translate(-1266.75,2940.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.03)">
@@ -6259,7 +6257,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1240.02,2687.58 -1255.09,2830.16"/>
+                <polyline class="nad-edge-path" points="-1240.02,2687.58 -1255.09,2830.16"/>
                 <g class="nad-edge-infos" transform="translate(-1243.44,2719.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.97)">
@@ -6281,7 +6279,7 @@
         <g id="364">
             <desc>L60-62-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1249.12,2988.74 -1064.77,2915.99"/>
+                <polyline class="nad-edge-path" points="-1249.12,2988.74 -1064.77,2915.99"/>
                 <g class="nad-edge-infos" transform="translate(-1218.89,2976.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.47)">
@@ -6300,7 +6298,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-880.41,2843.24 -1064.77,2915.99"/>
+                <polyline class="nad-edge-path" points="-880.41,2843.24 -1064.77,2915.99"/>
                 <g class="nad-edge-infos" transform="translate(-910.64,2855.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.53)">
@@ -6322,7 +6320,7 @@
         <g id="365">
             <desc>L61-62-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1214.10,2672.70 -1047.02,2748.05"/>
+                <polyline class="nad-edge-path" points="-1214.10,2672.70 -1047.02,2748.05"/>
                 <g class="nad-edge-infos" transform="translate(-1184.47,2686.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.27)">
@@ -6341,7 +6339,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-879.94,2823.40 -1047.02,2748.05"/>
+                <polyline class="nad-edge-path" points="-879.94,2823.40 -1047.02,2748.05"/>
                 <g class="nad-edge-infos" transform="translate(-909.56,2810.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.73)">
@@ -6363,7 +6361,7 @@
         <g id="366">
             <desc>T64-61-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1223.56,1950.26 -1229.63,2263.50"/>
+                <polyline class="nad-edge-path" points="-1223.56,1950.26 -1229.63,2263.50"/>
                 <g class="nad-edge-infos" transform="translate(-1224.19,1982.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.89)">
@@ -6380,10 +6378,10 @@
                         <text transform="rotate(-88.89)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1230.01" cy="2283.50" r="20.00"/>
+                <circle class="nad-winding" cx="-1230.01" cy="2283.50" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1236.85,2636.73 -1230.79,2323.49"/>
+                <polyline class="nad-edge-path" points="-1236.85,2636.73 -1230.79,2323.49"/>
                 <g class="nad-edge-infos" transform="translate(-1236.22,2604.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.11)">
@@ -6400,13 +6398,13 @@
                         <text transform="rotate(-88.89)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1230.40" cy="2303.49" r="20.00"/>
+                <circle class="nad-winding" cx="-1230.40" cy="2303.49" r="20.00"/>
             </g>
         </g>
         <g id="367">
             <desc>L62-66-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-850.68,2809.10 -790.81,2562.44"/>
+                <polyline class="nad-edge-path" points="-850.68,2809.10 -790.81,2562.44"/>
                 <g class="nad-edge-infos" transform="translate(-843.01,2777.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.64)">
@@ -6425,7 +6423,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-730.95,2315.78 -790.81,2562.44"/>
+                <polyline class="nad-edge-path" points="-730.95,2315.78 -790.81,2562.44"/>
                 <g class="nad-edge-infos" transform="translate(-738.62,2347.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.36)">
@@ -6447,7 +6445,7 @@
         <g id="368">
             <desc>L62-67-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-831.29,2831.58 -671.08,2817.05"/>
+                <polyline class="nad-edge-path" points="-831.29,2831.58 -671.08,2817.05"/>
                 <g class="nad-edge-infos" transform="translate(-798.93,2828.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.82)">
@@ -6466,7 +6464,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-510.86,2802.51 -671.08,2817.05"/>
+                <polyline class="nad-edge-path" points="-510.86,2802.51 -671.08,2817.05"/>
                 <g class="nad-edge-infos" transform="translate(-543.23,2805.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.18)">
@@ -6488,7 +6486,7 @@
         <g id="369">
             <desc>L63-64-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1501.95,2123.82 -1372.89,2031.70"/>
+                <polyline class="nad-edge-path" points="-1501.95,2123.82 -1372.89,2031.70"/>
                 <g class="nad-edge-infos" transform="translate(-1475.50,2104.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.48)">
@@ -6507,7 +6505,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-1243.83,1939.58 -1372.89,2031.70"/>
+                <polyline class="nad-edge-path" points="-1243.83,1939.58 -1372.89,2031.70"/>
                 <g class="nad-edge-infos" transform="translate(-1270.28,1958.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.52)">
@@ -6529,7 +6527,7 @@
         <g id="370">
             <desc>L64-65-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-1209.65,1903.08 -1030.54,1613.62"/>
+                <polyline class="nad-edge-path" points="-1209.65,1903.08 -1030.54,1613.62"/>
                 <g class="nad-edge-infos" transform="translate(-1192.55,1875.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.75)">
@@ -6548,7 +6546,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-851.43,1324.16 -1030.54,1613.62"/>
+                <polyline class="nad-edge-path" points="-851.43,1324.16 -1030.54,1613.62"/>
                 <g class="nad-edge-infos" transform="translate(-868.53,1351.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.25)">
@@ -6570,7 +6568,7 @@
         <g id="371">
             <desc>L65-68-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-821.23,1283.28 -635.42,1070.82"/>
+                <polyline class="nad-edge-path" points="-821.23,1283.28 -635.42,1070.82"/>
                 <g class="nad-edge-infos" transform="translate(-799.83,1258.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.17)">
@@ -6589,7 +6587,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-449.61,858.35 -635.42,1070.82"/>
+                <polyline class="nad-edge-path" points="-449.61,858.35 -635.42,1070.82"/>
                 <g class="nad-edge-infos" transform="translate(-471.01,882.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.83)">
@@ -6611,7 +6609,7 @@
         <g id="372">
             <desc>T65-66-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-835.12,1327.81 -784.89,1766.93"/>
+                <polyline class="nad-edge-path" points="-835.12,1327.81 -784.89,1766.93"/>
                 <g class="nad-edge-infos" transform="translate(-831.42,1360.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(173.47)">
@@ -6628,10 +6626,10 @@
                         <text transform="rotate(83.47)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-782.61" cy="1786.80" r="20.00"/>
+                <circle class="nad-winding" cx="-782.61" cy="1786.80" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-727.84,2265.67 -778.07,1826.54"/>
+                <polyline class="nad-edge-path" points="-727.84,2265.67 -778.07,1826.54"/>
                 <g class="nad-edge-infos" transform="translate(-731.53,2233.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-6.53)">
@@ -6648,13 +6646,13 @@
                         <text transform="rotate(-276.53)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-780.34" cy="1806.67" r="20.00"/>
+                <circle class="nad-winding" cx="-780.34" cy="1806.67" r="20.00"/>
             </g>
         </g>
         <g id="373">
             <desc>L66-67-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-714.09,2314.08 -605.20,2545.61"/>
+                <polyline class="nad-edge-path" points="-714.09,2314.08 -605.20,2545.61"/>
                 <g class="nad-edge-infos" transform="translate(-700.25,2343.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.81)">
@@ -6673,7 +6671,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-496.32,2777.13 -605.20,2545.61"/>
+                <polyline class="nad-edge-path" points="-496.32,2777.13 -605.20,2545.61"/>
                 <g class="nad-edge-infos" transform="translate(-510.15,2747.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.19)">
@@ -6695,7 +6693,7 @@
         <g id="374">
             <desc>L68-81-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-410.59,826.67 61.29,561.70"/>
+                <polyline class="nad-edge-path" points="-410.59,826.67 61.29,561.70"/>
                 <g class="nad-edge-infos" transform="translate(-382.25,810.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(60.68)">
@@ -6714,7 +6712,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="533.17,296.72 61.29,561.70"/>
+                <polyline class="nad-edge-path" points="533.17,296.72 61.29,561.70"/>
                 <g class="nad-edge-infos" transform="translate(504.83,312.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.32)">
@@ -6736,7 +6734,7 @@
         <g id="375">
             <desc>T68-69-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-458.22,836.87 -555.10,828.14"/>
+                <polyline class="nad-edge-path" points="-458.22,836.87 -555.10,828.14"/>
                 <g class="nad-edge-infos" transform="translate(-490.59,833.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.85)">
@@ -6753,10 +6751,10 @@
                         <text transform="rotate(-354.85)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-575.02" cy="826.35" r="20.00"/>
+                <circle class="nad-winding" cx="-575.02" cy="826.35" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-711.73,814.03 -614.86,822.76"/>
+                <polyline class="nad-edge-path" points="-711.73,814.03 -614.86,822.76"/>
                 <g class="nad-edge-infos" transform="translate(-679.36,816.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.15)">
@@ -6773,13 +6771,13 @@
                         <text transform="rotate(5.15)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-594.94" cy="824.55" r="20.00"/>
+                <circle class="nad-winding" cx="-594.94" cy="824.55" r="20.00"/>
             </g>
         </g>
         <g id="376">
             <desc>L69-70-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-759.73,799.93 -1153.54,594.19"/>
+                <polyline class="nad-edge-path" points="-759.73,799.93 -1153.54,594.19"/>
                 <g class="nad-edge-infos" transform="translate(-788.54,784.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.42)">
@@ -6798,7 +6796,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1547.34,388.45 -1153.54,594.19"/>
+                <polyline class="nad-edge-path" points="-1547.34,388.45 -1153.54,594.19"/>
                 <g class="nad-edge-infos" transform="translate(-1518.54,403.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.58)">
@@ -6820,7 +6818,7 @@
         <g id="377">
             <desc>L69-75-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-743.72,787.11 -805.39,556.79"/>
+                <polyline class="nad-edge-path" points="-743.72,787.11 -805.39,556.79"/>
                 <g class="nad-edge-infos" transform="translate(-752.13,755.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.99)">
@@ -6839,7 +6837,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-867.05,326.47 -805.39,556.79"/>
+                <polyline class="nad-edge-path" points="-867.05,326.47 -805.39,556.79"/>
                 <g class="nad-edge-infos" transform="translate(-858.64,357.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.01)">
@@ -6861,7 +6859,7 @@
         <g id="378">
             <desc>L69-77-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-716.30,797.02 -276.97,486.61"/>
+                <polyline class="nad-edge-path" points="-716.30,797.02 -276.97,486.61"/>
                 <g class="nad-edge-infos" transform="translate(-689.76,778.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(54.76)">
@@ -6880,7 +6878,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="162.37,176.20 -276.97,486.61"/>
+                <polyline class="nad-edge-path" points="162.37,176.20 -276.97,486.61"/>
                 <g class="nad-edge-infos" transform="translate(135.83,194.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.24)">
@@ -6902,7 +6900,7 @@
         <g id="379">
             <desc>L70-71-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1595.37,378.53 -1916.20,402.29"/>
+                <polyline class="nad-edge-path" points="-1595.37,378.53 -1916.20,402.29"/>
                 <g class="nad-edge-infos" transform="translate(-1627.78,380.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.24)">
@@ -6921,7 +6919,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2237.04,426.06 -1916.20,402.29"/>
+                <polyline class="nad-edge-path" points="-2237.04,426.06 -1916.20,402.29"/>
                 <g class="nad-edge-infos" transform="translate(-2204.62,423.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.76)">
@@ -6943,7 +6941,7 @@
         <g id="380">
             <desc>L70-74-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1547.40,364.71 -1430.56,302.87"/>
+                <polyline class="nad-edge-path" points="-1547.40,364.71 -1430.56,302.87"/>
                 <g class="nad-edge-infos" transform="translate(-1518.68,349.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.11)">
@@ -6962,7 +6960,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-1313.72,241.02 -1430.56,302.87"/>
+                <polyline class="nad-edge-path" points="-1313.72,241.02 -1430.56,302.87"/>
                 <g class="nad-edge-infos" transform="translate(-1342.44,256.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.89)">
@@ -6984,7 +6982,7 @@
         <g id="381">
             <desc>L70-75-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1544.59,373.92 -1221.79,339.24"/>
+                <polyline class="nad-edge-path" points="-1544.59,373.92 -1221.79,339.24"/>
                 <g class="nad-edge-infos" transform="translate(-1512.27,370.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(83.87)">
@@ -7003,7 +7001,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-899.00,304.56 -1221.79,339.24"/>
+                <polyline class="nad-edge-path" points="-899.00,304.56 -1221.79,339.24"/>
                 <g class="nad-edge-infos" transform="translate(-931.31,308.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-96.13)">
@@ -7025,7 +7023,7 @@
         <g id="382">
             <desc>L71-72-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2276.12,406.40 -2371.92,255.25"/>
+                <polyline class="nad-edge-path" points="-2276.12,406.40 -2371.92,255.25"/>
                 <g class="nad-edge-infos" transform="translate(-2293.52,378.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.37)">
@@ -7044,7 +7042,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2467.72,104.10 -2371.92,255.25"/>
+                <polyline class="nad-edge-path" points="-2467.72,104.10 -2371.92,255.25"/>
                 <g class="nad-edge-infos" transform="translate(-2450.32,131.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.63)">
@@ -7066,7 +7064,7 @@
         <g id="383">
             <desc>L71-73-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-2286.87,435.34 -2490.75,497.15"/>
+                <polyline class="nad-edge-path" points="-2286.87,435.34 -2490.75,497.15"/>
                 <g class="nad-edge-infos" transform="translate(-2317.97,444.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.87)">
@@ -7085,7 +7083,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-2694.63,558.96 -2490.75,497.15"/>
+                <polyline class="nad-edge-path" points="-2694.63,558.96 -2490.75,497.15"/>
                 <g class="nad-edge-infos" transform="translate(-2663.53,549.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.13)">
@@ -7107,7 +7105,7 @@
         <g id="384">
             <desc>L74-75-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-1266.06,233.47 -1082.41,265.46"/>
+                <polyline class="nad-edge-path" points="-1266.06,233.47 -1082.41,265.46"/>
                 <g class="nad-edge-infos" transform="translate(-1234.04,239.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.88)">
@@ -7126,7 +7124,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-898.76,297.46 -1082.41,265.46"/>
+                <polyline class="nad-edge-path" points="-898.76,297.46 -1082.41,265.46"/>
                 <g class="nad-edge-infos" transform="translate(-930.78,291.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-80.12)">
@@ -7148,7 +7146,7 @@
         <g id="385">
             <desc>L75-77-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-848.37,298.48 -345.22,231.66"/>
+                <polyline class="nad-edge-path" points="-848.37,298.48 -345.22,231.66"/>
                 <g class="nad-edge-infos" transform="translate(-816.15,294.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.44)">
@@ -7167,7 +7165,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="157.92,164.84 -345.22,231.66"/>
+                <polyline class="nad-edge-path" points="157.92,164.84 -345.22,231.66"/>
                 <g class="nad-edge-infos" transform="translate(125.70,169.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.56)">
@@ -7189,7 +7187,7 @@
         <g id="386">
             <desc>L76-77-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-186.41,-78.51 -12.30,34.54"/>
+                <polyline class="nad-edge-path" points="-186.41,-78.51 -12.30,34.54"/>
                 <g class="nad-edge-infos" transform="translate(-159.15,-60.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.00)">
@@ -7208,7 +7206,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="161.81,147.60 -12.30,34.54"/>
+                <polyline class="nad-edge-path" points="161.81,147.60 -12.30,34.54"/>
                 <g class="nad-edge-infos" transform="translate(134.55,129.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.00)">
@@ -7230,7 +7228,7 @@
         <g id="387">
             <desc>L77-78-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="200.16,142.45 374.58,-53.27"/>
+                <polyline class="nad-edge-path" points="200.16,142.45 374.58,-53.27"/>
                 <g class="nad-edge-infos" transform="translate(221.79,118.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.71)">
@@ -7249,7 +7247,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="549.00,-248.98 374.58,-53.27"/>
+                <polyline class="nad-edge-path" points="549.00,-248.98 374.58,-53.27"/>
                 <g class="nad-edge-infos" transform="translate(527.38,-224.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.29)">
@@ -7271,7 +7269,7 @@
         <g id="388">
             <desc>L77-80-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="207.94,167.64 260.83,180.80 660.15,66.09"/>
+                <polyline class="nad-edge-path" points="207.94,167.64 260.83,180.80 660.15,66.09"/>
                 <g class="nad-edge-infos" transform="translate(289.66,172.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
@@ -7290,7 +7288,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1097.32,-87.84 1059.48,-48.62 660.15,66.09"/>
+                <polyline class="nad-edge-path" points="1097.32,-87.84 1059.48,-48.62 660.15,66.09"/>
                 <g class="nad-edge-infos" transform="translate(1030.64,-40.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
@@ -7312,7 +7310,7 @@
         <g id="389">
             <desc>L77-80-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="200.90,143.13 238.74,103.91 638.07,-10.80"/>
+                <polyline class="nad-edge-path" points="200.90,143.13 238.74,103.91 638.07,-10.80"/>
                 <g class="nad-edge-infos" transform="translate(267.58,95.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.97)">
@@ -7331,7 +7329,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1090.28,-112.35 1037.39,-125.51 638.07,-10.80"/>
+                <polyline class="nad-edge-path" points="1090.28,-112.35 1037.39,-125.51 638.07,-10.80"/>
                 <g class="nad-edge-infos" transform="translate(1008.56,-117.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.03)">
@@ -7353,7 +7351,7 @@
         <g id="390">
             <desc>L77-82-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="206.27,172.35 684.34,397.39"/>
+                <polyline class="nad-edge-path" points="206.27,172.35 684.34,397.39"/>
                 <g class="nad-edge-infos" transform="translate(235.67,186.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(115.21)">
@@ -7372,7 +7370,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1162.42,622.43 684.34,397.39"/>
+                <polyline class="nad-edge-path" points="1162.42,622.43 684.34,397.39"/>
                 <g class="nad-edge-infos" transform="translate(1133.01,608.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-64.79)">
@@ -7394,7 +7392,7 @@
         <g id="391">
             <desc>L78-79-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="587.68,-281.39 738.56,-374.30"/>
+                <polyline class="nad-edge-path" points="587.68,-281.39 738.56,-374.30"/>
                 <g class="nad-edge-infos" transform="translate(615.36,-298.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.38)">
@@ -7413,7 +7411,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="889.43,-467.21 738.56,-374.30"/>
+                <polyline class="nad-edge-path" points="889.43,-467.21 738.56,-374.30"/>
                 <g class="nad-edge-infos" transform="translate(861.76,-450.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.62)">
@@ -7435,7 +7433,7 @@
         <g id="392">
             <desc>L79-80-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="923.34,-458.18 1013.08,-293.38"/>
+                <polyline class="nad-edge-path" points="923.34,-458.18 1013.08,-293.38"/>
                 <g class="nad-edge-infos" transform="translate(938.88,-429.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(151.43)">
@@ -7454,7 +7452,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1102.83,-128.58 1013.08,-293.38"/>
+                <polyline class="nad-edge-path" points="1102.83,-128.58 1013.08,-293.38"/>
                 <g class="nad-edge-infos" transform="translate(1087.28,-157.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-28.57)">
@@ -7476,7 +7474,7 @@
         <g id="393">
             <desc>L8-9-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-836.01,-2094.43 -966.57,-2309.32"/>
+                <polyline class="nad-edge-path" points="-836.01,-2094.43 -966.57,-2309.32"/>
                 <g class="nad-edge-infos" transform="translate(-852.89,-2122.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.28)">
@@ -7495,7 +7493,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-1097.12,-2524.22 -966.57,-2309.32"/>
+                <polyline class="nad-edge-path" points="-1097.12,-2524.22 -966.57,-2309.32"/>
                 <g class="nad-edge-infos" transform="translate(-1080.25,-2496.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.72)">
@@ -7517,7 +7515,7 @@
         <g id="394">
             <desc>L80-96-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1134.50,-89.73 1346.70,89.54"/>
+                <polyline class="nad-edge-path" points="1134.50,-89.73 1346.70,89.54"/>
                 <g class="nad-edge-infos" transform="translate(1159.33,-68.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.19)">
@@ -7536,7 +7534,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1558.89,268.82 1346.70,89.54"/>
+                <polyline class="nad-edge-path" points="1558.89,268.82 1346.70,89.54"/>
                 <g class="nad-edge-infos" transform="translate(1534.07,247.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.81)">
@@ -7558,7 +7556,7 @@
         <g id="395">
             <desc>L80-97-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1138.67,-96.65 1260.76,-47.38"/>
+                <polyline class="nad-edge-path" points="1138.67,-96.65 1260.76,-47.38"/>
                 <g class="nad-edge-infos" transform="translate(1168.81,-84.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.98)">
@@ -7577,7 +7575,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1382.85,1.89 1260.76,-47.38"/>
+                <polyline class="nad-edge-path" points="1382.85,1.89 1260.76,-47.38"/>
                 <g class="nad-edge-infos" transform="translate(1352.71,-10.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.02)">
@@ -7599,7 +7597,7 @@
         <g id="396">
             <desc>L80-98-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1133.93,-123.30 1374.81,-341.29"/>
+                <polyline class="nad-edge-path" points="1133.93,-123.30 1374.81,-341.29"/>
                 <g class="nad-edge-infos" transform="translate(1158.03,-145.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.86)">
@@ -7618,7 +7616,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1615.69,-559.27 1374.81,-341.29"/>
+                <polyline class="nad-edge-path" points="1615.69,-559.27 1374.81,-341.29"/>
                 <g class="nad-edge-infos" transform="translate(1591.59,-537.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.14)">
@@ -7640,7 +7638,7 @@
         <g id="397">
             <desc>L80-99-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1139.59,-113.03 1454.91,-200.88"/>
+                <polyline class="nad-edge-path" points="1139.59,-113.03 1454.91,-200.88"/>
                 <g class="nad-edge-infos" transform="translate(1170.89,-121.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.43)">
@@ -7659,7 +7657,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1770.23,-288.73 1454.91,-200.88"/>
+                <polyline class="nad-edge-path" points="1770.23,-288.73 1454.91,-200.88"/>
                 <g class="nad-edge-infos" transform="translate(1738.92,-280.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.57)">
@@ -7681,7 +7679,7 @@
         <g id="398">
             <desc>T81-80-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="576.31,269.64 810.61,106.19"/>
+                <polyline class="nad-edge-path" points="576.31,269.64 810.61,106.19"/>
                 <g class="nad-edge-infos" transform="translate(602.97,251.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.10)">
@@ -7698,10 +7696,10 @@
                         <text transform="rotate(-34.90)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="827.01" cy="94.74" r="20.00"/>
+                <circle class="nad-winding" cx="827.01" cy="94.74" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1094.11,-91.60 859.82,71.86"/>
+                <polyline class="nad-edge-path" points="1094.11,-91.60 859.82,71.86"/>
                 <g class="nad-edge-infos" transform="translate(1067.45,-73.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.90)">
@@ -7718,13 +7716,13 @@
                         <text transform="rotate(-34.90)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="843.41" cy="83.30" r="20.00"/>
+                <circle class="nad-winding" cx="843.41" cy="83.30" r="20.00"/>
             </g>
         </g>
         <g id="399">
             <desc>L82-83-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1202.59,652.21 1452.98,929.28"/>
+                <polyline class="nad-edge-path" points="1202.59,652.21 1452.98,929.28"/>
                 <g class="nad-edge-infos" transform="translate(1224.38,676.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.90)">
@@ -7743,7 +7741,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1703.37,1206.35 1452.98,929.28"/>
+                <polyline class="nad-edge-path" points="1703.37,1206.35 1452.98,929.28"/>
                 <g class="nad-edge-infos" transform="translate(1681.58,1182.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.10)">
@@ -7765,7 +7763,7 @@
         <g id="400">
             <desc>L82-96-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1204.58,616.38 1381.93,459.29"/>
+                <polyline class="nad-edge-path" points="1204.58,616.38 1381.93,459.29"/>
                 <g class="nad-edge-infos" transform="translate(1228.90,594.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.47)">
@@ -7784,7 +7782,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1559.28,302.19 1381.93,459.29"/>
+                <polyline class="nad-edge-path" points="1559.28,302.19 1381.93,459.29"/>
                 <g class="nad-edge-infos" transform="translate(1534.95,323.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.53)">
@@ -7806,7 +7804,7 @@
         <g id="401">
             <desc>L83-84-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1730.23,1248.82 1796.56,1408.75"/>
+                <polyline class="nad-edge-path" points="1730.23,1248.82 1796.56,1408.75"/>
                 <g class="nad-edge-infos" transform="translate(1742.68,1278.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.48)">
@@ -7825,7 +7823,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1862.88,1568.68 1796.56,1408.75"/>
+                <polyline class="nad-edge-path" points="1862.88,1568.68 1796.56,1408.75"/>
                 <g class="nad-edge-infos" transform="translate(1850.43,1538.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.52)">
@@ -7847,7 +7845,7 @@
         <g id="402">
             <desc>L83-85-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1743.05,1237.11 1987.39,1365.32"/>
+                <polyline class="nad-edge-path" points="1743.05,1237.11 1987.39,1365.32"/>
                 <g class="nad-edge-infos" transform="translate(1771.82,1252.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.69)">
@@ -7866,7 +7864,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2231.74,1493.53 1987.39,1365.32"/>
+                <polyline class="nad-edge-path" points="2231.74,1493.53 1987.39,1365.32"/>
                 <g class="nad-edge-infos" transform="translate(2202.96,1478.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.31)">
@@ -7888,7 +7886,7 @@
         <g id="403">
             <desc>L84-85-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1897.52,1586.58 2063.49,1548.81"/>
+                <polyline class="nad-edge-path" points="1897.52,1586.58 2063.49,1548.81"/>
                 <g class="nad-edge-infos" transform="translate(1929.21,1579.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.18)">
@@ -7907,7 +7905,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2229.45,1511.04 2063.49,1548.81"/>
+                <polyline class="nad-edge-path" points="2229.45,1511.04 2063.49,1548.81"/>
                 <g class="nad-edge-infos" transform="translate(2197.76,1518.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.82)">
@@ -7929,7 +7927,7 @@
         <g id="404">
             <desc>L85-86-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2256.30,1530.80 2275.87,1781.32"/>
+                <polyline class="nad-edge-path" points="2256.30,1530.80 2275.87,1781.32"/>
                 <g class="nad-edge-infos" transform="translate(2258.84,1563.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(175.53)">
@@ -7948,7 +7946,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2295.44,2031.83 2275.87,1781.32"/>
+                <polyline class="nad-edge-path" points="2295.44,2031.83 2275.87,1781.32"/>
                 <g class="nad-edge-infos" transform="translate(2292.91,1999.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-4.47)">
@@ -7970,7 +7968,7 @@
         <g id="405">
             <desc>L85-88-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2279.72,1503.15 2452.80,1487.93"/>
+                <polyline class="nad-edge-path" points="2279.72,1503.15 2452.80,1487.93"/>
                 <g class="nad-edge-infos" transform="translate(2312.10,1500.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(84.98)">
@@ -7989,7 +7987,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2625.87,1472.71 2452.80,1487.93"/>
+                <polyline class="nad-edge-path" points="2625.87,1472.71 2452.80,1487.93"/>
                 <g class="nad-edge-infos" transform="translate(2593.50,1475.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.02)">
@@ -8011,7 +8009,7 @@
         <g id="406">
             <desc>L85-89-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2271.92,1486.93 2467.13,1282.33"/>
+                <polyline class="nad-edge-path" points="2271.92,1486.93 2467.13,1282.33"/>
                 <g class="nad-edge-infos" transform="translate(2294.36,1463.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.65)">
@@ -8030,7 +8028,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2662.33,1077.73 2467.13,1282.33"/>
+                <polyline class="nad-edge-path" points="2662.33,1077.73 2467.13,1282.33"/>
                 <g class="nad-edge-infos" transform="translate(2639.90,1101.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.35)">
@@ -8052,7 +8050,7 @@
         <g id="407">
             <desc>L86-87-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2296.42,2082.73 2289.37,2261.37"/>
+                <polyline class="nad-edge-path" points="2296.42,2082.73 2289.37,2261.37"/>
                 <g class="nad-edge-infos" transform="translate(2295.14,2115.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.74)">
@@ -8071,7 +8069,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2282.31,2440.00 2289.37,2261.37"/>
+                <polyline class="nad-edge-path" points="2282.31,2440.00 2289.37,2261.37"/>
                 <g class="nad-edge-infos" transform="translate(2283.59,2407.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(2.26)">
@@ -8093,7 +8091,7 @@
         <g id="408">
             <desc>L88-89-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2653.05,1445.04 2665.61,1264.88"/>
+                <polyline class="nad-edge-path" points="2653.05,1445.04 2665.61,1264.88"/>
                 <g class="nad-edge-infos" transform="translate(2655.31,1412.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.99)">
@@ -8112,7 +8110,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2678.16,1084.71 2665.61,1264.88"/>
+                <polyline class="nad-edge-path" points="2678.16,1084.71 2665.61,1264.88"/>
                 <g class="nad-edge-infos" transform="translate(2675.90,1117.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.01)">
@@ -8134,7 +8132,7 @@
         <g id="409">
             <desc>L89-90-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2703.69,1068.54 2754.47,1088.34 2905.61,1065.22"/>
+                <polyline class="nad-edge-path" points="2703.69,1068.54 2754.47,1088.34 2905.61,1065.22"/>
                 <g class="nad-edge-infos" transform="translate(2784.13,1083.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
@@ -8153,7 +8151,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3099.28,1008.03 3056.75,1042.10 2905.61,1065.22"/>
+                <polyline class="nad-edge-path" points="3099.28,1008.03 3056.75,1042.10 2905.61,1065.22"/>
                 <g class="nad-edge-infos" transform="translate(3027.09,1046.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
@@ -8175,7 +8173,7 @@
         <g id="410">
             <desc>L89-90-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2699.84,1043.33 2742.37,1009.26 2893.51,986.14"/>
+                <polyline class="nad-edge-path" points="2699.84,1043.33 2742.37,1009.26 2893.51,986.14"/>
                 <g class="nad-edge-infos" transform="translate(2772.03,1004.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.30)">
@@ -8194,7 +8192,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3095.43,982.82 3044.65,963.02 2893.51,986.14"/>
+                <polyline class="nad-edge-path" points="3095.43,982.82 3044.65,963.02 2893.51,986.14"/>
                 <g class="nad-edge-infos" transform="translate(3015.00,967.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.70)">
@@ -8216,7 +8214,7 @@
         <g id="411">
             <desc>L89-92-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2693.05,1037.41 2721.07,990.66 2726.28,674.31"/>
+                <polyline class="nad-edge-path" points="2693.05,1037.41 2721.07,990.66 2726.28,674.31"/>
                 <g class="nad-edge-infos" transform="translate(2721.57,960.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
@@ -8235,7 +8233,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2705.02,310.32 2731.49,357.96 2726.28,674.31"/>
+                <polyline class="nad-edge-path" points="2705.02,310.32 2731.49,357.96 2726.28,674.31"/>
                 <g class="nad-edge-infos" transform="translate(2731.00,387.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
@@ -8257,7 +8255,7 @@
         <g id="412">
             <desc>L89-92-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2667.55,1036.99 2641.08,989.34 2646.29,672.99"/>
+                <polyline class="nad-edge-path" points="2667.55,1036.99 2641.08,989.34 2646.29,672.99"/>
                 <g class="nad-edge-infos" transform="translate(2641.58,959.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.94)">
@@ -8276,7 +8274,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2679.52,309.90 2651.50,356.64 2646.29,672.99"/>
+                <polyline class="nad-edge-path" points="2679.52,309.90 2651.50,356.64 2646.29,672.99"/>
                 <g class="nad-edge-infos" transform="translate(2651.01,386.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-179.06)">
@@ -8298,7 +8296,7 @@
         <g id="413">
             <desc>L90-91-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="3118.74,966.59 3115.71,794.70"/>
+                <polyline class="nad-edge-path" points="3118.74,966.59 3115.71,794.70"/>
                 <g class="nad-edge-infos" transform="translate(3118.16,934.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.01)">
@@ -8317,7 +8315,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="3112.69,622.80 3115.71,794.70"/>
+                <polyline class="nad-edge-path" points="3112.69,622.80 3115.71,794.70"/>
                 <g class="nad-edge-infos" transform="translate(3113.26,655.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(178.99)">
@@ -8339,7 +8337,7 @@
         <g id="414">
             <desc>L91-92-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="3091.72,582.18 2902.44,442.67"/>
+                <polyline class="nad-edge-path" points="3091.72,582.18 2902.44,442.67"/>
                 <g class="nad-edge-infos" transform="translate(3065.55,562.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-53.61)">
@@ -8358,7 +8356,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2713.16,303.16 2902.44,442.67"/>
+                <polyline class="nad-edge-path" points="2713.16,303.16 2902.44,442.67"/>
                 <g class="nad-edge-infos" transform="translate(2739.32,322.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(126.39)">
@@ -8380,7 +8378,7 @@
         <g id="415">
             <desc>L92-93-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2671.28,301.96 2558.90,375.26"/>
+                <polyline class="nad-edge-path" points="2671.28,301.96 2558.90,375.26"/>
                 <g class="nad-edge-infos" transform="translate(2644.06,319.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-123.11)">
@@ -8399,7 +8397,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2446.52,448.56 2558.90,375.26"/>
+                <polyline class="nad-edge-path" points="2446.52,448.56 2558.90,375.26"/>
                 <g class="nad-edge-infos" transform="translate(2473.74,430.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.89)">
@@ -8421,7 +8419,7 @@
         <g id="416">
             <desc>L92-94-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2668.16,280.88 2445.38,215.80"/>
+                <polyline class="nad-edge-path" points="2668.16,280.88 2445.38,215.80"/>
                 <g class="nad-edge-infos" transform="translate(2636.96,271.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.72)">
@@ -8440,7 +8438,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2222.60,150.72 2445.38,215.80"/>
+                <polyline class="nad-edge-path" points="2222.60,150.72 2445.38,215.80"/>
                 <g class="nad-edge-infos" transform="translate(2253.79,159.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.28)">
@@ -8462,7 +8460,7 @@
         <g id="417">
             <desc>L93-94-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2410.37,441.72 2311.64,303.03"/>
+                <polyline class="nad-edge-path" points="2410.37,441.72 2311.64,303.03"/>
                 <g class="nad-edge-infos" transform="translate(2391.52,415.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.45)">
@@ -8481,7 +8479,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="2212.91,164.35 2311.64,303.03"/>
+                <polyline class="nad-edge-path" points="2212.91,164.35 2311.64,303.03"/>
                 <g class="nad-edge-infos" transform="translate(2231.76,190.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.55)">
@@ -8503,7 +8501,7 @@
         <g id="418">
             <desc>L94-95-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2180.45,161.96 2061.10,286.17"/>
+                <polyline class="nad-edge-path" points="2180.45,161.96 2061.10,286.17"/>
                 <g class="nad-edge-infos" transform="translate(2157.93,185.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.14)">
@@ -8522,7 +8520,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1941.74,410.38 2061.10,286.17"/>
+                <polyline class="nad-edge-path" points="1941.74,410.38 2061.10,286.17"/>
                 <g class="nad-edge-infos" transform="translate(1964.26,386.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.86)">
@@ -8544,7 +8542,7 @@
         <g id="419">
             <desc>L94-96-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2173.26,149.26 1888.25,214.43"/>
+                <polyline class="nad-edge-path" points="2173.26,149.26 1888.25,214.43"/>
                 <g class="nad-edge-infos" transform="translate(2141.58,156.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-102.88)">
@@ -8563,7 +8561,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1603.23,279.60 1888.25,214.43"/>
+                <polyline class="nad-edge-path" points="1603.23,279.60 1888.25,214.43"/>
                 <g class="nad-edge-infos" transform="translate(1634.91,272.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(77.12)">
@@ -8585,7 +8583,7 @@
         <g id="420">
             <desc>L95-96-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1900.52,418.99 1751.22,357.02"/>
+                <polyline class="nad-edge-path" points="1900.52,418.99 1751.22,357.02"/>
                 <g class="nad-edge-infos" transform="translate(1870.50,406.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.46)">
@@ -8604,7 +8602,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1601.92,295.05 1751.22,357.02"/>
+                <polyline class="nad-edge-path" points="1601.92,295.05 1751.22,357.02"/>
                 <g class="nad-edge-infos" transform="translate(1631.94,307.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.54)">
@@ -8626,7 +8624,7 @@
         <g id="421">
             <desc>L96-97-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1564.81,263.68 1492.43,148.36"/>
+                <polyline class="nad-edge-path" points="1564.81,263.68 1492.43,148.36"/>
                 <g class="nad-edge-infos" transform="translate(1547.54,236.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.11)">
@@ -8645,7 +8643,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1420.05,33.04 1492.43,148.36"/>
+                <polyline class="nad-edge-path" points="1420.05,33.04 1492.43,148.36"/>
                 <g class="nad-edge-infos" transform="translate(1437.33,60.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.89)">

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -236,83 +236,83 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-384.73,205.05)" id="0">
             <desc>VL42</desc>
-            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="1" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(412.94,570.23)" id="2">
             <desc>VL45</desc>
-            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="3" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-23.01,891.24)" id="4">
             <desc>VL47</desc>
-            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="5" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(639.20,864.66)" id="6">
             <desc>VL48</desc>
-            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="7" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(141.33,400.64)" id="8">
             <desc>VL49</desc>
-            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="9" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(890.72,392.93)" id="10">
             <desc>VL50</desc>
-            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="11" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(778.38,-198.28)" id="12">
             <desc>VL51</desc>
-            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="13" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1112.17,-769.45)" id="14">
             <desc>VL52</desc>
-            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="15" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(777.95,-957.28)" id="16">
             <desc>VL53</desc>
-            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="17" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(289.01,-494.56)" id="18">
             <desc>VL54</desc>
-            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="19" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(327.81,-853.45)" id="20">
             <desc>VL55</desc>
-            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="21" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(612.02,-544.18)" id="22">
             <desc>VL56</desc>
-            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="23" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1098.74,20.20)" id="24">
             <desc>VL57</desc>
-            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="25" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1078.77,-408.41)" id="26">
             <desc>VL58</desc>
-            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="27" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-35.94,-870.64)" id="28">
             <desc>VL59</desc>
-            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="29" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-478.40,-719.94)" id="30">
             <desc>VL60</desc>
-            <circle class="nad-busnode" r="27.50" id="31" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="31" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-609.70,-985.82)" id="32">
             <desc>VL61</desc>
-            <circle class="nad-busnode" r="27.50" id="33" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="33" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-211.93,-1369.90)" id="34">
             <desc>VL63</desc>
-            <circle class="nad-busnode" r="27.50" id="35" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="35" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-800.22,310.03)" id="36">
             <desc>VL66</desc>
-            <circle class="nad-busnode" r="27.50" id="37" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="37" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-71.36,1313.89)" id="38">
             <desc>VL69</desc>
-            <circle class="nad-busnode" r="27.50" id="39" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="39" class="nad-vl120to180-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_118_bus_partial.svg
+++ b/src/test/resources/IEEE_118_bus_partial.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="986.50" viewBox="-1539.67 -1621.47 2951.84 3639.99" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -92,7 +90,7 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -238,90 +236,90 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-384.73,205.05)" id="0">
             <desc>VL42</desc>
-            <circle r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(412.94,570.23)" id="2">
             <desc>VL45</desc>
-            <circle r="27.50" id="3" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-23.01,891.24)" id="4">
             <desc>VL47</desc>
-            <circle r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(639.20,864.66)" id="6">
             <desc>VL48</desc>
-            <circle r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(141.33,400.64)" id="8">
             <desc>VL49</desc>
-            <circle r="27.50" id="9" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(890.72,392.93)" id="10">
             <desc>VL50</desc>
-            <circle r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(778.38,-198.28)" id="12">
             <desc>VL51</desc>
-            <circle r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1112.17,-769.45)" id="14">
             <desc>VL52</desc>
-            <circle r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(777.95,-957.28)" id="16">
             <desc>VL53</desc>
-            <circle r="27.50" id="17" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(289.01,-494.56)" id="18">
             <desc>VL54</desc>
-            <circle r="27.50" id="19" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(327.81,-853.45)" id="20">
             <desc>VL55</desc>
-            <circle r="27.50" id="21" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(612.02,-544.18)" id="22">
             <desc>VL56</desc>
-            <circle r="27.50" id="23" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1098.74,20.20)" id="24">
             <desc>VL57</desc>
-            <circle r="27.50" id="25" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1078.77,-408.41)" id="26">
             <desc>VL58</desc>
-            <circle r="27.50" id="27" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-35.94,-870.64)" id="28">
             <desc>VL59</desc>
-            <circle r="27.50" id="29" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-478.40,-719.94)" id="30">
             <desc>VL60</desc>
-            <circle r="27.50" id="31" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="31" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-609.70,-985.82)" id="32">
             <desc>VL61</desc>
-            <circle r="27.50" id="33" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="33" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-211.93,-1369.90)" id="34">
             <desc>VL63</desc>
-            <circle r="27.50" id="35" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="35" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-800.22,310.03)" id="36">
             <desc>VL66</desc>
-            <circle r="27.50" id="37" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="37" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-71.36,1313.89)" id="38">
             <desc>VL69</desc>
-            <circle r="27.50" id="39" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="39" class="nad-vl120to180-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="42">
             <desc>L40-42-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-385.25,179.56 -388.07,40.20"/>
+                <polyline class="nad-edge-path" points="-385.25,179.56 -388.07,40.20"/>
                 <g class="nad-edge-infos" transform="translate(-385.90,147.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.16)">
@@ -343,7 +341,7 @@
         <g id="45">
             <desc>L41-42-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-408.13,194.92 -644.22,92.70"/>
+                <polyline class="nad-edge-path" points="-408.13,194.92 -644.22,92.70"/>
                 <g class="nad-edge-infos" transform="translate(-437.95,182.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.59)">
@@ -365,7 +363,7 @@
         <g id="46">
             <desc>L42-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-368.47,224.70 -333.73,266.69 -135.64,340.34"/>
+                <polyline class="nad-edge-path" points="-368.47,224.70 -333.73,266.69 -135.64,340.34"/>
                 <g class="nad-edge-infos" transform="translate(-305.61,277.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -384,7 +382,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="116.18,404.89 62.45,413.99 -135.64,340.34"/>
+                <polyline class="nad-edge-path" points="116.18,404.89 62.45,413.99 -135.64,340.34"/>
                 <g class="nad-edge-infos" transform="translate(34.33,403.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -406,7 +404,7 @@
         <g id="47">
             <desc>L42-49-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-359.59,200.80 -305.85,191.71 -107.76,265.35"/>
+                <polyline class="nad-edge-path" points="-359.59,200.80 -305.85,191.71 -107.76,265.35"/>
                 <g class="nad-edge-infos" transform="translate(-277.73,202.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.39)">
@@ -425,7 +423,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="125.07,380.99 90.33,339.00 -107.76,265.35"/>
+                <polyline class="nad-edge-path" points="125.07,380.99 90.33,339.00 -107.76,265.35"/>
                 <g class="nad-edge-infos" transform="translate(62.21,328.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.61)">
@@ -447,7 +445,7 @@
         <g id="50">
             <desc>L44-45-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="420.91,546.01 468.94,399.99"/>
+                <polyline class="nad-edge-path" points="420.91,546.01 468.94,399.99"/>
                 <g class="nad-edge-infos" transform="translate(431.06,515.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.21)">
@@ -469,7 +467,7 @@
         <g id="53">
             <desc>L45-46-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="408.15,595.28 376.45,760.94"/>
+                <polyline class="nad-edge-path" points="408.15,595.28 376.45,760.94"/>
                 <g class="nad-edge-infos" transform="translate(402.04,627.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.17)">
@@ -491,7 +489,7 @@
         <g id="54">
             <desc>L45-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="391.31,556.72 277.13,485.43"/>
+                <polyline class="nad-edge-path" points="391.31,556.72 277.13,485.43"/>
                 <g class="nad-edge-infos" transform="translate(363.74,539.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.02)">
@@ -510,7 +508,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="162.96,414.15 277.13,485.43"/>
+                <polyline class="nad-edge-path" points="162.96,414.15 277.13,485.43"/>
                 <g class="nad-edge-infos" transform="translate(190.52,431.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.98)">
@@ -532,7 +530,7 @@
         <g id="55">
             <desc>L46-47-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="2.14,895.42 158.48,921.45"/>
+                <polyline class="nad-edge-path" points="2.14,895.42 158.48,921.45"/>
                 <g class="nad-edge-infos" transform="translate(34.20,900.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(99.45)">
@@ -554,7 +552,7 @@
         <g id="56">
             <desc>L47-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-14.91,867.06 59.16,645.94"/>
+                <polyline class="nad-edge-path" points="-14.91,867.06 59.16,645.94"/>
                 <g class="nad-edge-infos" transform="translate(-4.59,836.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.52)">
@@ -573,7 +571,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="133.23,424.82 59.16,645.94"/>
+                <polyline class="nad-edge-path" points="133.23,424.82 59.16,645.94"/>
                 <g class="nad-edge-infos" transform="translate(122.90,455.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.48)">
@@ -595,7 +593,7 @@
         <g id="57">
             <desc>L47-69-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-25.91,916.57 -47.18,1102.56"/>
+                <polyline class="nad-edge-path" points="-25.91,916.57 -47.18,1102.56"/>
                 <g class="nad-edge-infos" transform="translate(-29.60,948.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.47)">
@@ -614,7 +612,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-68.46,1288.56 -47.18,1102.56"/>
+                <polyline class="nad-edge-path" points="-68.46,1288.56 -47.18,1102.56"/>
                 <g class="nad-edge-infos" transform="translate(-64.76,1256.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.53)">
@@ -636,7 +634,7 @@
         <g id="58">
             <desc>L46-48-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="614.72,871.78 489.59,908.16"/>
+                <polyline class="nad-edge-path" points="614.72,871.78 489.59,908.16"/>
                 <g class="nad-edge-infos" transform="translate(583.51,880.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-106.21)">
@@ -658,7 +656,7 @@
         <g id="59">
             <desc>L48-49-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="620.55,847.28 390.27,632.65"/>
+                <polyline class="nad-edge-path" points="620.55,847.28 390.27,632.65"/>
                 <g class="nad-edge-infos" transform="translate(596.77,825.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.02)">
@@ -677,7 +675,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="159.98,418.03 390.27,632.65"/>
+                <polyline class="nad-edge-path" points="159.98,418.03 390.27,632.65"/>
                 <g class="nad-edge-infos" transform="translate(183.76,440.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.98)">
@@ -699,7 +697,7 @@
         <g id="60">
             <desc>L49-50-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="166.83,400.38 516.02,396.79"/>
+                <polyline class="nad-edge-path" points="166.83,400.38 516.02,396.79"/>
                 <g class="nad-edge-infos" transform="translate(199.32,400.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.41)">
@@ -718,7 +716,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="865.22,393.20 516.02,396.79"/>
+                <polyline class="nad-edge-path" points="865.22,393.20 516.02,396.79"/>
                 <g class="nad-edge-infos" transform="translate(832.72,393.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.59)">
@@ -740,7 +738,7 @@
         <g id="61">
             <desc>L49-51-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="159.91,383.17 459.86,101.18"/>
+                <polyline class="nad-edge-path" points="159.91,383.17 459.86,101.18"/>
                 <g class="nad-edge-infos" transform="translate(183.58,360.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.77)">
@@ -759,7 +757,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="759.81,-180.82 459.86,101.18"/>
+                <polyline class="nad-edge-path" points="759.81,-180.82 459.86,101.18"/>
                 <g class="nad-edge-infos" transform="translate(736.13,-158.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.23)">
@@ -781,7 +779,7 @@
         <g id="62">
             <desc>L49-54-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="157.50,380.93 192.07,338.79 254.64,-40.45"/>
+                <polyline class="nad-edge-path" points="157.50,380.93 192.07,338.79 254.64,-40.45"/>
                 <g class="nad-edge-infos" transform="translate(196.95,309.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -800,7 +798,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="298.00,-470.69 317.20,-419.69 254.64,-40.45"/>
+                <polyline class="nad-edge-path" points="298.00,-470.69 317.20,-419.69 254.64,-40.45"/>
                 <g class="nad-edge-infos" transform="translate(312.32,-390.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -822,7 +820,7 @@
         <g id="63">
             <desc>L49-54-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="132.34,376.78 113.14,325.77 175.70,-53.47"/>
+                <polyline class="nad-edge-path" points="132.34,376.78 113.14,325.77 175.70,-53.47"/>
                 <g class="nad-edge-infos" transform="translate(118.02,296.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.37)">
@@ -841,7 +839,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="272.84,-474.85 238.27,-432.71 175.70,-53.47"/>
+                <polyline class="nad-edge-path" points="272.84,-474.85 238.27,-432.71 175.70,-53.47"/>
                 <g class="nad-edge-infos" transform="translate(233.38,-403.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.63)">
@@ -863,7 +861,7 @@
         <g id="64">
             <desc>L49-66-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="120.57,385.83 76.20,354.19 -325.61,315.52"/>
+                <polyline class="nad-edge-path" points="120.57,385.83 76.20,354.19 -325.61,315.52"/>
                 <g class="nad-edge-infos" transform="translate(46.33,351.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -882,7 +880,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-777.01,299.45 -727.42,276.85 -325.61,315.52"/>
+                <polyline class="nad-edge-path" points="-777.01,299.45 -727.42,276.85 -325.61,315.52"/>
                 <g class="nad-edge-infos" transform="translate(-697.56,279.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -904,7 +902,7 @@
         <g id="65">
             <desc>L49-66-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="118.12,411.22 68.53,433.82 -333.28,395.15"/>
+                <polyline class="nad-edge-path" points="118.12,411.22 68.53,433.82 -333.28,395.15"/>
                 <g class="nad-edge-infos" transform="translate(38.67,430.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-84.50)">
@@ -923,7 +921,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-779.46,324.84 -735.08,356.48 -333.28,395.15"/>
+                <polyline class="nad-edge-path" points="-779.46,324.84 -735.08,356.48 -333.28,395.15"/>
                 <g class="nad-edge-infos" transform="translate(-705.22,359.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(95.50)">
@@ -945,7 +943,7 @@
         <g id="66">
             <desc>L49-69-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="135.54,425.48 34.99,857.26"/>
+                <polyline class="nad-edge-path" points="135.54,425.48 34.99,857.26"/>
                 <g class="nad-edge-infos" transform="translate(128.17,457.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-166.89)">
@@ -964,7 +962,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-65.57,1289.05 34.99,857.26"/>
+                <polyline class="nad-edge-path" points="-65.57,1289.05 34.99,857.26"/>
                 <g class="nad-edge-infos" transform="translate(-58.20,1257.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(13.11)">
@@ -986,7 +984,7 @@
         <g id="67">
             <desc>L50-57-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="903.14,370.67 994.73,206.57"/>
+                <polyline class="nad-edge-path" points="903.14,370.67 994.73,206.57"/>
                 <g class="nad-edge-infos" transform="translate(918.98,342.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.17)">
@@ -1005,7 +1003,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1086.32,42.47 994.73,206.57"/>
+                <polyline class="nad-edge-path" points="1086.32,42.47 994.73,206.57"/>
                 <g class="nad-edge-infos" transform="translate(1070.48,70.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.83)">
@@ -1027,7 +1025,7 @@
         <g id="68">
             <desc>L51-52-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="791.25,-220.30 945.28,-483.87"/>
+                <polyline class="nad-edge-path" points="791.25,-220.30 945.28,-483.87"/>
                 <g class="nad-edge-infos" transform="translate(807.65,-248.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(30.30)">
@@ -1046,7 +1044,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1099.30,-747.44 945.28,-483.87"/>
+                <polyline class="nad-edge-path" points="1099.30,-747.44 945.28,-483.87"/>
                 <g class="nad-edge-infos" transform="translate(1082.91,-719.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.70)">
@@ -1068,7 +1066,7 @@
         <g id="69">
             <desc>L51-58-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="799.28,-212.90 928.58,-303.35"/>
+                <polyline class="nad-edge-path" points="799.28,-212.90 928.58,-303.35"/>
                 <g class="nad-edge-infos" transform="translate(825.91,-231.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.03)">
@@ -1087,7 +1085,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1057.88,-393.79 928.58,-303.35"/>
+                <polyline class="nad-edge-path" points="1057.88,-393.79 928.58,-303.35"/>
                 <g class="nad-edge-infos" transform="translate(1031.25,-375.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.97)">
@@ -1109,7 +1107,7 @@
         <g id="70">
             <desc>L52-53-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1089.94,-781.95 945.06,-863.37"/>
+                <polyline class="nad-edge-path" points="1089.94,-781.95 945.06,-863.37"/>
                 <g class="nad-edge-infos" transform="translate(1061.61,-797.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-60.66)">
@@ -1128,7 +1126,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="800.18,-944.79 945.06,-863.37"/>
+                <polyline class="nad-edge-path" points="800.18,-944.79 945.06,-863.37"/>
                 <g class="nad-edge-infos" transform="translate(828.51,-928.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.34)">
@@ -1150,7 +1148,7 @@
         <g id="71">
             <desc>L53-54-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="759.43,-939.76 533.48,-725.92"/>
+                <polyline class="nad-edge-path" points="759.43,-939.76 533.48,-725.92"/>
                 <g class="nad-edge-infos" transform="translate(735.82,-917.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.42)">
@@ -1169,7 +1167,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="307.53,-512.09 533.48,-725.92"/>
+                <polyline class="nad-edge-path" points="307.53,-512.09 533.48,-725.92"/>
                 <g class="nad-edge-infos" transform="translate(331.14,-534.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.58)">
@@ -1191,7 +1189,7 @@
         <g id="72">
             <desc>L54-55-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="291.75,-519.91 308.41,-674.00"/>
+                <polyline class="nad-edge-path" points="291.75,-519.91 308.41,-674.00"/>
                 <g class="nad-edge-infos" transform="translate(295.25,-552.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.17)">
@@ -1210,7 +1208,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="325.07,-828.09 308.41,-674.00"/>
+                <polyline class="nad-edge-path" points="325.07,-828.09 308.41,-674.00"/>
                 <g class="nad-edge-infos" transform="translate(321.58,-795.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.83)">
@@ -1232,7 +1230,7 @@
         <g id="73">
             <desc>L54-56-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="314.21,-498.43 450.52,-519.37"/>
+                <polyline class="nad-edge-path" points="314.21,-498.43 450.52,-519.37"/>
                 <g class="nad-edge-infos" transform="translate(346.34,-503.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.27)">
@@ -1251,7 +1249,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="586.82,-540.31 450.52,-519.37"/>
+                <polyline class="nad-edge-path" points="586.82,-540.31 450.52,-519.37"/>
                 <g class="nad-edge-infos" transform="translate(554.70,-535.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.73)">
@@ -1273,7 +1271,7 @@
         <g id="74">
             <desc>L54-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="272.34,-513.85 126.54,-682.60"/>
+                <polyline class="nad-edge-path" points="272.34,-513.85 126.54,-682.60"/>
                 <g class="nad-edge-infos" transform="translate(251.09,-538.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.83)">
@@ -1292,7 +1290,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-19.27,-851.34 126.54,-682.60"/>
+                <polyline class="nad-edge-path" points="-19.27,-851.34 126.54,-682.60"/>
                 <g class="nad-edge-infos" transform="translate(1.98,-826.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.17)">
@@ -1314,7 +1312,7 @@
         <g id="75">
             <desc>L55-56-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="345.07,-834.67 469.92,-698.81"/>
+                <polyline class="nad-edge-path" points="345.07,-834.67 469.92,-698.81"/>
                 <g class="nad-edge-infos" transform="translate(367.06,-810.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.42)">
@@ -1333,7 +1331,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="594.77,-562.96 469.92,-698.81"/>
+                <polyline class="nad-edge-path" points="594.77,-562.96 469.92,-698.81"/>
                 <g class="nad-edge-infos" transform="translate(572.78,-586.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.58)">
@@ -1355,7 +1353,7 @@
         <g id="76">
             <desc>L55-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="302.34,-854.65 145.94,-862.04"/>
+                <polyline class="nad-edge-path" points="302.34,-854.65 145.94,-862.04"/>
                 <g class="nad-edge-infos" transform="translate(269.88,-856.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.29)">
@@ -1374,7 +1372,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-10.47,-869.43 145.94,-862.04"/>
+                <polyline class="nad-edge-path" points="-10.47,-869.43 145.94,-862.04"/>
                 <g class="nad-edge-infos" transform="translate(22.00,-867.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.71)">
@@ -1396,7 +1394,7 @@
         <g id="77">
             <desc>L56-57-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="628.68,-524.87 855.38,-261.99"/>
+                <polyline class="nad-edge-path" points="628.68,-524.87 855.38,-261.99"/>
                 <g class="nad-edge-infos" transform="translate(649.90,-500.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(139.23)">
@@ -1415,7 +1413,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1082.09,0.89 855.38,-261.99"/>
+                <polyline class="nad-edge-path" points="1082.09,0.89 855.38,-261.99"/>
                 <g class="nad-edge-infos" transform="translate(1060.86,-23.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-40.77)">
@@ -1437,7 +1435,7 @@
         <g id="78">
             <desc>L56-58-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="636.51,-537.06 845.40,-476.30"/>
+                <polyline class="nad-edge-path" points="636.51,-537.06 845.40,-476.30"/>
                 <g class="nad-edge-infos" transform="translate(667.72,-527.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.22)">
@@ -1456,7 +1454,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1054.29,-415.53 845.40,-476.30"/>
+                <polyline class="nad-edge-path" points="1054.29,-415.53 845.40,-476.30"/>
                 <g class="nad-edge-infos" transform="translate(1023.08,-424.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.78)">
@@ -1478,7 +1476,7 @@
         <g id="79">
             <desc>L56-59-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="598.04,-565.50 568.15,-611.08 306.04,-743.13"/>
+                <polyline class="nad-edge-path" points="598.04,-565.50 568.15,-611.08 306.04,-743.13"/>
                 <g class="nad-edge-infos" transform="translate(541.36,-624.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1497,7 +1495,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-10.48,-872.09 43.93,-875.19 306.04,-743.13"/>
+                <polyline class="nad-edge-path" points="-10.48,-872.09 43.93,-875.19 306.04,-743.13"/>
                 <g class="nad-edge-infos" transform="translate(70.72,-861.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1519,7 +1517,7 @@
         <g id="80">
             <desc>L56-59-2</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="586.57,-542.73 532.15,-539.63 270.04,-671.69"/>
+                <polyline class="nad-edge-path" points="586.57,-542.73 532.15,-539.63 270.04,-671.69"/>
                 <g class="nad-edge-infos" transform="translate(505.36,-553.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.26)">
@@ -1538,7 +1536,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-21.95,-849.31 7.94,-803.74 270.04,-671.69"/>
+                <polyline class="nad-edge-path" points="-21.95,-849.31 7.94,-803.74 270.04,-671.69"/>
                 <g class="nad-edge-infos" transform="translate(34.73,-790.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.74)">
@@ -1560,7 +1558,7 @@
         <g id="81">
             <desc>L59-60-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-60.08,-862.42 -257.17,-795.29"/>
+                <polyline class="nad-edge-path" points="-60.08,-862.42 -257.17,-795.29"/>
                 <g class="nad-edge-infos" transform="translate(-90.84,-851.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.81)">
@@ -1579,7 +1577,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-454.26,-728.16 -257.17,-795.29"/>
+                <polyline class="nad-edge-path" points="-454.26,-728.16 -257.17,-795.29"/>
                 <g class="nad-edge-infos" transform="translate(-423.50,-738.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.19)">
@@ -1601,7 +1599,7 @@
         <g id="82">
             <desc>L59-61-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-60.94,-875.66 -322.82,-928.23"/>
+                <polyline class="nad-edge-path" points="-60.94,-875.66 -322.82,-928.23"/>
                 <g class="nad-edge-infos" transform="translate(-92.80,-882.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.65)">
@@ -1620,7 +1618,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-584.70,-980.80 -322.82,-928.23"/>
+                <polyline class="nad-edge-path" points="-584.70,-980.80 -322.82,-928.23"/>
                 <g class="nad-edge-infos" transform="translate(-552.83,-974.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(101.35)">
@@ -1642,7 +1640,7 @@
         <g id="83">
             <desc>T63-59-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-203.45,-1345.85 -133.91,-1148.56"/>
+                <polyline class="nad-edge-path" points="-203.45,-1345.85 -133.91,-1148.56"/>
                 <g class="nad-edge-infos" transform="translate(-192.65,-1315.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.58)">
@@ -1659,10 +1657,10 @@
                         <text transform="rotate(70.58)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-127.26" cy="-1129.70" r="20.00"/>
+                <circle class="nad-winding" cx="-127.26" cy="-1129.70" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-44.42,-894.69 -113.96,-1091.97"/>
+                <polyline class="nad-edge-path" points="-44.42,-894.69 -113.96,-1091.97"/>
                 <g class="nad-edge-infos" transform="translate(-55.22,-925.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.42)">
@@ -1679,13 +1677,13 @@
                         <text transform="rotate(-289.42)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-120.61" cy="-1110.84" r="20.00"/>
+                <circle class="nad-winding" cx="-120.61" cy="-1110.84" r="20.00"/>
             </g>
         </g>
         <g id="84">
             <desc>L60-61-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-489.69,-742.80 -544.05,-852.88"/>
+                <polyline class="nad-edge-path" points="-489.69,-742.80 -544.05,-852.88"/>
                 <g class="nad-edge-infos" transform="translate(-504.08,-771.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.28)">
@@ -1704,7 +1702,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-598.41,-962.95 -544.05,-852.88"/>
+                <polyline class="nad-edge-path" points="-598.41,-962.95 -544.05,-852.88"/>
                 <g class="nad-edge-infos" transform="translate(-584.02,-933.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.72)">
@@ -1726,7 +1724,7 @@
         <g id="87">
             <desc>L60-62-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-499.08,-705.01 -644.79,-599.82"/>
+                <polyline class="nad-edge-path" points="-499.08,-705.01 -644.79,-599.82"/>
                 <g class="nad-edge-infos" transform="translate(-525.43,-685.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-125.83)">
@@ -1748,7 +1746,7 @@
         <g id="88">
             <desc>L61-62-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-619.13,-962.13 -710.44,-732.76"/>
+                <polyline class="nad-edge-path" points="-619.13,-962.13 -710.44,-732.76"/>
                 <g class="nad-edge-infos" transform="translate(-631.15,-931.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.29)">
@@ -1770,10 +1768,10 @@
         <g id="91">
             <desc>T64-61-1</desc>
             <g class="nad-vl120to180-1">
-                <circle cx="-609.22" cy="-1213.64" r="20.00"/>
+                <circle class="nad-winding" cx="-609.22" cy="-1213.64" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-609.65,-1011.32 -609.31,-1173.64"/>
+                <polyline class="nad-edge-path" points="-609.65,-1011.32 -609.31,-1173.64"/>
                 <g class="nad-edge-infos" transform="translate(-609.58,-1043.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(0.12)">
@@ -1790,13 +1788,13 @@
                         <text transform="rotate(-89.88)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-609.26" cy="-1193.64" r="20.00"/>
+                <circle class="nad-winding" cx="-609.26" cy="-1193.64" r="20.00"/>
             </g>
         </g>
         <g id="92">
             <desc>L63-64-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-237.22,-1373.19 -410.36,-1395.68"/>
+                <polyline class="nad-edge-path" points="-237.22,-1373.19 -410.36,-1395.68"/>
                 <g class="nad-edge-infos" transform="translate(-269.44,-1377.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.60)">
@@ -1818,7 +1816,7 @@
         <g id="93">
             <desc>L62-66-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-800.57,284.53 -805.70,-84.84"/>
+                <polyline class="nad-edge-path" points="-800.57,284.53 -805.70,-84.84"/>
                 <g class="nad-edge-infos" transform="translate(-801.02,252.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.80)">
@@ -1840,7 +1838,7 @@
         <g id="96">
             <desc>L66-67-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-814.96,330.84 -940.23,507.63"/>
+                <polyline class="nad-edge-path" points="-814.96,330.84 -940.23,507.63"/>
                 <g class="nad-edge-infos" transform="translate(-833.75,357.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.68)">
@@ -1862,10 +1860,10 @@
         <g id="99">
             <desc>T65-66-1</desc>
             <g class="nad-vl120to180-1">
-                <circle cx="-1079.94" cy="313.75" r="20.00"/>
+                <circle class="nad-winding" cx="-1079.94" cy="313.75" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-825.71,310.37 -1039.95,313.21"/>
+                <polyline class="nad-edge-path" points="-825.71,310.37 -1039.95,313.21"/>
                 <g class="nad-edge-infos" transform="translate(-858.21,310.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.76)">
@@ -1882,13 +1880,13 @@
                         <text transform="rotate(-0.76)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1059.94" cy="313.48" r="20.00"/>
+                <circle class="nad-winding" cx="-1059.94" cy="313.48" r="20.00"/>
             </g>
         </g>
         <g id="102">
             <desc>L69-70-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-49.22,1326.55 151.41,1441.36"/>
+                <polyline class="nad-edge-path" points="-49.22,1326.55 151.41,1441.36"/>
                 <g class="nad-edge-infos" transform="translate(-21.02,1342.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(119.78)">
@@ -1910,7 +1908,7 @@
         <g id="105">
             <desc>L69-75-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-86.29,1334.56 -224.71,1526.05"/>
+                <polyline class="nad-edge-path" points="-86.29,1334.56 -224.71,1526.05"/>
                 <g class="nad-edge-infos" transform="translate(-105.33,1360.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.14)">
@@ -1932,7 +1930,7 @@
         <g id="108">
             <desc>L69-77-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-96.80,1315.55 -305.44,1329.15"/>
+                <polyline class="nad-edge-path" points="-96.80,1315.55 -305.44,1329.15"/>
                 <g class="nad-edge-infos" transform="translate(-129.23,1317.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-93.73)">
@@ -1954,10 +1952,10 @@
         <g id="111">
             <desc>T68-69-1</desc>
             <g class="nad-vl120to180-1">
-                <circle cx="-13.84" cy="1575.97" r="20.00"/>
+                <circle class="nad-winding" cx="-13.84" cy="1575.97" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-65.89,1338.80 -22.41,1536.90"/>
+                <polyline class="nad-edge-path" points="-65.89,1338.80 -22.41,1536.90"/>
                 <g class="nad-edge-infos" transform="translate(-58.92,1370.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(167.62)">
@@ -1974,7 +1972,7 @@
                         <text transform="rotate(77.62)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-18.13" cy="1556.44" r="20.00"/>
+                <circle class="nad-winding" cx="-18.13" cy="1556.44" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -207,43 +207,43 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-178.77,407.56)" id="0">
             <desc>VL113</desc>
-            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="1" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-641.86,1404.47)" id="2">
             <desc>VL114</desc>
-            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="3" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(95.73,1251.53)" id="4">
             <desc>VL23</desc>
-            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="5" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-777.31,1072.53)" id="6">
             <desc>VL27</desc>
-            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="7" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(158.89,-689.41)" id="8">
             <desc>VL30</desc>
-            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="9" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-609.09,288.76)" id="10">
             <desc>VL31</desc>
-            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="11" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(-399.08,854.10)" id="12">
             <desc>VL32</desc>
-            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="13" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(1109.61,-122.88)" id="14">
             <desc>VL37</desc>
-            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle r="27.50" id="15" class="nad-vl120to180-0 nad-busnode"/>
         </g>
         <g transform="translate(393.66,-484.06)" id="16">
             <desc>VL38</desc>
-            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="17" class="nad-vl120to180-1 nad-busnode"/>
         </g>
         <g transform="translate(-335.40,-921.45)" id="18">
             <desc>VL65</desc>
-            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-1"/>
+            <circle r="27.50" id="19" class="nad-vl120to180-1 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_118_bus_partial_non_connected.svg
+++ b/src/test/resources/IEEE_118_bus_partial_non_connected.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="861.83" viewBox="-1413.35 -1581.18 3205.08 3452.81" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -92,7 +90,7 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -209,50 +207,50 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-178.77,407.56)" id="0">
             <desc>VL113</desc>
-            <circle r="27.50" id="1" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-641.86,1404.47)" id="2">
             <desc>VL114</desc>
-            <circle r="27.50" id="3" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="3" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(95.73,1251.53)" id="4">
             <desc>VL23</desc>
-            <circle r="27.50" id="5" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="5" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-777.31,1072.53)" id="6">
             <desc>VL27</desc>
-            <circle r="27.50" id="7" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="7" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(158.89,-689.41)" id="8">
             <desc>VL30</desc>
-            <circle r="27.50" id="9" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="9" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-609.09,288.76)" id="10">
             <desc>VL31</desc>
-            <circle r="27.50" id="11" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="11" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(-399.08,854.10)" id="12">
             <desc>VL32</desc>
-            <circle r="27.50" id="13" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(1109.61,-122.88)" id="14">
             <desc>VL37</desc>
-            <circle r="27.50" id="15" class="nad-vl120to180-0"/>
+            <circle class="nad-busnode" r="27.50" id="15" class="nad-vl120to180-0"/>
         </g>
         <g transform="translate(393.66,-484.06)" id="16">
             <desc>VL38</desc>
-            <circle r="27.50" id="17" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="17" class="nad-vl120to180-1"/>
         </g>
         <g transform="translate(-335.40,-921.45)" id="18">
             <desc>VL65</desc>
-            <circle r="27.50" id="19" class="nad-vl120to180-1"/>
+            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl120to180-1"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22">
             <desc>L17-113-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-180.22,382.10 -192.18,171.78"/>
+                <polyline class="nad-edge-path" points="-180.22,382.10 -192.18,171.78"/>
                 <g class="nad-edge-infos" transform="translate(-182.06,349.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.26)">
@@ -274,7 +272,7 @@
         <g id="23">
             <desc>L32-113-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-387.80,831.23 -288.92,630.83"/>
+                <polyline class="nad-edge-path" points="-387.80,831.23 -288.92,630.83"/>
                 <g class="nad-edge-infos" transform="translate(-373.42,802.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.26)">
@@ -293,7 +291,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-190.05,430.43 -288.92,630.83"/>
+                <polyline class="nad-edge-path" points="-190.05,430.43 -288.92,630.83"/>
                 <g class="nad-edge-infos" transform="translate(-204.43,459.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.74)">
@@ -315,7 +313,7 @@
         <g id="24">
             <desc>L32-114-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-409.37,877.43 -520.47,1129.28"/>
+                <polyline class="nad-edge-path" points="-409.37,877.43 -520.47,1129.28"/>
                 <g class="nad-edge-infos" transform="translate(-422.49,907.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.20)">
@@ -334,7 +332,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-631.57,1381.14 -520.47,1129.28"/>
+                <polyline class="nad-edge-path" points="-631.57,1381.14 -520.47,1129.28"/>
                 <g class="nad-edge-infos" transform="translate(-618.46,1351.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.80)">
@@ -356,7 +354,7 @@
         <g id="27">
             <desc>L114-115-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-667.16,1407.69 -816.46,1426.66"/>
+                <polyline class="nad-edge-path" points="-667.16,1407.69 -816.46,1426.66"/>
                 <g class="nad-edge-infos" transform="translate(-699.40,1411.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.24)">
@@ -378,7 +376,7 @@
         <g id="30">
             <desc>L22-23-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="106.35,1274.71 191.93,1461.58"/>
+                <polyline class="nad-edge-path" points="106.35,1274.71 191.93,1461.58"/>
                 <g class="nad-edge-infos" transform="translate(119.88,1304.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.39)">
@@ -400,7 +398,7 @@
         <g id="33">
             <desc>L23-24-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="121.21,1250.56 317.78,1243.13"/>
+                <polyline class="nad-edge-path" points="121.21,1250.56 317.78,1243.13"/>
                 <g class="nad-edge-infos" transform="translate(153.69,1249.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.83)">
@@ -422,7 +420,7 @@
         <g id="36">
             <desc>L23-25-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="70.36,1254.07 -92.86,1270.43"/>
+                <polyline class="nad-edge-path" points="70.36,1254.07 -92.86,1270.43"/>
                 <g class="nad-edge-infos" transform="translate(38.02,1257.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-95.72)">
@@ -444,7 +442,7 @@
         <g id="37">
             <desc>L23-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="75.85,1235.56 -151.68,1052.81"/>
+                <polyline class="nad-edge-path" points="75.85,1235.56 -151.68,1052.81"/>
                 <g class="nad-edge-infos" transform="translate(50.51,1215.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-51.23)">
@@ -463,7 +461,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-379.20,870.07 -151.68,1052.81"/>
+                <polyline class="nad-edge-path" points="-379.20,870.07 -151.68,1052.81"/>
                 <g class="nad-edge-infos" transform="translate(-353.86,890.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(128.77)">
@@ -485,7 +483,7 @@
         <g id="38">
             <desc>L25-27-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-753.95,1082.74 -529.38,1180.93"/>
+                <polyline class="nad-edge-path" points="-753.95,1082.74 -529.38,1180.93"/>
                 <g class="nad-edge-infos" transform="translate(-724.17,1095.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.62)">
@@ -507,7 +505,7 @@
         <g id="41">
             <desc>L27-28-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-801.54,1064.57 -995.33,1000.90"/>
+                <polyline class="nad-edge-path" points="-801.54,1064.57 -995.33,1000.90"/>
                 <g class="nad-edge-infos" transform="translate(-832.41,1054.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-71.81)">
@@ -529,7 +527,7 @@
         <g id="42">
             <desc>L27-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-755.23,1059.77 -588.20,963.31"/>
+                <polyline class="nad-edge-path" points="-755.23,1059.77 -588.20,963.31"/>
                 <g class="nad-edge-infos" transform="translate(-727.09,1043.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.99)">
@@ -548,7 +546,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-421.16,866.85 -588.20,963.31"/>
+                <polyline class="nad-edge-path" points="-421.16,866.85 -588.20,963.31"/>
                 <g class="nad-edge-infos" transform="translate(-449.31,883.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.01)">
@@ -570,7 +568,7 @@
         <g id="43">
             <desc>L27-115-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-789.91,1094.70 -884.19,1260.69"/>
+                <polyline class="nad-edge-path" points="-789.91,1094.70 -884.19,1260.69"/>
                 <g class="nad-edge-infos" transform="translate(-805.96,1122.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.40)">
@@ -592,7 +590,7 @@
         <g id="46">
             <desc>L8-30-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="161.28,-714.79 181.09,-925.10"/>
+                <polyline class="nad-edge-path" points="161.28,-714.79 181.09,-925.10"/>
                 <g class="nad-edge-infos" transform="translate(164.33,-747.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.38)">
@@ -614,7 +612,7 @@
         <g id="49">
             <desc>L26-30-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="180.22,-703.39 366.84,-825.70"/>
+                <polyline class="nad-edge-path" points="180.22,-703.39 366.84,-825.70"/>
                 <g class="nad-edge-infos" transform="translate(207.40,-721.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(56.76)">
@@ -636,7 +634,7 @@
         <g id="50">
             <desc>L30-38-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="178.09,-672.62 276.28,-586.74"/>
+                <polyline class="nad-edge-path" points="178.09,-672.62 276.28,-586.74"/>
                 <g class="nad-edge-infos" transform="translate(202.55,-651.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.18)">
@@ -655,7 +653,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="374.47,-500.85 276.28,-586.74"/>
+                <polyline class="nad-edge-path" points="374.47,-500.85 276.28,-586.74"/>
                 <g class="nad-edge-infos" transform="translate(350.00,-522.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.82)">
@@ -677,7 +675,7 @@
         <g id="51">
             <desc>T30-17-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="146.05,-667.38 -8.24,-402.63"/>
+                <polyline class="nad-edge-path" points="146.05,-667.38 -8.24,-402.63"/>
                 <g class="nad-edge-infos" transform="translate(129.69,-639.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-149.77)">
@@ -694,16 +692,16 @@
                         <text transform="rotate(-59.77)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-18.31" cy="-385.35" r="20.00"/>
+                <circle class="nad-winding" cx="-18.31" cy="-385.35" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <circle cx="-28.38" cy="-368.07" r="20.00"/>
+                <circle class="nad-winding" cx="-28.38" cy="-368.07" r="20.00"/>
             </g>
         </g>
         <g id="52">
             <desc>L17-31-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-589.89,271.97 -407.34,112.38"/>
+                <polyline class="nad-edge-path" points="-589.89,271.97 -407.34,112.38"/>
                 <g class="nad-edge-infos" transform="translate(-565.42,250.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.84)">
@@ -725,7 +723,7 @@
         <g id="55">
             <desc>L29-31-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-633.16,280.34 -821.49,214.53"/>
+                <polyline class="nad-edge-path" points="-633.16,280.34 -821.49,214.53"/>
                 <g class="nad-edge-infos" transform="translate(-663.84,269.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.74)">
@@ -747,7 +745,7 @@
         <g id="56">
             <desc>L31-32-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="-600.21,312.66 -504.08,571.43"/>
+                <polyline class="nad-edge-path" points="-600.21,312.66 -504.08,571.43"/>
                 <g class="nad-edge-infos" transform="translate(-588.89,343.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.62)">
@@ -766,7 +764,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="-407.96,830.19 -504.08,571.43"/>
+                <polyline class="nad-edge-path" points="-407.96,830.19 -504.08,571.43"/>
                 <g class="nad-edge-infos" transform="translate(-419.28,799.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.38)">
@@ -788,7 +786,7 @@
         <g id="59">
             <desc>L35-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1102.91,-98.27 1048.86,100.04"/>
+                <polyline class="nad-edge-path" points="1102.91,-98.27 1048.86,100.04"/>
                 <g class="nad-edge-infos" transform="translate(1094.36,-66.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.76)">
@@ -810,7 +808,7 @@
         <g id="62">
             <desc>L33-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1125.34,-102.80 1267.79,79.00"/>
+                <polyline class="nad-edge-path" points="1125.34,-102.80 1267.79,79.00"/>
                 <g class="nad-edge-infos" transform="translate(1145.39,-77.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.92)">
@@ -832,7 +830,7 @@
         <g id="65">
             <desc>L34-37-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1084.13,-121.93 940.03,-116.57"/>
+                <polyline class="nad-edge-path" points="1084.13,-121.93 940.03,-116.57"/>
                 <g class="nad-edge-infos" transform="translate(1051.65,-120.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.13)">
@@ -854,7 +852,7 @@
         <g id="68">
             <desc>L37-39-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1121.54,-145.41 1215.57,-323.09"/>
+                <polyline class="nad-edge-path" points="1121.54,-145.41 1215.57,-323.09"/>
                 <g class="nad-edge-infos" transform="translate(1136.74,-174.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.89)">
@@ -876,7 +874,7 @@
         <g id="71">
             <desc>L37-40-1</desc>
             <g class="nad-vl120to180-0">
-                <polyline points="1135.10,-123.68 1350.67,-130.46"/>
+                <polyline class="nad-edge-path" points="1135.10,-123.68 1350.67,-130.46"/>
                 <g class="nad-edge-infos" transform="translate(1167.58,-124.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.20)">
@@ -898,7 +896,7 @@
         <g id="72">
             <desc>T38-37-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="416.43,-472.58 724.85,-316.98"/>
+                <polyline class="nad-edge-path" points="416.43,-472.58 724.85,-316.98"/>
                 <g class="nad-edge-infos" transform="translate(445.44,-457.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.77)">
@@ -915,10 +913,10 @@
                         <text transform="rotate(26.77)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="742.71" cy="-307.97" r="20.00"/>
+                <circle class="nad-winding" cx="742.71" cy="-307.97" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <polyline points="1086.85,-134.36 778.42,-289.96"/>
+                <polyline class="nad-edge-path" points="1086.85,-134.36 778.42,-289.96"/>
                 <g class="nad-edge-infos" transform="translate(1057.83,-149.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.23)">
@@ -935,13 +933,13 @@
                         <text transform="rotate(-333.23)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="760.56" cy="-298.97" r="20.00"/>
+                <circle class="nad-winding" cx="760.56" cy="-298.97" r="20.00"/>
             </g>
         </g>
         <g id="73">
             <desc>L38-65-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="371.79,-497.18 29.13,-702.76"/>
+                <polyline class="nad-edge-path" points="371.79,-497.18 29.13,-702.76"/>
                 <g class="nad-edge-infos" transform="translate(343.92,-513.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.04)">
@@ -960,7 +958,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180-1">
-                <polyline points="-313.54,-908.33 29.13,-702.76"/>
+                <polyline class="nad-edge-path" points="-313.54,-908.33 29.13,-702.76"/>
                 <g class="nad-edge-infos" transform="translate(-285.67,-891.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.96)">
@@ -982,7 +980,7 @@
         <g id="76">
             <desc>L64-65-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-336.22,-946.94 -342.74,-1151.32"/>
+                <polyline class="nad-edge-path" points="-336.22,-946.94 -342.74,-1151.32"/>
                 <g class="nad-edge-infos" transform="translate(-337.25,-979.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-1.83)">
@@ -1004,7 +1002,7 @@
         <g id="79">
             <desc>L65-68-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-357.76,-933.73 -551.17,-1039.95"/>
+                <polyline class="nad-edge-path" points="-357.76,-933.73 -551.17,-1039.95"/>
                 <g class="nad-edge-infos" transform="translate(-386.24,-949.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.22)">
@@ -1026,7 +1024,7 @@
         <g id="82">
             <desc>T65-66-1</desc>
             <g class="nad-vl120to180-1">
-                <polyline points="-357.53,-908.78 -495.05,-829.99"/>
+                <polyline class="nad-edge-path" points="-357.53,-908.78 -495.05,-829.99"/>
                 <g class="nad-edge-infos" transform="translate(-385.73,-892.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-119.81)">
@@ -1043,10 +1041,10 @@
                         <text transform="rotate(-29.81)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-512.41" cy="-820.05" r="20.00"/>
+                <circle class="nad-winding" cx="-512.41" cy="-820.05" r="20.00"/>
             </g>
             <g class="nad-vl120to180-0">
-                <circle cx="-529.76" cy="-810.11" r="20.00"/>
+                <circle class="nad-winding" cx="-529.76" cy="-810.11" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -108,59 +108,59 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(827.88,25.42)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(405.95,123.38)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(369.06,599.72)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(568.63,975.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_14_bus.svg
+++ b/src/test/resources/IEEE_14_bus.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="801.74" viewBox="-920.95 -877.83 2048.83 2053.29" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -110,66 +108,66 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(827.88,25.42)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(405.95,123.38)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(369.06,599.72)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(568.63,975.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="28">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -188,7 +186,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
@@ -210,7 +208,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -229,7 +227,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
@@ -251,7 +249,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -270,7 +268,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(78.60)">
@@ -292,7 +290,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
@@ -311,7 +309,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -333,7 +331,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -352,7 +350,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
@@ -374,7 +372,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -393,7 +391,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
@@ -415,7 +413,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -434,7 +432,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
@@ -456,7 +454,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -475,7 +473,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
@@ -497,7 +495,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-613.96,-278.15 -469.33,-102.81"/>
+                <polyline class="nad-edge-path" points="-613.96,-278.15 -469.33,-102.81"/>
                 <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -516,7 +514,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-324.70,72.53 -469.33,-102.81"/>
+                <polyline class="nad-edge-path" points="-324.70,72.53 -469.33,-102.81"/>
                 <g class="nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-39.52)">
@@ -538,7 +536,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-40.58,397.53 -166.12,254.45"/>
+                <polyline class="nad-edge-path" points="-40.58,397.53 -166.12,254.45"/>
                 <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -557,7 +555,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-291.66,111.37 -166.12,254.45"/>
+                <polyline class="nad-edge-path" points="-291.66,111.37 -166.12,254.45"/>
                 <g class="nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(138.74)">
@@ -579,7 +577,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -598,7 +596,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
@@ -620,7 +618,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -639,7 +637,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
@@ -661,7 +659,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -680,7 +678,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
@@ -702,7 +700,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-103.07)">
@@ -721,7 +719,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -743,7 +741,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
@@ -762,7 +760,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -784,7 +782,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,10 +799,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">21</text>
                     </g>
                 </g>
-                <circle cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(4.43)">
@@ -821,13 +819,13 @@
                         <text transform="rotate(-85.57)" x="19.00">-18</text>
                     </g>
                 </g>
-                <circle cx="386.73" cy="371.52" r="20.00"/>
+                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -844,10 +842,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">-13</text>
                     </g>
                 </g>
-                <circle cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
@@ -864,13 +862,13 @@
                         <text transform="rotate(-34.32)" x="19.00">16</text>
                     </g>
                 </g>
-                <circle cx="182.84" cy="275.68" r="20.00"/>
+                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -887,10 +885,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">9</text>
                     </g>
                 </g>
-                <circle cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
@@ -907,13 +905,13 @@
                         <text transform="rotate(2.94)" x="19.00">-6</text>
                     </g>
                 </g>
-                <circle cx="-65.47" cy="-364.87" r="20.00"/>
+                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -932,7 +930,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -954,7 +952,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -973,7 +971,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(114.98)">

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -107,23 +107,23 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
@@ -131,35 +131,35 @@
         </g>
         <g transform="translate(596.05,-263.35)" id="11" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="12"/>
+            <circle r="27.50" id="12" class="nad-busnode"/>
         </g>
         <g transform="translate(827.88,25.42)" id="13" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="14"/>
+            <circle r="27.50" id="14" class="nad-busnode"/>
         </g>
         <g transform="translate(405.95,123.38)" id="15" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="16"/>
+            <circle r="27.50" id="16" class="nad-busnode"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="17" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="18"/>
+            <circle r="27.50" id="18" class="nad-busnode"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="19" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="20"/>
+            <circle r="27.50" id="20" class="nad-busnode"/>
         </g>
         <g transform="translate(369.06,599.72)" id="21" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="22"/>
+            <circle r="27.50" id="22" class="nad-busnode"/>
         </g>
         <g transform="translate(568.63,975.46)" id="23" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="24"/>
+            <circle r="27.50" id="24" class="nad-busnode"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="25" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="26"/>
+            <circle r="27.50" id="26" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_14_bus_disconnection.svg
+++ b/src/test/resources/IEEE_14_bus_disconnection.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="801.74" viewBox="-920.95 -877.83 2048.83 2053.29" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -109,23 +107,23 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
@@ -133,42 +131,42 @@
         </g>
         <g transform="translate(596.05,-263.35)" id="11" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="12"/>
+            <circle class="nad-busnode" r="27.50" id="12"/>
         </g>
         <g transform="translate(827.88,25.42)" id="13" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="14"/>
+            <circle class="nad-busnode" r="27.50" id="14"/>
         </g>
         <g transform="translate(405.95,123.38)" id="15" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="16"/>
+            <circle class="nad-busnode" r="27.50" id="16"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="17" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="18"/>
+            <circle class="nad-busnode" r="27.50" id="18"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="19" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle r="27.50" id="20"/>
+            <circle class="nad-busnode" r="27.50" id="20"/>
         </g>
         <g transform="translate(369.06,599.72)" id="21" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle r="27.50" id="22"/>
+            <circle class="nad-busnode" r="27.50" id="22"/>
         </g>
         <g transform="translate(568.63,975.46)" id="23" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle r="27.50" id="24"/>
+            <circle class="nad-busnode" r="27.50" id="24"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="25" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="26"/>
+            <circle class="nad-busnode" r="27.50" id="26"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="27">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -187,7 +185,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-11.78)">
@@ -209,7 +207,7 @@
         <g id="28">
             <desc>L1-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -228,7 +226,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(44.94)">
@@ -250,7 +248,7 @@
         <g id="29">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-101.40)">
@@ -269,7 +267,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -291,7 +289,7 @@
         <g id="30">
             <desc>L10-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-26.97)">
@@ -310,7 +308,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -332,7 +330,7 @@
         <g id="31">
             <desc>L6-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -351,7 +349,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(37.73)">
@@ -373,7 +371,7 @@
         <g id="32">
             <desc>L6-12-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -392,7 +390,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(133.48)">
@@ -414,7 +412,7 @@
         <g id="33">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -433,7 +431,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-0.86)">
@@ -455,7 +453,7 @@
         <g id="34">
             <desc>L6-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -474,7 +472,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(74.62)">
@@ -496,7 +494,7 @@
         <g id="35" class="nad-disconnected">
             <desc>L13-14-1</desc>
             <g class="nad-disconnected nad-vl0to30">
-                <polyline points="-613.96,-278.15 -473.94,-108.41"/>
+                <polyline class="nad-edge-path" points="-613.96,-278.15 -473.94,-108.41"/>
                 <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -515,7 +513,7 @@
                 </g>
             </g>
             <g class="nad-disconnected nad-vl0to30">
-                <polyline points="-333.93,61.34 -473.94,-108.41"/>
+                <polyline class="nad-edge-path" points="-333.93,61.34 -473.94,-108.41"/>
                 <g class="nad-edge-infos" transform="translate(-354.61,36.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -537,7 +535,7 @@
         <g id="36" class="nad-disconnected">
             <desc>L9-14-1</desc>
             <g class="nad-disconnected nad-vl0to30">
-                <polyline points="-40.58,397.53 -161.34,259.90"/>
+                <polyline class="nad-edge-path" points="-40.58,397.53 -161.34,259.90"/>
                 <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -556,7 +554,7 @@
                 </g>
             </g>
             <g class="nad-disconnected nad-vl0to30">
-                <polyline points="-282.09,122.27 -161.34,259.90"/>
+                <polyline class="nad-edge-path" points="-282.09,122.27 -161.34,259.90"/>
                 <g class="nad-edge-infos" transform="translate(-260.66,146.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -578,7 +576,7 @@
         <g id="37">
             <desc>L2-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -597,7 +595,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-38.76)">
@@ -619,7 +617,7 @@
         <g id="38">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -638,7 +636,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(26.18)">
@@ -660,7 +658,7 @@
         <g id="39">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -679,7 +677,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(103.15)">
@@ -701,7 +699,7 @@
         <g id="40">
             <desc>L3-4-1</desc>
             <g class="nad-disconnected nad-vl120to180">
-                <polyline points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -720,7 +718,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -742,7 +740,7 @@
         <g id="41">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-20.91)">
@@ -761,7 +759,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -783,7 +781,7 @@
         <g id="42">
             <desc>T4-7-1</desc>
             <g class="nad-disconnected nad-vl120to180">
-                <polyline points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -800,10 +798,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -820,13 +818,13 @@
                         <text transform="rotate(-85.57)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="386.73" cy="371.52" r="20.00"/>
+                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="43">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -843,10 +841,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">-6</text>
                     </g>
                 </g>
-                <circle cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(55.68)">
@@ -863,13 +861,13 @@
                         <text transform="rotate(-34.32)" x="19.00">11</text>
                     </g>
                 </g>
-                <circle cx="182.84" cy="275.68" r="20.00"/>
+                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="44">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -886,10 +884,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">14</text>
                     </g>
                 </g>
-                <circle cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(92.94)">
@@ -906,13 +904,13 @@
                         <text transform="rotate(2.94)" x="19.00">-10</text>
                     </g>
                 </g>
-                <circle cx="-65.47" cy="-364.87" r="20.00"/>
+                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="45">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -931,7 +929,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -953,7 +951,7 @@
         <g id="46">
             <desc>L7-9-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -972,7 +970,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="801.74" viewBox="-920.95 -877.83 2048.83 2053.29" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -110,66 +108,66 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle r="12.50" id="7"/>
+            <circle class="nad-busnode" r="12.50" id="7"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle r="12.50" id="11"/>
+            <circle class="nad-busnode" r="12.50" id="11"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(827.88,25.42)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(405.95,123.38)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(369.06,599.72)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(568.63,975.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="28">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -188,7 +186,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
@@ -210,7 +208,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -229,7 +227,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
@@ -251,7 +249,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -270,7 +268,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -292,7 +290,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
@@ -311,7 +309,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -333,7 +331,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -352,7 +350,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
@@ -374,7 +372,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-354.60,-396.29 -491.32,-525.95"/>
+                <polyline class="nad-edge-path" points="-354.60,-396.29 -491.32,-525.95"/>
                 <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -393,7 +391,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-628.04,-655.60 -491.32,-525.95"/>
+                <polyline class="nad-edge-path" points="-628.04,-655.60 -491.32,-525.95"/>
                 <g class="nad-edge-infos" transform="translate(-604.46,-633.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
@@ -415,7 +413,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-635.50,-652.33 -633.03,-487.83"/>
+                <polyline class="nad-edge-path" points="-635.50,-652.33 -633.03,-487.83"/>
                 <g class="nad-edge-infos" transform="translate(-635.01,-619.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -434,7 +432,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-630.57,-323.32 -633.03,-487.83"/>
+                <polyline class="nad-edge-path" points="-630.57,-323.32 -633.03,-487.83"/>
                 <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
@@ -456,7 +454,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -475,7 +473,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
@@ -497,7 +495,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-613.96,-278.15 -464.56,-97.03"/>
+                <polyline class="nad-edge-path" points="-613.96,-278.15 -464.56,-97.03"/>
                 <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -516,7 +514,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-315.16,84.10 -464.56,-97.03"/>
+                <polyline class="nad-edge-path" points="-315.16,84.10 -464.56,-97.03"/>
                 <g class="nad-edge-infos" transform="translate(-335.84,59.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -538,7 +536,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-40.58,397.53 -171.07,248.81"/>
+                <polyline class="nad-edge-path" points="-40.58,397.53 -171.07,248.81"/>
                 <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -557,7 +555,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-301.55,100.09 -171.07,248.81"/>
+                <polyline class="nad-edge-path" points="-301.55,100.09 -171.07,248.81"/>
                 <g class="nad-edge-infos" transform="translate(-280.12,124.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -579,7 +577,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -598,7 +596,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
@@ -620,7 +618,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -639,7 +637,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
@@ -661,7 +659,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -680,7 +678,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
@@ -702,7 +700,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -721,7 +719,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -743,7 +741,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
@@ -762,7 +760,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -784,7 +782,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,10 +799,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -821,13 +819,13 @@
                         <text transform="rotate(-85.57)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="386.73" cy="371.52" r="20.00"/>
+                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -844,10 +842,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
@@ -864,13 +862,13 @@
                         <text transform="rotate(-34.32)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="182.84" cy="275.68" r="20.00"/>
+                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -887,10 +885,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
@@ -907,13 +905,13 @@
                         <text transform="rotate(2.94)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-65.47" cy="-364.87" r="20.00"/>
+                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -932,7 +930,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -954,7 +952,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -973,7 +971,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/src/test/resources/IEEE_14_bus_fictitious.svg
+++ b/src/test/resources/IEEE_14_bus_fictitious.svg
@@ -108,59 +108,59 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="12.50" id="7"/>
+            <circle r="12.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="12.50" id="11"/>
+            <circle r="12.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(827.88,25.42)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(405.95,123.38)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(369.06,599.72)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(568.63,975.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -102,59 +102,59 @@
     <g class="nad-vl-nodes">
         <g transform="translate(979.43,495.57)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-1039.27,14.91)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-879.21,-478.53)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-111.97,-704.76)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-399.66,-132.95)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(-711.89,460.94)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(889.61,18.81)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(536.13,-344.90)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(358.14,151.61)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(642.46,167.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(-200.18,-394.87)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(157.47,788.76)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(468.63,1266.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(-308.54,477.21)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_14_bus_text_nodes.svg
+++ b/src/test/resources/IEEE_14_bus_text_nodes.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="782.28" viewBox="-1703.58 -1368.54 3285.49 3212.74" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -104,66 +102,66 @@
     <g class="nad-vl-nodes">
         <g transform="translate(979.43,495.57)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-1039.27,14.91)" id="2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-879.21,-478.53)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-111.97,-704.76)" id="6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(-399.66,-132.95)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(-711.89,460.94)" id="10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(889.61,18.81)" id="12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(536.13,-344.90)" id="14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(358.14,151.61)" id="16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(642.46,167.97)" id="18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(-200.18,-394.87)" id="20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(157.47,788.76)" id="22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(468.63,1266.46)" id="24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(-308.54,477.21)" id="26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="28">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="974.70,470.51 934.52,257.19"/>
+                <polyline class="nad-edge-path" points="974.70,470.51 934.52,257.19"/>
                 <g class="nad-edge-infos" transform="translate(968.69,438.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.67)">
@@ -182,7 +180,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="894.33,43.87 934.52,257.19"/>
+                <polyline class="nad-edge-path" points="894.33,43.87 934.52,257.19"/>
                 <g class="nad-edge-infos" transform="translate(900.34,75.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.33)">
@@ -204,7 +202,7 @@
         <g id="29">
             <desc>L1-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="961.14,477.79 810.94,331.77"/>
+                <polyline class="nad-edge-path" points="961.14,477.79 810.94,331.77"/>
                 <g class="nad-edge-infos" transform="translate(937.84,455.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-45.81)">
@@ -223,7 +221,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="660.74,185.74 810.94,331.77"/>
+                <polyline class="nad-edge-path" points="660.74,185.74 810.94,331.77"/>
                 <g class="nad-edge-infos" transform="translate(684.05,208.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(134.19)">
@@ -245,7 +243,7 @@
         <g id="30">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-330.09,463.57 -673.91,246.06"/>
+                <polyline class="nad-edge-path" points="-330.09,463.57 -673.91,246.06"/>
                 <g class="nad-edge-infos" transform="translate(-357.55,446.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-57.68)">
@@ -264,7 +262,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-1017.72,28.54 -673.91,246.06"/>
+                <polyline class="nad-edge-path" points="-1017.72,28.54 -673.91,246.06"/>
                 <g class="nad-edge-infos" transform="translate(-990.26,45.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(122.32)">
@@ -286,7 +284,7 @@
         <g id="31">
             <desc>L10-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-1031.40,-9.35 -959.24,-231.81"/>
+                <polyline class="nad-edge-path" points="-1031.40,-9.35 -959.24,-231.81"/>
                 <g class="nad-edge-infos" transform="translate(-1021.38,-40.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.97)">
@@ -305,7 +303,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-887.07,-454.28 -959.24,-231.81"/>
+                <polyline class="nad-edge-path" points="-887.07,-454.28 -959.24,-231.81"/>
                 <g class="nad-edge-infos" transform="translate(-897.10,-423.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.03)">
@@ -327,7 +325,7 @@
         <g id="32">
             <desc>L6-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-225.48,-397.99 -539.69,-436.70"/>
+                <polyline class="nad-edge-path" points="-225.48,-397.99 -539.69,-436.70"/>
                 <g class="nad-edge-infos" transform="translate(-257.74,-401.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.98)">
@@ -346,7 +344,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-853.90,-475.41 -539.69,-436.70"/>
+                <polyline class="nad-edge-path" points="-853.90,-475.41 -539.69,-436.70"/>
                 <g class="nad-edge-infos" transform="translate(-821.64,-471.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.02)">
@@ -368,7 +366,7 @@
         <g id="33">
             <desc>L6-12-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-193.19,-419.39 -156.07,-549.82"/>
+                <polyline class="nad-edge-path" points="-193.19,-419.39 -156.07,-549.82"/>
                 <g class="nad-edge-infos" transform="translate(-184.30,-450.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.89)">
@@ -387,7 +385,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-118.95,-680.24 -156.07,-549.82"/>
+                <polyline class="nad-edge-path" points="-118.95,-680.24 -156.07,-549.82"/>
                 <g class="nad-edge-infos" transform="translate(-127.85,-648.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.11)">
@@ -409,7 +407,7 @@
         <g id="34">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-123.43,-681.99 -255.81,-418.86"/>
+                <polyline class="nad-edge-path" points="-123.43,-681.99 -255.81,-418.86"/>
                 <g class="nad-edge-infos" transform="translate(-138.03,-652.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.29)">
@@ -428,7 +426,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-388.20,-155.73 -255.81,-418.86"/>
+                <polyline class="nad-edge-path" points="-388.20,-155.73 -255.81,-418.86"/>
                 <g class="nad-edge-infos" transform="translate(-373.59,-184.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.71)">
@@ -450,7 +448,7 @@
         <g id="35">
             <desc>L6-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-215.63,-374.58 -299.92,-263.91"/>
+                <polyline class="nad-edge-path" points="-215.63,-374.58 -299.92,-263.91"/>
                 <g class="nad-edge-infos" transform="translate(-235.32,-348.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.71)">
@@ -469,7 +467,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-384.21,-153.24 -299.92,-263.91"/>
+                <polyline class="nad-edge-path" points="-384.21,-153.24 -299.92,-263.91"/>
                 <g class="nad-edge-infos" transform="translate(-364.52,-179.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.29)">
@@ -491,7 +489,7 @@
         <g id="36">
             <desc>L13-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-411.53,-110.38 -555.78,163.99"/>
+                <polyline class="nad-edge-path" points="-411.53,-110.38 -555.78,163.99"/>
                 <g class="nad-edge-infos" transform="translate(-426.65,-81.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.27)">
@@ -510,7 +508,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-700.03,438.37 -555.78,163.99"/>
+                <polyline class="nad-edge-path" points="-700.03,438.37 -555.78,163.99"/>
                 <g class="nad-edge-infos" transform="translate(-684.90,409.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(27.73)">
@@ -532,7 +530,7 @@
         <g id="37">
             <desc>L9-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-334.02,476.18 -510.22,469.07"/>
+                <polyline class="nad-edge-path" points="-334.02,476.18 -510.22,469.07"/>
                 <g class="nad-edge-infos" transform="translate(-366.49,474.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.69)">
@@ -551,7 +549,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-686.41,461.97 -510.22,469.07"/>
+                <polyline class="nad-edge-path" points="-686.41,461.97 -510.22,469.07"/>
                 <g class="nad-edge-infos" transform="translate(-653.94,463.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.31)">
@@ -573,7 +571,7 @@
         <g id="38">
             <desc>L2-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="871.83,0.52 712.87,-163.04"/>
+                <polyline class="nad-edge-path" points="871.83,0.52 712.87,-163.04"/>
                 <g class="nad-edge-infos" transform="translate(849.18,-22.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.18)">
@@ -592,7 +590,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="553.90,-326.61 712.87,-163.04"/>
+                <polyline class="nad-edge-path" points="553.90,-326.61 712.87,-163.04"/>
                 <g class="nad-edge-infos" transform="translate(576.56,-303.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.82)">
@@ -614,7 +612,7 @@
         <g id="39">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="864.87,24.99 623.87,85.21"/>
+                <polyline class="nad-edge-path" points="864.87,24.99 623.87,85.21"/>
                 <g class="nad-edge-infos" transform="translate(833.34,32.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.03)">
@@ -633,7 +631,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="382.88,145.43 623.87,85.21"/>
+                <polyline class="nad-edge-path" points="382.88,145.43 623.87,85.21"/>
                 <g class="nad-edge-infos" transform="translate(414.41,137.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.97)">
@@ -655,7 +653,7 @@
         <g id="40">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="867.77,31.99 766.03,93.39"/>
+                <polyline class="nad-edge-path" points="867.77,31.99 766.03,93.39"/>
                 <g class="nad-edge-infos" transform="translate(839.95,48.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.11)">
@@ -674,7 +672,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="664.29,154.79 766.03,93.39"/>
+                <polyline class="nad-edge-path" points="664.29,154.79 766.03,93.39"/>
                 <g class="nad-edge-infos" transform="translate(692.12,138.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.89)">
@@ -696,7 +694,7 @@
         <g id="41">
             <desc>L3-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="527.53,-320.89 447.14,-96.64"/>
+                <polyline class="nad-edge-path" points="527.53,-320.89 447.14,-96.64"/>
                 <g class="nad-edge-infos" transform="translate(516.56,-290.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-160.28)">
@@ -715,7 +713,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="366.74,127.60 447.14,-96.64"/>
+                <polyline class="nad-edge-path" points="366.74,127.60 447.14,-96.64"/>
                 <g class="nad-edge-infos" transform="translate(377.71,97.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(19.72)">
@@ -737,7 +735,7 @@
         <g id="42">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="383.60,153.07 500.30,159.79"/>
+                <polyline class="nad-edge-path" points="383.60,153.07 500.30,159.79"/>
                 <g class="nad-edge-infos" transform="translate(416.04,154.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.29)">
@@ -756,7 +754,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="617.00,166.50 500.30,159.79"/>
+                <polyline class="nad-edge-path" points="617.00,166.50 500.30,159.79"/>
                 <g class="nad-edge-infos" transform="translate(584.56,164.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.71)">
@@ -778,7 +776,7 @@
         <g id="43">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="350.48,175.93 266.82,441.57"/>
+                <polyline class="nad-edge-path" points="350.48,175.93 266.82,441.57"/>
                 <g class="nad-edge-infos" transform="translate(340.72,206.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.52)">
@@ -795,10 +793,10 @@
                         <text transform="rotate(-72.52)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="260.81" cy="460.65" r="20.00"/>
+                <circle class="nad-winding" cx="260.81" cy="460.65" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="165.13,764.44 248.80,498.80"/>
+                <polyline class="nad-edge-path" points="165.13,764.44 248.80,498.80"/>
                 <g class="nad-edge-infos" transform="translate(174.90,733.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.48)">
@@ -815,13 +813,13 @@
                         <text transform="rotate(-72.52)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="254.80" cy="479.72" r="20.00"/>
+                <circle class="nad-winding" cx="254.80" cy="479.72" r="20.00"/>
             </g>
         </g>
         <g id="44">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="335.23,162.80 51.76,301.24"/>
+                <polyline class="nad-edge-path" points="335.23,162.80 51.76,301.24"/>
                 <g class="nad-edge-infos" transform="translate(306.02,177.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.03)">
@@ -838,10 +836,10 @@
                         <text transform="rotate(-26.03)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="33.79" cy="310.02" r="20.00"/>
+                <circle class="nad-winding" cx="33.79" cy="310.02" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-285.63,466.02 -2.16,327.57"/>
+                <polyline class="nad-edge-path" points="-285.63,466.02 -2.16,327.57"/>
                 <g class="nad-edge-infos" transform="translate(-256.42,451.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.97)">
@@ -858,13 +856,13 @@
                         <text transform="rotate(-26.03)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="15.81" cy="318.80" r="20.00"/>
+                <circle class="nad-winding" cx="15.81" cy="318.80" r="20.00"/>
             </g>
         </g>
         <g id="45">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="621.26,153.81 246.09,-96.79"/>
+                <polyline class="nad-edge-path" points="621.26,153.81 246.09,-96.79"/>
                 <g class="nad-edge-infos" transform="translate(594.23,135.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.26)">
@@ -881,10 +879,10 @@
                         <text transform="rotate(-326.26)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="229.46" cy="-107.90" r="20.00"/>
+                <circle class="nad-winding" cx="229.46" cy="-107.90" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-178.97,-380.70 196.20,-130.11"/>
+                <polyline class="nad-edge-path" points="-178.97,-380.70 196.20,-130.11"/>
                 <g class="nad-edge-infos" transform="translate(-151.94,-362.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.74)">
@@ -901,13 +899,13 @@
                         <text transform="rotate(33.74)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="212.83" cy="-119.00" r="20.00"/>
+                <circle class="nad-winding" cx="212.83" cy="-119.00" r="20.00"/>
             </g>
         </g>
         <g id="46">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="171.39,810.13 313.05,1027.61"/>
+                <polyline class="nad-edge-path" points="171.39,810.13 313.05,1027.61"/>
                 <g class="nad-edge-infos" transform="translate(189.13,837.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(146.92)">
@@ -926,7 +924,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="454.71,1245.09 313.05,1027.61"/>
+                <polyline class="nad-edge-path" points="454.71,1245.09 313.05,1027.61"/>
                 <g class="nad-edge-infos" transform="translate(436.97,1217.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-33.08)">
@@ -948,7 +946,7 @@
         <g id="47">
             <desc>L7-9-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="136.28,774.59 -75.53,632.98"/>
+                <polyline class="nad-edge-path" points="136.28,774.59 -75.53,632.98"/>
                 <g class="nad-edge-infos" transform="translate(109.26,756.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.24)">
@@ -967,7 +965,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-287.34,491.38 -75.53,632.98"/>
+                <polyline class="nad-edge-path" points="-287.34,491.38 -75.53,632.98"/>
                 <g class="nad-edge-infos" transform="translate(-260.32,509.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.76)">

--- a/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/src/test/resources/IEEE_14_id_prefixed.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="801.74" viewBox="-920.95 -877.83 2048.83 2053.29" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -110,66 +108,66 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="test_0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="test_1"/>
+            <circle class="nad-busnode" r="27.50" id="test_1"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="test_2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle r="27.50" id="test_3"/>
+            <circle class="nad-busnode" r="27.50" id="test_3"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="test_4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="test_5"/>
+            <circle class="nad-busnode" r="27.50" id="test_5"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="test_6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle r="27.50" id="test_7"/>
+            <circle class="nad-busnode" r="27.50" id="test_7"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="test_8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="test_9"/>
+            <circle class="nad-busnode" r="27.50" id="test_9"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="test_10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle r="27.50" id="test_11"/>
+            <circle class="nad-busnode" r="27.50" id="test_11"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="test_12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="test_13"/>
+            <circle class="nad-busnode" r="27.50" id="test_13"/>
         </g>
         <g transform="translate(827.88,25.42)" id="test_14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="test_15"/>
+            <circle class="nad-busnode" r="27.50" id="test_15"/>
         </g>
         <g transform="translate(405.95,123.38)" id="test_16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="test_17"/>
+            <circle class="nad-busnode" r="27.50" id="test_17"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="test_18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="test_19"/>
+            <circle class="nad-busnode" r="27.50" id="test_19"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="test_20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle r="27.50" id="test_21"/>
+            <circle class="nad-busnode" r="27.50" id="test_21"/>
         </g>
         <g transform="translate(369.06,599.72)" id="test_22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle r="27.50" id="test_23"/>
+            <circle class="nad-busnode" r="27.50" id="test_23"/>
         </g>
         <g transform="translate(568.63,975.46)" id="test_24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle r="27.50" id="test_25"/>
+            <circle class="nad-busnode" r="27.50" id="test_25"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="test_26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="test_27"/>
+            <circle class="nad-busnode" r="27.50" id="test_27"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="test_28">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="522.21,-617.54 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="522.21,-617.54 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(528.85,-585.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(168.22)">
@@ -188,7 +186,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="590.85,-288.31 556.53,-452.92"/>
+                <polyline class="nad-edge-path" points="590.85,-288.31 556.53,-452.92"/>
                 <g class="nad-edge-infos" transform="translate(584.22,-320.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-11.78)">
@@ -210,7 +208,7 @@
         <g id="test_29">
             <desc>L1-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="499.00,-624.45 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="499.00,-624.45 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(476.04,-601.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.06)">
@@ -229,7 +227,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="243.15,-368.02 371.07,-496.24"/>
+                <polyline class="nad-edge-path" points="243.15,-368.02 371.07,-496.24"/>
                 <g class="nad-edge-infos" transform="translate(266.10,-391.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.94)">
@@ -251,7 +249,7 @@
         <g id="test_30">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-48.76,421.74 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-48.76,421.74 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-80.62,428.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.40)">
@@ -270,7 +268,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-493.51,511.39 -271.14,466.56"/>
+                <polyline class="nad-edge-path" points="-493.51,511.39 -271.14,466.56"/>
                 <g class="nad-edge-infos" transform="translate(-461.65,504.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.60)">
@@ -292,7 +290,7 @@
         <g id="test_31">
             <desc>L10-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-530.08,493.70 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-530.08,493.70 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-544.82,464.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-26.97)">
@@ -311,7 +309,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-709.39,141.34 -619.73,317.52"/>
+                <polyline class="nad-edge-path" points="-709.39,141.34 -619.73,317.52"/>
                 <g class="nad-edge-infos" transform="translate(-694.65,170.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(153.03)">
@@ -333,7 +331,7 @@
         <g id="test_32">
             <desc>L6-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-351.70,-358.58 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-351.70,-358.58 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-371.59,-332.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.27)">
@@ -352,7 +350,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-705.35,98.44 -528.52,-130.07"/>
+                <polyline class="nad-edge-path" points="-705.35,98.44 -528.52,-130.07"/>
                 <g class="nad-edge-infos" transform="translate(-685.46,72.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.73)">
@@ -374,7 +372,7 @@
         <g id="test_33">
             <desc>L6-12-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-354.60,-396.29 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-354.60,-396.29 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-378.18,-418.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-46.52)">
@@ -393,7 +391,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-617.16,-645.28 -485.88,-520.79"/>
+                <polyline class="nad-edge-path" points="-617.16,-645.28 -485.88,-520.79"/>
                 <g class="nad-edge-infos" transform="translate(-593.57,-622.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.48)">
@@ -415,7 +413,7 @@
         <g id="test_34">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-635.28,-637.33 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-635.28,-637.33 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-634.79,-604.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.14)">
@@ -434,7 +432,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-630.57,-323.32 -632.92,-480.33"/>
+                <polyline class="nad-edge-path" points="-630.57,-323.32 -632.92,-480.33"/>
                 <g class="nad-edge-infos" transform="translate(-631.05,-355.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.86)">
@@ -456,7 +454,7 @@
         <g id="test_35">
             <desc>L6-13-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-360.68,-371.98 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-360.68,-371.98 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-392.02,-363.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-105.38)">
@@ -475,7 +473,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-605.60,-304.59 -483.14,-338.29"/>
+                <polyline class="nad-edge-path" points="-605.60,-304.59 -483.14,-338.29"/>
                 <g class="nad-edge-infos" transform="translate(-574.26,-313.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(74.62)">
@@ -497,7 +495,7 @@
         <g id="test_36">
             <desc>L13-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-613.96,-278.15 -469.33,-102.81"/>
+                <polyline class="nad-edge-path" points="-613.96,-278.15 -469.33,-102.81"/>
                 <g class="nad-edge-infos" transform="translate(-593.28,-253.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(140.48)">
@@ -516,7 +514,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-324.70,72.53 -469.33,-102.81"/>
+                <polyline class="nad-edge-path" points="-324.70,72.53 -469.33,-102.81"/>
                 <g class="nad-edge-infos" transform="translate(-345.38,47.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-39.52)">
@@ -538,7 +536,7 @@
         <g id="test_37">
             <desc>L9-14-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-40.58,397.53 -166.12,254.45"/>
+                <polyline class="nad-edge-path" points="-40.58,397.53 -166.12,254.45"/>
                 <g class="nad-edge-infos" transform="translate(-62.02,373.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.26)">
@@ -557,7 +555,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-291.66,111.37 -166.12,254.45"/>
+                <polyline class="nad-edge-path" points="-291.66,111.37 -166.12,254.45"/>
                 <g class="nad-edge-infos" transform="translate(-270.22,135.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.74)">
@@ -579,7 +577,7 @@
         <g id="test_38">
             <desc>L2-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="612.02,-243.46 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="612.02,-243.46 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(632.36,-218.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.24)">
@@ -598,7 +596,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="811.91,5.53 711.96,-118.97"/>
+                <polyline class="nad-edge-path" points="811.91,5.53 711.96,-118.97"/>
                 <g class="nad-edge-infos" transform="translate(791.57,-19.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.76)">
@@ -620,7 +618,7 @@
         <g id="test_39">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="584.80,-240.46 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="584.80,-240.46 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(570.47,-211.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.82)">
@@ -639,7 +637,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="417.20,100.49 501.00,-69.99"/>
+                <polyline class="nad-edge-path" points="417.20,100.49 501.00,-69.99"/>
                 <g class="nad-edge-infos" transform="translate(431.54,71.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.18)">
@@ -661,7 +659,7 @@
         <g id="test_40">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="571.22,-269.15 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="571.22,-269.15 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(539.57,-276.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.85)">
@@ -680,7 +678,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="249.97,-344.17 410.59,-306.66"/>
+                <polyline class="nad-edge-path" points="249.97,-344.17 410.59,-306.66"/>
                 <g class="nad-edge-infos" transform="translate(281.62,-336.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.15)">
@@ -702,7 +700,7 @@
         <g id="test_41">
             <desc>L3-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="803.04,31.18 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="803.04,31.18 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(771.38,38.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-103.07)">
@@ -721,7 +719,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="430.79,117.61 616.91,74.40"/>
+                <polyline class="nad-edge-path" points="430.79,117.61 616.91,74.40"/>
                 <g class="nad-edge-infos" transform="translate(462.45,110.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(76.93)">
@@ -743,7 +741,7 @@
         <g id="test_42">
             <desc>L4-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="396.85,99.55 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="396.85,99.55 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(385.26,69.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-20.91)">
@@ -762,7 +760,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="234.24,-326.15 315.54,-113.30"/>
+                <polyline class="nad-edge-path" points="234.24,-326.15 315.54,-113.30"/>
                 <g class="nad-edge-infos" transform="translate(245.83,-295.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.09)">
@@ -784,7 +782,7 @@
         <g id="test_43">
             <desc>T4-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="403.98,148.80 389.82,331.64"/>
+                <polyline class="nad-edge-path" points="403.98,148.80 389.82,331.64"/>
                 <g class="nad-edge-infos" transform="translate(401.47,181.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.57)">
@@ -801,10 +799,10 @@
                         <text transform="rotate(-85.57)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="388.28" cy="351.58" r="20.00"/>
+                <circle class="nad-winding" cx="388.28" cy="351.58" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="371.03,574.29 385.19,391.46"/>
+                <polyline class="nad-edge-path" points="371.03,574.29 385.19,391.46"/>
                 <g class="nad-edge-infos" transform="translate(373.54,541.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.43)">
@@ -821,13 +819,13 @@
                         <text transform="rotate(-85.57)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="386.73" cy="371.52" r="20.00"/>
+                <circle class="nad-winding" cx="386.73" cy="371.52" r="20.00"/>
             </g>
         </g>
         <g id="test_44">
             <desc>T4-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="384.89,137.75 215.87,253.12"/>
+                <polyline class="nad-edge-path" points="384.89,137.75 215.87,253.12"/>
                 <g class="nad-edge-infos" transform="translate(358.05,156.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.32)">
@@ -844,10 +842,10 @@
                         <text transform="rotate(-34.32)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="199.35" cy="264.40" r="20.00"/>
+                <circle class="nad-winding" cx="199.35" cy="264.40" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-2.70,402.32 166.32,286.95"/>
+                <polyline class="nad-edge-path" points="-2.70,402.32 166.32,286.95"/>
                 <g class="nad-edge-infos" transform="translate(24.14,384.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.68)">
@@ -864,13 +862,13 @@
                         <text transform="rotate(-34.32)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="182.84" cy="275.68" r="20.00"/>
+                <circle class="nad-winding" cx="182.84" cy="275.68" r="20.00"/>
             </g>
         </g>
         <g id="test_45">
             <desc>T5-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="199.67,-351.28 -25.52,-362.82"/>
+                <polyline class="nad-edge-path" points="199.67,-351.28 -25.52,-362.82"/>
                 <g class="nad-edge-infos" transform="translate(167.21,-352.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.06)">
@@ -887,10 +885,10 @@
                         <text transform="rotate(-357.06)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-45.49" cy="-363.85" r="20.00"/>
+                <circle class="nad-winding" cx="-45.49" cy="-363.85" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-310.63,-377.44 -85.44,-365.90"/>
+                <polyline class="nad-edge-path" points="-310.63,-377.44 -85.44,-365.90"/>
                 <g class="nad-edge-infos" transform="translate(-278.17,-375.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.94)">
@@ -907,13 +905,13 @@
                         <text transform="rotate(2.94)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-65.47" cy="-364.87" r="20.00"/>
+                <circle class="nad-winding" cx="-65.47" cy="-364.87" r="20.00"/>
             </g>
         </g>
         <g id="test_46">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="381.02,622.24 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="381.02,622.24 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(396.27,650.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.03)">
@@ -932,7 +930,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="556.67,952.94 468.84,787.59"/>
+                <polyline class="nad-edge-path" points="556.67,952.94 468.84,787.59"/>
                 <g class="nad-edge-infos" transform="translate(541.42,924.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.97)">
@@ -954,7 +952,7 @@
         <g id="test_47">
             <desc>L7-9-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="345.94,588.95 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="345.94,588.95 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(316.48,575.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.02)">
@@ -973,7 +971,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-0.65,427.47 172.65,508.21"/>
+                <polyline class="nad-edge-path" points="-0.65,427.47 172.65,508.21"/>
                 <g class="nad-edge-infos" transform="translate(28.81,441.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.98)">

--- a/src/test/resources/IEEE_14_id_prefixed.svg
+++ b/src/test/resources/IEEE_14_id_prefixed.svg
@@ -108,59 +108,59 @@
     <g class="nad-vl-nodes">
         <g transform="translate(517.01,-642.50)" id="test_0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="test_1"/>
+            <circle r="27.50" id="test_1" class="nad-busnode"/>
         </g>
         <g transform="translate(-518.51,516.42)" id="test_2" class="nad-vl0to30">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="test_3"/>
+            <circle r="27.50" id="test_3" class="nad-busnode"/>
         </g>
         <g transform="translate(-720.95,118.61)" id="test_4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="test_5"/>
+            <circle r="27.50" id="test_5" class="nad-busnode"/>
         </g>
         <g transform="translate(-635.66,-662.83)" id="test_6" class="nad-vl0to30">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="test_7"/>
+            <circle r="27.50" id="test_7" class="nad-busnode"/>
         </g>
         <g transform="translate(-630.18,-297.82)" id="test_8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="test_9"/>
+            <circle r="27.50" id="test_9" class="nad-busnode"/>
         </g>
         <g transform="translate(-308.48,92.20)" id="test_10" class="nad-vl0to30">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="test_11"/>
+            <circle r="27.50" id="test_11" class="nad-busnode"/>
         </g>
         <g transform="translate(596.05,-263.35)" id="test_12" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="test_13"/>
+            <circle r="27.50" id="test_13" class="nad-busnode"/>
         </g>
         <g transform="translate(827.88,25.42)" id="test_14" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="test_15"/>
+            <circle r="27.50" id="test_15" class="nad-busnode"/>
         </g>
         <g transform="translate(405.95,123.38)" id="test_16" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="test_17"/>
+            <circle r="27.50" id="test_17" class="nad-busnode"/>
         </g>
         <g transform="translate(225.14,-349.97)" id="test_18" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="test_19"/>
+            <circle r="27.50" id="test_19" class="nad-busnode"/>
         </g>
         <g transform="translate(-336.09,-378.75)" id="test_20" class="nad-vl0to30">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="test_21"/>
+            <circle r="27.50" id="test_21" class="nad-busnode"/>
         </g>
         <g transform="translate(369.06,599.72)" id="test_22" class="nad-vl0to30">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="test_23"/>
+            <circle r="27.50" id="test_23" class="nad-busnode"/>
         </g>
         <g transform="translate(568.63,975.46)" id="test_24" class="nad-vl0to30">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="test_25"/>
+            <circle r="27.50" id="test_25" class="nad-busnode"/>
         </g>
         <g transform="translate(-23.76,416.70)" id="test_26" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="test_27"/>
+            <circle r="27.50" id="test_27" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="544.77" viewBox="-1377.69 -895.93 3431.77 2336.89" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -148,106 +146,106 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-962.13,480.68)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-493.64,692.74)" id="2" class="nad-vl120to180">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(46.99,652.79)" id="4" class="nad-vl180to300">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-160.17,328.18)" id="6" class="nad-vl180to300">
             <desc>VL12</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(180.28,320.01)" id="8" class="nad-vl180to300">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(644.30,427.15)" id="10" class="nad-vl180to300">
             <desc>VL14</desc>
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(879.89,-504.78)" id="12" class="nad-vl180to300">
             <desc>VL15</desc>
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(871.96,-122.70)" id="14" class="nad-vl180to300">
             <desc>VL16</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(1398.65,-57.76)" id="16" class="nad-vl180to300">
             <desc>VL17</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(1425.03,-379.69)" id="18" class="nad-vl180to300">
             <desc>VL18</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(505.57,-664.44)" id="20" class="nad-vl180to300">
             <desc>VL19</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(-977.53,1089.24)" id="22" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(64.25,-650.28)" id="24" class="nad-vl180to300">
             <desc>VL20</desc>
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(1379.40,-680.93)" id="26" class="nad-vl180to300">
             <desc>VL21</desc>
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
         <g transform="translate(1754.07,-359.50)" id="28" class="nad-vl180to300">
             <desc>VL22</desc>
-            <circle r="27.50" id="29"/>
+            <circle class="nad-busnode" r="27.50" id="29"/>
         </g>
         <g transform="translate(13.35,-87.40)" id="30" class="nad-vl180to300">
             <desc>VL23</desc>
-            <circle r="27.50" id="31"/>
+            <circle class="nad-busnode" r="27.50" id="31"/>
         </g>
         <g transform="translate(284.26,-318.91)" id="32" class="nad-vl180to300">
             <desc>VL24</desc>
-            <circle r="27.50" id="33"/>
+            <circle class="nad-busnode" r="27.50" id="33"/>
         </g>
         <g transform="translate(-439.43,-35.17)" id="34" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="35"/>
+            <circle class="nad-busnode" r="27.50" id="35"/>
         </g>
         <g transform="translate(-752.55,865.30)" id="36" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="37"/>
+            <circle class="nad-busnode" r="27.50" id="37"/>
         </g>
         <g transform="translate(-1169.10,698.07)" id="38" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="39"/>
+            <circle class="nad-busnode" r="27.50" id="39"/>
         </g>
         <g transform="translate(-591.99,1240.96)" id="40" class="nad-vl120to180">
             <desc>VL6</desc>
-            <circle r="27.50" id="41"/>
+            <circle class="nad-busnode" r="27.50" id="41"/>
         </g>
         <g transform="translate(-1177.69,-238.11)" id="42" class="nad-vl120to180">
             <desc>VL7</desc>
-            <circle r="27.50" id="43"/>
+            <circle class="nad-busnode" r="27.50" id="43"/>
         </g>
         <g transform="translate(-846.14,126.31)" id="44" class="nad-vl180to300">
             <desc>VL8</desc>
-            <circle r="27.50" id="45"/>
+            <circle class="nad-busnode" r="27.50" id="45"/>
         </g>
         <g transform="translate(-477.52,372.89)" id="46" class="nad-vl120to180">
             <desc>VL9</desc>
-            <circle r="27.50" id="47"/>
+            <circle class="nad-busnode" r="27.50" id="47"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="48">
             <desc>L-1-2-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-962.77,506.17 -969.83,784.96"/>
+                <polyline class="nad-edge-path" points="-962.77,506.17 -969.83,784.96"/>
                 <g class="nad-edge-infos" transform="translate(-963.59,538.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.55)">
@@ -266,7 +264,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-976.89,1063.75 -969.83,784.96"/>
+                <polyline class="nad-edge-path" points="-976.89,1063.75 -969.83,784.96"/>
                 <g class="nad-edge-infos" transform="translate(-976.06,1031.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.45)">
@@ -288,7 +286,7 @@
         <g id="49">
             <desc>L-3-1-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-457.58,-17.26 -700.78,222.75"/>
+                <polyline class="nad-edge-path" points="-457.58,-17.26 -700.78,222.75"/>
                 <g class="nad-edge-infos" transform="translate(-480.72,5.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.62)">
@@ -307,7 +305,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-943.98,462.77 -700.78,222.75"/>
+                <polyline class="nad-edge-path" points="-943.98,462.77 -700.78,222.75"/>
                 <g class="nad-edge-infos" transform="translate(-920.84,439.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.38)">
@@ -329,7 +327,7 @@
         <g id="50">
             <desc>L-1-5-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-979.71,499.15 -1065.61,589.38"/>
+                <polyline class="nad-edge-path" points="-979.71,499.15 -1065.61,589.38"/>
                 <g class="nad-edge-infos" transform="translate(-1002.12,522.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.41)">
@@ -348,7 +346,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-1151.52,679.60 -1065.61,589.38"/>
+                <polyline class="nad-edge-path" points="-1151.52,679.60 -1065.61,589.38"/>
                 <g class="nad-edge-infos" transform="translate(-1129.11,656.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.59)">
@@ -370,7 +368,7 @@
         <g id="51">
             <desc>L-10-6-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-498.14,717.83 -542.81,966.85"/>
+                <polyline class="nad-edge-path" points="-498.14,717.83 -542.81,966.85"/>
                 <g class="nad-edge-infos" transform="translate(-503.88,749.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.83)">
@@ -389,7 +387,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-587.48,1215.86 -542.81,966.85"/>
+                <polyline class="nad-edge-path" points="-587.48,1215.86 -542.81,966.85"/>
                 <g class="nad-edge-infos" transform="translate(-581.75,1183.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.17)">
@@ -411,7 +409,7 @@
         <g id="52">
             <desc>L-8-10-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="-832.66,147.96 -669.89,409.52"/>
+                <polyline class="nad-edge-path" points="-832.66,147.96 -669.89,409.52"/>
                 <g class="nad-edge-infos" transform="translate(-815.49,175.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.11)">
@@ -430,7 +428,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-507.11,671.09 -669.89,409.52"/>
+                <polyline class="nad-edge-path" points="-507.11,671.09 -669.89,409.52"/>
                 <g class="nad-edge-infos" transform="translate(-524.28,643.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-31.89)">
@@ -452,7 +450,7 @@
         <g id="53">
             <desc>T-5-10-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-1143.60,697.87 -861.37,695.64"/>
+                <polyline class="nad-edge-path" points="-1143.60,697.87 -861.37,695.64"/>
                 <g class="nad-edge-infos" transform="translate(-1111.11,697.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(89.55)">
@@ -469,10 +467,10 @@
                         <text transform="rotate(-0.45)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-841.37" cy="695.48" r="20.00"/>
+                <circle class="nad-winding" cx="-841.37" cy="695.48" r="20.00"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-519.14,692.94 -801.37,695.17"/>
+                <polyline class="nad-edge-path" points="-519.14,692.94 -801.37,695.17"/>
                 <g class="nad-edge-infos" transform="translate(-551.64,693.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-90.45)">
@@ -489,13 +487,13 @@
                         <text transform="rotate(-0.45)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-821.37" cy="695.32" r="20.00"/>
+                <circle class="nad-winding" cx="-821.37" cy="695.32" r="20.00"/>
             </g>
         </g>
         <g id="54">
             <desc>T-11-10-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="21.56,654.67 -193.40,670.55"/>
+                <polyline class="nad-edge-path" points="21.56,654.67 -193.40,670.55"/>
                 <g class="nad-edge-infos" transform="translate(-10.85,657.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.23)">
@@ -512,10 +510,10 @@
                         <text transform="rotate(-4.23)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-213.35" cy="672.03" r="20.00"/>
+                <circle class="nad-winding" cx="-213.35" cy="672.03" r="20.00"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-468.21,690.86 -253.24,674.97"/>
+                <polyline class="nad-edge-path" points="-468.21,690.86 -253.24,674.97"/>
                 <g class="nad-edge-infos" transform="translate(-435.80,688.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(85.77)">
@@ -532,13 +530,13 @@
                         <text transform="rotate(-4.23)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-233.30" cy="673.50" r="20.00"/>
+                <circle class="nad-winding" cx="-233.30" cy="673.50" r="20.00"/>
             </g>
         </g>
         <g id="55">
             <desc>T-12-10-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="-177.38,347.00 -306.65,488.32"/>
+                <polyline class="nad-edge-path" points="-177.38,347.00 -306.65,488.32"/>
                 <g class="nad-edge-infos" transform="translate(-199.31,370.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-137.55)">
@@ -555,10 +553,10 @@
                         <text transform="rotate(-47.55)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-320.15" cy="503.08" r="20.00"/>
+                <circle class="nad-winding" cx="-320.15" cy="503.08" r="20.00"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-476.43,673.92 -347.15,532.59"/>
+                <polyline class="nad-edge-path" points="-476.43,673.92 -347.15,532.59"/>
                 <g class="nad-edge-infos" transform="translate(-454.49,649.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.45)">
@@ -575,13 +573,13 @@
                         <text transform="rotate(-47.55)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-333.65" cy="517.84" r="20.00"/>
+                <circle class="nad-winding" cx="-333.65" cy="517.84" r="20.00"/>
             </g>
         </g>
         <g id="56">
             <desc>L-11-13-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="56.48,629.12 113.64,486.40"/>
+                <polyline class="nad-edge-path" points="56.48,629.12 113.64,486.40"/>
                 <g class="nad-edge-infos" transform="translate(68.56,598.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.83)">
@@ -600,7 +598,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="170.80,343.68 113.64,486.40"/>
+                <polyline class="nad-edge-path" points="170.80,343.68 113.64,486.40"/>
                 <g class="nad-edge-infos" transform="translate(158.71,373.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.17)">
@@ -622,7 +620,7 @@
         <g id="57">
             <desc>L-11-14-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="70.85,643.78 345.64,539.97"/>
+                <polyline class="nad-edge-path" points="70.85,643.78 345.64,539.97"/>
                 <g class="nad-edge-infos" transform="translate(101.25,632.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.31)">
@@ -641,7 +639,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="620.44,436.17 345.64,539.97"/>
+                <polyline class="nad-edge-path" points="620.44,436.17 345.64,539.97"/>
                 <g class="nad-edge-infos" transform="translate(590.04,447.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-110.69)">
@@ -663,7 +661,7 @@
         <g id="58">
             <desc>T-11-9-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="24.50,640.79 -188.79,526.96"/>
+                <polyline class="nad-edge-path" points="24.50,640.79 -188.79,526.96"/>
                 <g class="nad-edge-infos" transform="translate(-4.18,625.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-61.91)">
@@ -680,10 +678,10 @@
                         <text transform="rotate(-331.91)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-206.44" cy="517.55" r="20.00"/>
+                <circle class="nad-winding" cx="-206.44" cy="517.55" r="20.00"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-455.02,384.89 -241.73,498.72"/>
+                <polyline class="nad-edge-path" points="-455.02,384.89 -241.73,498.72"/>
                 <g class="nad-edge-infos" transform="translate(-426.35,400.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(118.09)">
@@ -700,13 +698,13 @@
                         <text transform="rotate(28.09)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-224.08" cy="508.13" r="20.00"/>
+                <circle class="nad-winding" cx="-224.08" cy="508.13" r="20.00"/>
             </g>
         </g>
         <g id="59">
             <desc>L-12-13-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="-134.67,327.57 10.06,324.09"/>
+                <polyline class="nad-edge-path" points="-134.67,327.57 10.06,324.09"/>
                 <g class="nad-edge-infos" transform="translate(-102.18,326.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.62)">
@@ -725,7 +723,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="154.78,320.62 10.06,324.09"/>
+                <polyline class="nad-edge-path" points="154.78,320.62 10.06,324.09"/>
                 <g class="nad-edge-infos" transform="translate(122.29,321.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.38)">
@@ -747,7 +745,7 @@
         <g id="60">
             <desc>L-12-23-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="-150.34,304.65 -73.41,120.39"/>
+                <polyline class="nad-edge-path" points="-150.34,304.65 -73.41,120.39"/>
                 <g class="nad-edge-infos" transform="translate(-137.82,274.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.66)">
@@ -766,7 +764,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="3.53,-63.87 -73.41,120.39"/>
+                <polyline class="nad-edge-path" points="3.53,-63.87 -73.41,120.39"/>
                 <g class="nad-edge-infos" transform="translate(-9.00,-33.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.34)">
@@ -788,7 +786,7 @@
         <g id="61">
             <desc>T-9-12-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-452.27,369.33 -348.55,354.72"/>
+                <polyline class="nad-edge-path" points="-452.27,369.33 -348.55,354.72"/>
                 <g class="nad-edge-infos" transform="translate(-420.08,364.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
@@ -805,10 +803,10 @@
                         <text transform="rotate(-8.02)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-328.74" cy="351.93" r="20.00"/>
+                <circle class="nad-winding" cx="-328.74" cy="351.93" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-185.42,331.74 -289.13,346.35"/>
+                <polyline class="nad-edge-path" points="-185.42,331.74 -289.13,346.35"/>
                 <g class="nad-edge-infos" transform="translate(-217.60,336.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
@@ -825,13 +823,13 @@
                         <text transform="rotate(-8.02)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-308.94" cy="349.14" r="20.00"/>
+                <circle class="nad-winding" cx="-308.94" cy="349.14" r="20.00"/>
             </g>
         </g>
         <g id="62">
             <desc>L-23-13-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="23.02,-63.80 96.81,116.30"/>
+                <polyline class="nad-edge-path" points="23.02,-63.80 96.81,116.30"/>
                 <g class="nad-edge-infos" transform="translate(35.34,-33.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.72)">
@@ -850,7 +848,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="170.61,296.41 96.81,116.30"/>
+                <polyline class="nad-edge-path" points="170.61,296.41 96.81,116.30"/>
                 <g class="nad-edge-infos" transform="translate(158.29,266.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.28)">
@@ -872,7 +870,7 @@
         <g id="63">
             <desc>L-14-16-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="654.05,403.59 758.13,152.23"/>
+                <polyline class="nad-edge-path" points="654.05,403.59 758.13,152.23"/>
                 <g class="nad-edge-infos" transform="translate(666.48,373.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(22.49)">
@@ -891,7 +889,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="862.21,-99.14 758.13,152.23"/>
+                <polyline class="nad-edge-path" points="862.21,-99.14 758.13,152.23"/>
                 <g class="nad-edge-infos" transform="translate(849.77,-69.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-157.51)">
@@ -913,7 +911,7 @@
         <g id="64">
             <desc>L-16-15-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="872.49,-148.20 875.93,-313.74"/>
+                <polyline class="nad-edge-path" points="872.49,-148.20 875.93,-313.74"/>
                 <g class="nad-edge-infos" transform="translate(873.16,-180.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(1.19)">
@@ -932,7 +930,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="879.36,-479.29 875.93,-313.74"/>
+                <polyline class="nad-edge-path" points="879.36,-479.29 875.93,-313.74"/>
                 <g class="nad-edge-infos" transform="translate(878.69,-446.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-178.81)">
@@ -954,7 +952,7 @@
         <g id="65">
             <desc>L-15-21-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
+                <polyline class="nad-edge-path" points="904.96,-500.10 958.53,-490.10 1142.95,-555.13"/>
                 <g class="nad-edge-infos" transform="translate(986.83,-500.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
@@ -973,7 +971,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
+                <polyline class="nad-edge-path" points="1362.81,-661.56 1327.36,-620.17 1142.95,-555.13"/>
                 <g class="nad-edge-infos" transform="translate(1299.07,-610.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
@@ -995,7 +993,7 @@
         <g id="66">
             <desc>L-21-15-2 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
+                <polyline class="nad-edge-path" points="1354.33,-685.61 1300.76,-695.61 1116.34,-630.58"/>
                 <g class="nad-edge-infos" transform="translate(1272.46,-685.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.43)">
@@ -1014,7 +1012,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
+                <polyline class="nad-edge-path" points="896.48,-524.15 931.93,-565.54 1116.34,-630.58"/>
                 <g class="nad-edge-infos" transform="translate(960.22,-575.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.57)">
@@ -1036,7 +1034,7 @@
         <g id="67">
             <desc>L-15-24-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="855.55,-497.18 582.08,-411.85"/>
+                <polyline class="nad-edge-path" points="855.55,-497.18 582.08,-411.85"/>
                 <g class="nad-edge-infos" transform="translate(824.52,-487.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-107.33)">
@@ -1055,7 +1053,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="308.60,-326.51 582.08,-411.85"/>
+                <polyline class="nad-edge-path" points="308.60,-326.51 582.08,-411.85"/>
                 <g class="nad-edge-infos" transform="translate(339.63,-336.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(72.67)">
@@ -1077,7 +1075,7 @@
         <g id="68">
             <desc>L-16-17-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="897.27,-119.58 1135.31,-90.23"/>
+                <polyline class="nad-edge-path" points="897.27,-119.58 1135.31,-90.23"/>
                 <g class="nad-edge-infos" transform="translate(929.52,-115.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.03)">
@@ -1096,7 +1094,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1373.34,-60.88 1135.31,-90.23"/>
+                <polyline class="nad-edge-path" points="1373.34,-60.88 1135.31,-90.23"/>
                 <g class="nad-edge-infos" transform="translate(1341.09,-64.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.97)">
@@ -1118,7 +1116,7 @@
         <g id="69">
             <desc>L-16-19-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="857.67,-143.83 688.76,-393.57"/>
+                <polyline class="nad-edge-path" points="857.67,-143.83 688.76,-393.57"/>
                 <g class="nad-edge-infos" transform="translate(839.47,-170.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.07)">
@@ -1137,7 +1135,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="519.85,-643.31 688.76,-393.57"/>
+                <polyline class="nad-edge-path" points="519.85,-643.31 688.76,-393.57"/>
                 <g class="nad-edge-infos" transform="translate(538.06,-616.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.93)">
@@ -1159,7 +1157,7 @@
         <g id="70">
             <desc>L-17-18-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1400.74,-83.17 1411.84,-218.72"/>
+                <polyline class="nad-edge-path" points="1400.74,-83.17 1411.84,-218.72"/>
                 <g class="nad-edge-infos" transform="translate(1403.39,-115.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.68)">
@@ -1178,7 +1176,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1422.95,-354.28 1411.84,-218.72"/>
+                <polyline class="nad-edge-path" points="1422.95,-354.28 1411.84,-218.72"/>
                 <g class="nad-edge-infos" transform="translate(1420.30,-321.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.32)">
@@ -1200,7 +1198,7 @@
         <g id="71">
             <desc>L-17-22-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1418.09,-74.26 1576.36,-208.63"/>
+                <polyline class="nad-edge-path" points="1418.09,-74.26 1576.36,-208.63"/>
                 <g class="nad-edge-infos" transform="translate(1442.87,-95.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.67)">
@@ -1219,7 +1217,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1734.63,-343.00 1576.36,-208.63"/>
+                <polyline class="nad-edge-path" points="1734.63,-343.00 1576.36,-208.63"/>
                 <g class="nad-edge-infos" transform="translate(1709.86,-321.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.33)">
@@ -1241,7 +1239,7 @@
         <g id="72">
             <desc>L-18-21-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
+                <polyline class="nad-edge-path" points="1434.33,-403.43 1454.20,-454.18 1441.76,-536.30"/>
                 <g class="nad-edge-infos" transform="translate(1449.71,-483.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
@@ -1260,7 +1258,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
+                <polyline class="nad-edge-path" points="1395.31,-661.01 1429.32,-618.42 1441.76,-536.30"/>
                 <g class="nad-edge-infos" transform="translate(1433.82,-588.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
@@ -1282,7 +1280,7 @@
         <g id="73">
             <desc>L-18-21-2 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
+                <polyline class="nad-edge-path" points="1409.12,-399.62 1375.11,-442.20 1362.67,-524.32"/>
                 <g class="nad-edge-infos" transform="translate(1370.61,-471.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.61)">
@@ -1301,7 +1299,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
+                <polyline class="nad-edge-path" points="1370.10,-657.19 1350.23,-606.44 1362.67,-524.32"/>
                 <g class="nad-edge-infos" transform="translate(1354.72,-576.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.39)">
@@ -1323,7 +1321,7 @@
         <g id="74">
             <desc>L-19-20-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
+                <polyline class="nad-edge-path" points="483.09,-676.47 435.04,-702.19 283.62,-697.34"/>
                 <g class="nad-edge-infos" transform="translate(405.05,-701.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
@@ -1342,7 +1340,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
+                <polyline class="nad-edge-path" points="85.91,-663.73 132.21,-692.48 283.62,-697.34"/>
                 <g class="nad-edge-infos" transform="translate(162.20,-693.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
@@ -1364,7 +1362,7 @@
         <g id="75">
             <desc>L-19-20-2 </desc>
             <g class="nad-vl180to300">
-                <polyline points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
+                <polyline class="nad-edge-path" points="483.91,-650.99 437.60,-622.24 286.19,-617.38"/>
                 <g class="nad-edge-infos" transform="translate(407.62,-621.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-91.84)">
@@ -1383,7 +1381,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
+                <polyline class="nad-edge-path" points="86.73,-638.24 134.78,-612.52 286.19,-617.38"/>
                 <g class="nad-edge-infos" transform="translate(164.76,-613.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.16)">
@@ -1405,7 +1403,7 @@
         <g id="76">
             <desc>L-2-4-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-959.46,1071.25 -865.04,977.27"/>
+                <polyline class="nad-edge-path" points="-959.46,1071.25 -865.04,977.27"/>
                 <g class="nad-edge-infos" transform="translate(-936.42,1048.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
@@ -1424,7 +1422,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-770.63,883.29 -865.04,977.27"/>
+                <polyline class="nad-edge-path" points="-770.63,883.29 -865.04,977.27"/>
                 <g class="nad-edge-infos" transform="translate(-793.66,906.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
@@ -1446,7 +1444,7 @@
         <g id="77">
             <desc>L-2-6-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-953.80,1098.58 -784.76,1165.10"/>
+                <polyline class="nad-edge-path" points="-953.80,1098.58 -784.76,1165.10"/>
                 <g class="nad-edge-infos" transform="translate(-923.56,1110.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(111.48)">
@@ -1465,7 +1463,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-615.72,1231.62 -784.76,1165.10"/>
+                <polyline class="nad-edge-path" points="-615.72,1231.62 -784.76,1165.10"/>
                 <g class="nad-edge-infos" transform="translate(-645.96,1219.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-68.52)">
@@ -1487,7 +1485,7 @@
         <g id="78">
             <desc>L-20-23-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
+                <polyline class="nad-edge-path" points="49.56,-629.43 18.17,-584.88 -1.04,-372.44"/>
                 <g class="nad-edge-infos" transform="translate(15.47,-555.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
@@ -1506,7 +1504,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
+                <polyline class="nad-edge-path" points="2.64,-110.54 -20.25,-160.00 -1.04,-372.44"/>
                 <g class="nad-edge-infos" transform="translate(-17.54,-189.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
@@ -1528,7 +1526,7 @@
         <g id="79">
             <desc>L-20-23-2 </desc>
             <g class="nad-vl180to300">
-                <polyline points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
+                <polyline class="nad-edge-path" points="74.96,-627.14 97.85,-577.68 78.64,-365.24"/>
                 <g class="nad-edge-infos" transform="translate(95.14,-547.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.83)">
@@ -1547,7 +1545,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
+                <polyline class="nad-edge-path" points="28.04,-108.25 59.43,-152.80 78.64,-365.24"/>
                 <g class="nad-edge-infos" transform="translate(62.13,-182.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.17)">
@@ -1569,7 +1567,7 @@
         <g id="80">
             <desc>L-21-22-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="1398.75,-664.33 1566.74,-520.22"/>
+                <polyline class="nad-edge-path" points="1398.75,-664.33 1566.74,-520.22"/>
                 <g class="nad-edge-infos" transform="translate(1423.42,-643.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(130.63)">
@@ -1588,7 +1586,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="1734.72,-376.11 1566.74,-520.22"/>
+                <polyline class="nad-edge-path" points="1734.72,-376.11 1566.74,-520.22"/>
                 <g class="nad-edge-infos" transform="translate(1710.05,-397.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-49.37)">
@@ -1610,7 +1608,7 @@
         <g id="81">
             <desc>T-24-3-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="260.52,-309.61 -49.66,-187.99"/>
+                <polyline class="nad-edge-path" points="260.52,-309.61 -49.66,-187.99"/>
                 <g class="nad-edge-infos" transform="translate(230.26,-297.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.41)">
@@ -1627,10 +1625,10 @@
                         <text transform="rotate(-21.41)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-68.28" cy="-180.69" r="20.00"/>
+                <circle class="nad-winding" cx="-68.28" cy="-180.69" r="20.00"/>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-415.69,-44.48 -105.52,-166.09"/>
+                <polyline class="nad-edge-path" points="-415.69,-44.48 -105.52,-166.09"/>
                 <g class="nad-edge-infos" transform="translate(-385.44,-56.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.59)">
@@ -1647,13 +1645,13 @@
                         <text transform="rotate(-21.41)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-86.90" cy="-173.39" r="20.00"/>
+                <circle class="nad-winding" cx="-86.90" cy="-173.39" r="20.00"/>
             </g>
         </g>
         <g id="82">
             <desc>L-3-9-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-441.80,-9.78 -458.48,168.86"/>
+                <polyline class="nad-edge-path" points="-441.80,-9.78 -458.48,168.86"/>
                 <g class="nad-edge-infos" transform="translate(-444.82,22.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-174.67)">
@@ -1672,7 +1670,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-475.15,347.50 -458.48,168.86"/>
+                <polyline class="nad-edge-path" points="-475.15,347.50 -458.48,168.86"/>
                 <g class="nad-edge-infos" transform="translate(-472.13,315.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(5.33)">
@@ -1694,7 +1692,7 @@
         <g id="83">
             <desc>L-4-9-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-740.12,843.04 -615.03,619.10"/>
+                <polyline class="nad-edge-path" points="-740.12,843.04 -615.03,619.10"/>
                 <g class="nad-edge-infos" transform="translate(-724.27,814.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(29.19)">
@@ -1713,7 +1711,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-489.95,395.15 -615.03,619.10"/>
+                <polyline class="nad-edge-path" points="-489.95,395.15 -615.03,619.10"/>
                 <g class="nad-edge-infos" transform="translate(-505.80,423.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-150.81)">
@@ -1735,7 +1733,7 @@
         <g id="84">
             <desc>L-7-8-1 </desc>
             <g class="nad-vl120to180">
-                <polyline points="-1160.53,-219.25 -1011.91,-55.90"/>
+                <polyline class="nad-edge-path" points="-1160.53,-219.25 -1011.91,-55.90"/>
                 <g class="nad-edge-infos" transform="translate(-1138.66,-195.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(137.70)">
@@ -1754,7 +1752,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-863.30,107.45 -1011.91,-55.90"/>
+                <polyline class="nad-edge-path" points="-863.30,107.45 -1011.91,-55.90"/>
                 <g class="nad-edge-infos" transform="translate(-885.17,83.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-42.30)">
@@ -1776,7 +1774,7 @@
         <g id="85">
             <desc>L-8-9-1 </desc>
             <g class="nad-vl180to300">
-                <polyline points="-824.94,140.49 -661.83,249.60"/>
+                <polyline class="nad-edge-path" points="-824.94,140.49 -661.83,249.60"/>
                 <g class="nad-edge-infos" transform="translate(-797.93,158.56)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(123.78)">
@@ -1795,7 +1793,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-498.71,358.71 -661.83,249.60"/>
+                <polyline class="nad-edge-path" points="-498.71,358.71 -661.83,249.60"/>
                 <g class="nad-edge-infos" transform="translate(-525.72,340.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.22)">

--- a/src/test/resources/IEEE_24_bus.svg
+++ b/src/test/resources/IEEE_24_bus.svg
@@ -146,99 +146,99 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-962.13,480.68)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-493.64,692.74)" id="2" class="nad-vl120to180">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(46.99,652.79)" id="4" class="nad-vl180to300">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-160.17,328.18)" id="6" class="nad-vl180to300">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(180.28,320.01)" id="8" class="nad-vl180to300">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(644.30,427.15)" id="10" class="nad-vl180to300">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(879.89,-504.78)" id="12" class="nad-vl180to300">
             <desc>VL15</desc>
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(871.96,-122.70)" id="14" class="nad-vl180to300">
             <desc>VL16</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(1398.65,-57.76)" id="16" class="nad-vl180to300">
             <desc>VL17</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(1425.03,-379.69)" id="18" class="nad-vl180to300">
             <desc>VL18</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(505.57,-664.44)" id="20" class="nad-vl180to300">
             <desc>VL19</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(-977.53,1089.24)" id="22" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(64.25,-650.28)" id="24" class="nad-vl180to300">
             <desc>VL20</desc>
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(1379.40,-680.93)" id="26" class="nad-vl180to300">
             <desc>VL21</desc>
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
         <g transform="translate(1754.07,-359.50)" id="28" class="nad-vl180to300">
             <desc>VL22</desc>
-            <circle class="nad-busnode" r="27.50" id="29"/>
+            <circle r="27.50" id="29" class="nad-busnode"/>
         </g>
         <g transform="translate(13.35,-87.40)" id="30" class="nad-vl180to300">
             <desc>VL23</desc>
-            <circle class="nad-busnode" r="27.50" id="31"/>
+            <circle r="27.50" id="31" class="nad-busnode"/>
         </g>
         <g transform="translate(284.26,-318.91)" id="32" class="nad-vl180to300">
             <desc>VL24</desc>
-            <circle class="nad-busnode" r="27.50" id="33"/>
+            <circle r="27.50" id="33" class="nad-busnode"/>
         </g>
         <g transform="translate(-439.43,-35.17)" id="34" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="35"/>
+            <circle r="27.50" id="35" class="nad-busnode"/>
         </g>
         <g transform="translate(-752.55,865.30)" id="36" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="37"/>
+            <circle r="27.50" id="37" class="nad-busnode"/>
         </g>
         <g transform="translate(-1169.10,698.07)" id="38" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="39"/>
+            <circle r="27.50" id="39" class="nad-busnode"/>
         </g>
         <g transform="translate(-591.99,1240.96)" id="40" class="nad-vl120to180">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="41"/>
+            <circle r="27.50" id="41" class="nad-busnode"/>
         </g>
         <g transform="translate(-1177.69,-238.11)" id="42" class="nad-vl120to180">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="43"/>
+            <circle r="27.50" id="43" class="nad-busnode"/>
         </g>
         <g transform="translate(-846.14,126.31)" id="44" class="nad-vl180to300">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="45"/>
+            <circle r="27.50" id="45" class="nad-busnode"/>
         </g>
         <g transform="translate(-477.52,372.89)" id="46" class="nad-vl120to180">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="47"/>
+            <circle r="27.50" id="47" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="710.39" viewBox="-1761.04 -1433.43 3649.75 3240.91" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -163,130 +161,130 @@
     <g class="nad-vl-nodes">
         <g transform="translate(565.06,-817.84)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(210.04,69.85)" id="2" class="nad-vl30to50">
             <desc>VL10</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-610.23,747.39)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(1145.30,-81.29)" id="6" class="nad-vl30to50">
             <desc>VL12</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(1588.70,194.19)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(913.52,122.69)" id="10" class="nad-vl30to50">
             <desc>VL14</desc>
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(487.32,-474.91)" id="12" class="nad-vl30to50">
             <desc>VL15</desc>
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(1396.87,-367.51)" id="14" class="nad-vl30to50">
             <desc>VL16</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(921.96,-302.15)" id="16" class="nad-vl30to50">
             <desc>VL17</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(290.45,-1130.66)" id="18" class="nad-vl30to50">
             <desc>VL18</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(-82.84,-1218.43)" id="20" class="nad-vl30to50">
             <desc>VL19</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(180.70,-263.40)" id="22" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(-34.48,-735.42)" id="24" class="nad-vl30to50">
             <desc>VL20</desc>
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(387.95,405.49)" id="26" class="nad-vl30to50">
             <desc>VL21</desc>
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
         <g transform="translate(-140.57,127.31)" id="28" class="nad-vl30to50">
             <desc>VL22</desc>
-            <circle r="27.50" id="29"/>
+            <circle class="nad-busnode" r="27.50" id="29"/>
         </g>
         <g transform="translate(-407.83,-535.70)" id="30" class="nad-vl30to50">
             <desc>VL23</desc>
-            <circle r="27.50" id="31"/>
+            <circle class="nad-busnode" r="27.50" id="31"/>
         </g>
         <g transform="translate(-785.89,-44.13)" id="32" class="nad-vl30to50">
             <desc>VL24</desc>
-            <circle r="27.50" id="33"/>
+            <circle class="nad-busnode" r="27.50" id="33"/>
         </g>
         <g transform="translate(-1136.46,521.59)" id="34" class="nad-vl30to50">
             <desc>VL25</desc>
-            <circle r="27.50" id="35"/>
+            <circle class="nad-busnode" r="27.50" id="35"/>
         </g>
         <g transform="translate(-1561.04,399.29)" id="36" class="nad-vl30to50">
             <desc>VL26</desc>
-            <circle r="27.50" id="37"/>
+            <circle class="nad-busnode" r="27.50" id="37"/>
         </g>
         <g transform="translate(-831.63,1168.73)" id="38" class="nad-vl30to50">
             <desc>VL27</desc>
-            <circle r="27.50" id="39"/>
+            <circle class="nad-busnode" r="27.50" id="39"/>
         </g>
         <g transform="translate(-213.94,1050.08)" id="40" class="nad-vl120to180">
             <desc>VL28</desc>
-            <circle r="27.50" id="41"/>
+            <circle class="nad-busnode" r="27.50" id="41"/>
         </g>
         <g transform="translate(-759.33,1607.48)" id="42" class="nad-vl30to50">
             <desc>VL29</desc>
-            <circle r="27.50" id="43"/>
+            <circle class="nad-busnode" r="27.50" id="43"/>
         </g>
         <g transform="translate(901.51,-716.33)" id="44" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle r="27.50" id="45"/>
+            <circle class="nad-busnode" r="27.50" id="45"/>
         </g>
         <g transform="translate(-1075.65,1516.77)" id="46" class="nad-vl30to50">
             <desc>VL30</desc>
-            <circle r="27.50" id="47"/>
+            <circle class="nad-busnode" r="27.50" id="47"/>
         </g>
         <g transform="translate(605.40,-102.54)" id="48" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle r="27.50" id="49"/>
+            <circle class="nad-busnode" r="27.50" id="49"/>
         </g>
         <g transform="translate(-325.24,-198.83)" id="50" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle r="27.50" id="51"/>
+            <circle class="nad-busnode" r="27.50" id="51"/>
         </g>
         <g transform="translate(71.61,428.90)" id="52" class="nad-vl120to180">
             <desc>VL6</desc>
-            <circle r="27.50" id="53"/>
+            <circle class="nad-busnode" r="27.50" id="53"/>
         </g>
         <g transform="translate(-458.72,201.69)" id="54" class="nad-vl120to180">
             <desc>VL7</desc>
-            <circle r="27.50" id="55"/>
+            <circle class="nad-busnode" r="27.50" id="55"/>
         </g>
         <g transform="translate(173.93,995.43)" id="56" class="nad-vl120to180">
             <desc>VL8</desc>
-            <circle r="27.50" id="57"/>
+            <circle class="nad-busnode" r="27.50" id="57"/>
         </g>
         <g transform="translate(-207.43,574.68)" id="58" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle r="27.50" id="59"/>
+            <circle class="nad-busnode" r="27.50" id="59"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="60">
             <desc>L1-2-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="550.53,-796.88 372.88,-540.62"/>
+                <polyline class="nad-edge-path" points="550.53,-796.88 372.88,-540.62"/>
                 <g class="nad-edge-infos" transform="translate(532.02,-770.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.27)">
@@ -305,7 +303,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="195.23,-284.35 372.88,-540.62"/>
+                <polyline class="nad-edge-path" points="195.23,-284.35 372.88,-540.62"/>
                 <g class="nad-edge-infos" transform="translate(213.75,-311.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.73)">
@@ -327,7 +325,7 @@
         <g id="61">
             <desc>L1-3-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="589.47,-810.47 733.28,-767.08"/>
+                <polyline class="nad-edge-path" points="589.47,-810.47 733.28,-767.08"/>
                 <g class="nad-edge-infos" transform="translate(620.59,-801.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.79)">
@@ -346,7 +344,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="877.09,-723.69 733.28,-767.08"/>
+                <polyline class="nad-edge-path" points="877.09,-723.69 733.28,-767.08"/>
                 <g class="nad-edge-infos" transform="translate(845.98,-733.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.21)">
@@ -368,7 +366,7 @@
         <g id="62">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-191.18,555.03 1.30,322.26"/>
+                <polyline class="nad-edge-path" points="-191.18,555.03 1.30,322.26"/>
                 <g class="nad-edge-infos" transform="translate(-170.47,529.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(39.59)">
@@ -387,7 +385,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="193.79,89.50 1.30,322.26"/>
+                <polyline class="nad-edge-path" points="193.79,89.50 1.30,322.26"/>
                 <g class="nad-edge-infos" transform="translate(173.07,114.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-140.41)">
@@ -409,7 +407,7 @@
         <g id="63">
             <desc>L10-20-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="202.63,45.45 87.78,-332.78"/>
+                <polyline class="nad-edge-path" points="202.63,45.45 87.78,-332.78"/>
                 <g class="nad-edge-infos" transform="translate(193.18,14.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.89)">
@@ -428,7 +426,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-27.07,-711.02 87.78,-332.78"/>
+                <polyline class="nad-edge-path" points="-27.07,-711.02 87.78,-332.78"/>
                 <g class="nad-edge-infos" transform="translate(-17.63,-679.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.11)">
@@ -450,7 +448,7 @@
         <g id="64">
             <desc>L10-17-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="232.64,58.04 566.00,-116.15"/>
+                <polyline class="nad-edge-path" points="232.64,58.04 566.00,-116.15"/>
                 <g class="nad-edge-infos" transform="translate(261.44,42.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.41)">
@@ -469,7 +467,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="899.36,-290.34 566.00,-116.15"/>
+                <polyline class="nad-edge-path" points="899.36,-290.34 566.00,-116.15"/>
                 <g class="nad-edge-infos" transform="translate(870.55,-275.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.59)">
@@ -491,7 +489,7 @@
         <g id="65">
             <desc>L10-21-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="221.98,92.38 298.99,237.67"/>
+                <polyline class="nad-edge-path" points="221.98,92.38 298.99,237.67"/>
                 <g class="nad-edge-infos" transform="translate(237.20,121.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.07)">
@@ -510,7 +508,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="376.00,382.96 298.99,237.67"/>
+                <polyline class="nad-edge-path" points="376.00,382.96 298.99,237.67"/>
                 <g class="nad-edge-infos" transform="translate(360.78,354.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.93)">
@@ -532,7 +530,7 @@
         <g id="66">
             <desc>L10-22-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="184.87,73.98 34.73,98.58"/>
+                <polyline class="nad-edge-path" points="184.87,73.98 34.73,98.58"/>
                 <g class="nad-edge-infos" transform="translate(152.80,79.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.31)">
@@ -551,7 +549,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-115.40,123.18 34.73,98.58"/>
+                <polyline class="nad-edge-path" points="-115.40,123.18 34.73,98.58"/>
                 <g class="nad-edge-infos" transform="translate(-83.33,117.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.69)">
@@ -573,7 +571,7 @@
         <g id="67">
             <desc>T6-10-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="80.79,405.11 130.03,277.37"/>
+                <polyline class="nad-edge-path" points="80.79,405.11 130.03,277.37"/>
                 <g class="nad-edge-infos" transform="translate(92.48,374.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.08)">
@@ -590,10 +588,10 @@
                         <text transform="rotate(-68.92)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="137.23" cy="258.71" r="20.00"/>
+                <circle class="nad-winding" cx="137.23" cy="258.71" r="20.00"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="200.86,93.65 151.62,221.39"/>
+                <polyline class="nad-edge-path" points="200.86,93.65 151.62,221.39"/>
                 <g class="nad-edge-infos" transform="translate(189.17,123.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.92)">
@@ -610,13 +608,13 @@
                         <text transform="rotate(-68.92)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="144.42" cy="240.05" r="20.00"/>
+                <circle class="nad-winding" cx="144.42" cy="240.05" r="20.00"/>
             </g>
         </g>
         <g id="68">
             <desc>L9-11-1</desc>
             <g class="nad-vl0to30">
-                <polyline points="-230.87,584.73 -408.83,661.04"/>
+                <polyline class="nad-edge-path" points="-230.87,584.73 -408.83,661.04"/>
                 <g class="nad-edge-infos" transform="translate(-260.74,597.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-113.21)">
@@ -635,7 +633,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-586.80,737.35 -408.83,661.04"/>
+                <polyline class="nad-edge-path" points="-586.80,737.35 -408.83,661.04"/>
                 <g class="nad-edge-infos" transform="translate(-556.93,724.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(66.79)">
@@ -657,7 +655,7 @@
         <g id="69">
             <desc>L12-13-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="1166.96,-67.83 1367.00,56.45"/>
+                <polyline class="nad-edge-path" points="1166.96,-67.83 1367.00,56.45"/>
                 <g class="nad-edge-infos" transform="translate(1194.57,-50.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.85)">
@@ -676,7 +674,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1567.04,180.73 1367.00,56.45"/>
+                <polyline class="nad-edge-path" points="1567.04,180.73 1367.00,56.45"/>
                 <g class="nad-edge-infos" transform="translate(1539.44,163.58)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-58.15)">
@@ -698,7 +696,7 @@
         <g id="70">
             <desc>L12-14-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="1126.16,-64.44 1029.41,20.70"/>
+                <polyline class="nad-edge-path" points="1126.16,-64.44 1029.41,20.70"/>
                 <g class="nad-edge-infos" transform="translate(1101.76,-42.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.35)">
@@ -717,7 +715,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="932.66,105.85 1029.41,20.70"/>
+                <polyline class="nad-edge-path" points="932.66,105.85 1029.41,20.70"/>
                 <g class="nad-edge-infos" transform="translate(957.06,84.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.65)">
@@ -739,7 +737,7 @@
         <g id="71">
             <desc>L12-15-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="1123.42,-94.38 816.31,-278.10"/>
+                <polyline class="nad-edge-path" points="1123.42,-94.38 816.31,-278.10"/>
                 <g class="nad-edge-infos" transform="translate(1095.53,-111.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-59.11)">
@@ -758,7 +756,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="509.20,-461.82 816.31,-278.10"/>
+                <polyline class="nad-edge-path" points="509.20,-461.82 816.31,-278.10"/>
                 <g class="nad-edge-infos" transform="translate(537.09,-445.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(120.89)">
@@ -780,7 +778,7 @@
         <g id="72">
             <desc>L12-16-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="1162.14,-100.44 1271.09,-224.40"/>
+                <polyline class="nad-edge-path" points="1162.14,-100.44 1271.09,-224.40"/>
                 <g class="nad-edge-infos" transform="translate(1183.59,-124.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.31)">
@@ -799,7 +797,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="1380.04,-348.36 1271.09,-224.40"/>
+                <polyline class="nad-edge-path" points="1380.04,-348.36 1271.09,-224.40"/>
                 <g class="nad-edge-infos" transform="translate(1358.58,-323.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.69)">
@@ -821,7 +819,7 @@
         <g id="73">
             <desc>T4-12-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="630.88,-101.54 845.38,-93.09"/>
+                <polyline class="nad-edge-path" points="630.88,-101.54 845.38,-93.09"/>
                 <g class="nad-edge-infos" transform="translate(663.36,-100.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(92.25)">
@@ -838,10 +836,10 @@
                         <text transform="rotate(2.25)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="865.36" cy="-92.31" r="20.00"/>
+                <circle class="nad-winding" cx="865.36" cy="-92.31" r="20.00"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="1119.82,-82.29 905.33,-90.73"/>
+                <polyline class="nad-edge-path" points="1119.82,-82.29 905.33,-90.73"/>
                 <g class="nad-edge-infos" transform="translate(1087.35,-83.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.75)">
@@ -858,13 +856,13 @@
                         <text transform="rotate(-357.75)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="885.35" cy="-91.52" r="20.00"/>
+                <circle class="nad-winding" cx="885.35" cy="-91.52" r="20.00"/>
             </g>
         </g>
         <g id="74">
             <desc>L14-15-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="898.71,101.93 700.42,-176.11"/>
+                <polyline class="nad-edge-path" points="898.71,101.93 700.42,-176.11"/>
                 <g class="nad-edge-infos" transform="translate(879.84,75.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-35.50)">
@@ -883,7 +881,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="502.13,-454.15 700.42,-176.11"/>
+                <polyline class="nad-edge-path" points="502.13,-454.15 700.42,-176.11"/>
                 <g class="nad-edge-infos" transform="translate(521.00,-427.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.50)">
@@ -905,7 +903,7 @@
         <g id="75">
             <desc>L15-18-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="479.99,-499.33 388.89,-802.78"/>
+                <polyline class="nad-edge-path" points="479.99,-499.33 388.89,-802.78"/>
                 <g class="nad-edge-infos" transform="translate(470.64,-530.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.71)">
@@ -924,7 +922,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="297.78,-1106.23 388.89,-802.78"/>
+                <polyline class="nad-edge-path" points="297.78,-1106.23 388.89,-802.78"/>
                 <g class="nad-edge-infos" transform="translate(307.13,-1075.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.29)">
@@ -946,7 +944,7 @@
         <g id="76">
             <desc>L15-23-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="461.88,-476.63 39.74,-505.30"/>
+                <polyline class="nad-edge-path" points="461.88,-476.63 39.74,-505.30"/>
                 <g class="nad-edge-infos" transform="translate(429.45,-478.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.12)">
@@ -965,7 +963,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-382.39,-533.97 39.74,-505.30"/>
+                <polyline class="nad-edge-path" points="-382.39,-533.97 39.74,-505.30"/>
                 <g class="nad-edge-infos" transform="translate(-349.97,-531.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.88)">
@@ -987,7 +985,7 @@
         <g id="77">
             <desc>L16-17-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="1371.61,-364.03 1159.42,-334.83"/>
+                <polyline class="nad-edge-path" points="1371.61,-364.03 1159.42,-334.83"/>
                 <g class="nad-edge-infos" transform="translate(1339.41,-359.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.84)">
@@ -1006,7 +1004,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="947.22,-305.63 1159.42,-334.83"/>
+                <polyline class="nad-edge-path" points="947.22,-305.63 1159.42,-334.83"/>
                 <g class="nad-edge-infos" transform="translate(979.42,-310.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.16)">
@@ -1028,7 +1026,7 @@
         <g id="78">
             <desc>L18-19-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="265.63,-1136.49 103.80,-1174.55"/>
+                <polyline class="nad-edge-path" points="265.63,-1136.49 103.80,-1174.55"/>
                 <g class="nad-edge-infos" transform="translate(233.99,-1143.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-76.77)">
@@ -1047,7 +1045,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-58.02,-1212.60 103.80,-1174.55"/>
+                <polyline class="nad-edge-path" points="-58.02,-1212.60 103.80,-1174.55"/>
                 <g class="nad-edge-infos" transform="translate(-26.38,-1205.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(103.23)">
@@ -1069,7 +1067,7 @@
         <g id="79">
             <desc>L19-20-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-80.30,-1193.06 -58.66,-976.93"/>
+                <polyline class="nad-edge-path" points="-80.30,-1193.06 -58.66,-976.93"/>
                 <g class="nad-edge-infos" transform="translate(-77.07,-1160.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.28)">
@@ -1088,7 +1086,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-37.02,-760.79 -58.66,-976.93"/>
+                <polyline class="nad-edge-path" points="-37.02,-760.79 -58.66,-976.93"/>
                 <g class="nad-edge-infos" transform="translate(-40.26,-793.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.72)">
@@ -1110,7 +1108,7 @@
         <g id="80">
             <desc>L2-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="204.55,-254.36 393.05,-182.97"/>
+                <polyline class="nad-edge-path" points="204.55,-254.36 393.05,-182.97"/>
                 <g class="nad-edge-infos" transform="translate(234.94,-242.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(110.74)">
@@ -1129,7 +1127,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="581.56,-111.57 393.05,-182.97"/>
+                <polyline class="nad-edge-path" points="581.56,-111.57 393.05,-182.97"/>
                 <g class="nad-edge-infos" transform="translate(551.16,-123.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-69.26)">
@@ -1151,7 +1149,7 @@
         <g id="81">
             <desc>L2-5-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="155.41,-260.17 -72.27,-231.11"/>
+                <polyline class="nad-edge-path" points="155.41,-260.17 -72.27,-231.11"/>
                 <g class="nad-edge-infos" transform="translate(123.17,-256.05)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.27)">
@@ -1170,7 +1168,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-299.95,-202.06 -72.27,-231.11"/>
+                <polyline class="nad-edge-path" points="-299.95,-202.06 -72.27,-231.11"/>
                 <g class="nad-edge-infos" transform="translate(-267.71,-206.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.73)">
@@ -1192,7 +1190,7 @@
         <g id="82">
             <desc>L2-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="176.74,-238.21 126.16,82.75"/>
+                <polyline class="nad-edge-path" points="176.74,-238.21 126.16,82.75"/>
                 <g class="nad-edge-infos" transform="translate(171.68,-206.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-171.05)">
@@ -1211,7 +1209,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="75.58,403.71 126.16,82.75"/>
+                <polyline class="nad-edge-path" points="75.58,403.71 126.16,82.75"/>
                 <g class="nad-edge-infos" transform="translate(80.64,371.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(8.95)">
@@ -1233,7 +1231,7 @@
         <g id="83">
             <desc>L21-22-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="365.38,393.62 123.69,266.40"/>
+                <polyline class="nad-edge-path" points="365.38,393.62 123.69,266.40"/>
                 <g class="nad-edge-infos" transform="translate(336.62,378.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.24)">
@@ -1252,7 +1250,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-118.00,139.18 123.69,266.40"/>
+                <polyline class="nad-edge-path" points="-118.00,139.18 123.69,266.40"/>
                 <g class="nad-edge-infos" transform="translate(-89.24,154.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.76)">
@@ -1274,7 +1272,7 @@
         <g id="84">
             <desc>L22-24-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-165.21,120.76 -463.23,41.59"/>
+                <polyline class="nad-edge-path" points="-165.21,120.76 -463.23,41.59"/>
                 <g class="nad-edge-infos" transform="translate(-196.62,112.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.12)">
@@ -1293,7 +1291,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-761.25,-37.59 -463.23,41.59"/>
+                <polyline class="nad-edge-path" points="-761.25,-37.59 -463.23,41.59"/>
                 <g class="nad-edge-infos" transform="translate(-729.84,-29.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.88)">
@@ -1315,7 +1313,7 @@
         <g id="85">
             <desc>L23-24-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-423.38,-515.48 -596.86,-289.91"/>
+                <polyline class="nad-edge-path" points="-423.38,-515.48 -596.86,-289.91"/>
                 <g class="nad-edge-infos" transform="translate(-443.19,-489.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-142.44)">
@@ -1334,7 +1332,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-770.35,-64.35 -596.86,-289.91"/>
+                <polyline class="nad-edge-path" points="-770.35,-64.35 -596.86,-289.91"/>
                 <g class="nad-edge-infos" transform="translate(-750.53,-90.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(37.56)">
@@ -1356,7 +1354,7 @@
         <g id="86">
             <desc>L24-25-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-799.33,-22.46 -961.18,238.73"/>
+                <polyline class="nad-edge-path" points="-799.33,-22.46 -961.18,238.73"/>
                 <g class="nad-edge-infos" transform="translate(-816.44,5.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.21)">
@@ -1375,7 +1373,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-1123.03,499.91 -961.18,238.73"/>
+                <polyline class="nad-edge-path" points="-1123.03,499.91 -961.18,238.73"/>
                 <g class="nad-edge-infos" transform="translate(-1105.91,472.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(31.79)">
@@ -1397,7 +1395,7 @@
         <g id="87">
             <desc>L25-26-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-1160.96,514.53 -1348.75,460.44"/>
+                <polyline class="nad-edge-path" points="-1160.96,514.53 -1348.75,460.44"/>
                 <g class="nad-edge-infos" transform="translate(-1192.19,505.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-73.93)">
@@ -1416,7 +1414,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-1536.54,406.35 -1348.75,460.44"/>
+                <polyline class="nad-edge-path" points="-1536.54,406.35 -1348.75,460.44"/>
                 <g class="nad-edge-infos" transform="translate(-1505.31,415.35)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.07)">
@@ -1438,7 +1436,7 @@
         <g id="88">
             <desc>L25-27-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-1125.59,544.65 -984.04,845.16"/>
+                <polyline class="nad-edge-path" points="-1125.59,544.65 -984.04,845.16"/>
                 <g class="nad-edge-infos" transform="translate(-1111.74,574.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.78)">
@@ -1457,7 +1455,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-842.50,1145.66 -984.04,845.16"/>
+                <polyline class="nad-edge-path" points="-842.50,1145.66 -984.04,845.16"/>
                 <g class="nad-edge-infos" transform="translate(-856.35,1116.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.22)">
@@ -1479,7 +1477,7 @@
         <g id="89">
             <desc>L27-29-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-827.48,1193.89 -795.48,1388.11"/>
+                <polyline class="nad-edge-path" points="-827.48,1193.89 -795.48,1388.11"/>
                 <g class="nad-edge-infos" transform="translate(-822.20,1225.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(170.64)">
@@ -1498,7 +1496,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-763.48,1582.32 -795.48,1388.11"/>
+                <polyline class="nad-edge-path" points="-763.48,1582.32 -795.48,1388.11"/>
                 <g class="nad-edge-infos" transform="translate(-768.76,1550.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-9.36)">
@@ -1520,7 +1518,7 @@
         <g id="90">
             <desc>L27-30-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-846.27,1189.61 -953.64,1342.75"/>
+                <polyline class="nad-edge-path" points="-846.27,1189.61 -953.64,1342.75"/>
                 <g class="nad-edge-infos" transform="translate(-864.93,1216.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-144.96)">
@@ -1539,7 +1537,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-1061.01,1495.89 -953.64,1342.75"/>
+                <polyline class="nad-edge-path" points="-1061.01,1495.89 -953.64,1342.75"/>
                 <g class="nad-edge-infos" transform="translate(-1042.35,1469.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(35.04)">
@@ -1561,7 +1559,7 @@
         <g id="91">
             <desc>T28-27-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-238.98,1054.89 -493.32,1103.75"/>
+                <polyline class="nad-edge-path" points="-238.98,1054.89 -493.32,1103.75"/>
                 <g class="nad-edge-infos" transform="translate(-270.90,1061.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.87)">
@@ -1578,10 +1576,10 @@
                         <text transform="rotate(-10.87)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-512.96" cy="1107.52" r="20.00"/>
+                <circle class="nad-winding" cx="-512.96" cy="1107.52" r="20.00"/>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-806.59,1163.92 -552.24,1115.07"/>
+                <polyline class="nad-edge-path" points="-806.59,1163.92 -552.24,1115.07"/>
                 <g class="nad-edge-infos" transform="translate(-774.67,1157.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.13)">
@@ -1598,13 +1596,13 @@
                         <text transform="rotate(-10.87)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-532.60" cy="1111.29" r="20.00"/>
+                <circle class="nad-winding" cx="-532.60" cy="1111.29" r="20.00"/>
             </g>
         </g>
         <g id="92">
             <desc>L8-28-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="148.67,998.99 -20.01,1022.76"/>
+                <polyline class="nad-edge-path" points="148.67,998.99 -20.01,1022.76"/>
                 <g class="nad-edge-infos" transform="translate(116.49,1003.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.02)">
@@ -1623,7 +1621,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-188.69,1046.52 -20.01,1022.76"/>
+                <polyline class="nad-edge-path" points="-188.69,1046.52 -20.01,1022.76"/>
                 <g class="nad-edge-infos" transform="translate(-156.50,1041.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.98)">
@@ -1645,7 +1643,7 @@
         <g id="93">
             <desc>L6-28-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="60.96,452.07 -71.16,739.49"/>
+                <polyline class="nad-edge-path" points="60.96,452.07 -71.16,739.49"/>
                 <g class="nad-edge-infos" transform="translate(47.39,481.60)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-155.31)">
@@ -1664,7 +1662,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-203.29,1026.91 -71.16,739.49"/>
+                <polyline class="nad-edge-path" points="-203.29,1026.91 -71.16,739.49"/>
                 <g class="nad-edge-infos" transform="translate(-189.71,997.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(24.69)">
@@ -1686,7 +1684,7 @@
         <g id="94">
             <desc>L29-30-1</desc>
             <g class="nad-vl30to50">
-                <polyline points="-783.85,1600.45 -917.49,1562.13"/>
+                <polyline class="nad-edge-path" points="-783.85,1600.45 -917.49,1562.13"/>
                 <g class="nad-edge-infos" transform="translate(-815.09,1591.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.00)">
@@ -1705,7 +1703,7 @@
                 </g>
             </g>
             <g class="nad-vl30to50">
-                <polyline points="-1051.14,1523.80 -917.49,1562.13"/>
+                <polyline class="nad-edge-path" points="-1051.14,1523.80 -917.49,1562.13"/>
                 <g class="nad-edge-infos" transform="translate(-1019.90,1532.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.00)">
@@ -1727,7 +1725,7 @@
         <g id="95">
             <desc>L3-4-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="890.43,-693.36 753.46,-409.43"/>
+                <polyline class="nad-edge-path" points="890.43,-693.36 753.46,-409.43"/>
                 <g class="nad-edge-infos" transform="translate(876.31,-664.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.25)">
@@ -1746,7 +1744,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="616.48,-125.51 753.46,-409.43"/>
+                <polyline class="nad-edge-path" points="616.48,-125.51 753.46,-409.43"/>
                 <g class="nad-edge-infos" transform="translate(630.61,-154.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.75)">
@@ -1768,7 +1766,7 @@
         <g id="96">
             <desc>L4-6-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="587.33,-84.55 338.51,163.18"/>
+                <polyline class="nad-edge-path" points="587.33,-84.55 338.51,163.18"/>
                 <g class="nad-edge-infos" transform="translate(564.30,-61.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.87)">
@@ -1787,7 +1785,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="89.68,410.91 338.51,163.18"/>
+                <polyline class="nad-edge-path" points="89.68,410.91 338.51,163.18"/>
                 <g class="nad-edge-infos" transform="translate(112.72,387.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.13)">
@@ -1809,7 +1807,7 @@
         <g id="97">
             <desc>L5-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="-333.31,-174.64 -391.98,1.43"/>
+                <polyline class="nad-edge-path" points="-333.31,-174.64 -391.98,1.43"/>
                 <g class="nad-edge-infos" transform="translate(-343.58,-143.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.57)">
@@ -1828,7 +1826,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-450.66,177.50 -391.98,1.43"/>
+                <polyline class="nad-edge-path" points="-450.66,177.50 -391.98,1.43"/>
                 <g class="nad-edge-infos" transform="translate(-440.38,146.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(18.43)">
@@ -1850,7 +1848,7 @@
         <g id="98">
             <desc>L6-7-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="48.17,418.86 -193.55,315.30"/>
+                <polyline class="nad-edge-path" points="48.17,418.86 -193.55,315.30"/>
                 <g class="nad-edge-infos" transform="translate(18.30,406.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-66.81)">
@@ -1869,7 +1867,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="-435.28,211.74 -193.55,315.30"/>
+                <polyline class="nad-edge-path" points="-435.28,211.74 -193.55,315.30"/>
                 <g class="nad-edge-infos" transform="translate(-405.41,224.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(113.19)">
@@ -1891,7 +1889,7 @@
         <g id="99">
             <desc>L6-8-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="76.15,454.00 122.77,712.17"/>
+                <polyline class="nad-edge-path" points="76.15,454.00 122.77,712.17"/>
                 <g class="nad-edge-infos" transform="translate(81.92,485.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(169.76)">
@@ -1910,7 +1908,7 @@
                 </g>
             </g>
             <g class="nad-vl120to180">
-                <polyline points="169.39,970.34 122.77,712.17"/>
+                <polyline class="nad-edge-path" points="169.39,970.34 122.77,712.17"/>
                 <g class="nad-edge-infos" transform="translate(163.62,938.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-10.24)">
@@ -1932,7 +1930,7 @@
         <g id="100">
             <desc>T6-9-1</desc>
             <g class="nad-vl120to180">
-                <polyline points="49.01,440.71 -41.32,487.90"/>
+                <polyline class="nad-edge-path" points="49.01,440.71 -41.32,487.90"/>
                 <g class="nad-edge-infos" transform="translate(20.21,455.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-117.58)">
@@ -1949,10 +1947,10 @@
                         <text transform="rotate(-27.58)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-59.05" cy="497.16" r="20.00"/>
+                <circle class="nad-winding" cx="-59.05" cy="497.16" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-184.83,562.87 -94.50,515.68"/>
+                <polyline class="nad-edge-path" points="-184.83,562.87 -94.50,515.68"/>
                 <g class="nad-edge-infos" transform="translate(-156.03,547.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.42)">
@@ -1969,7 +1967,7 @@
                         <text transform="rotate(-27.58)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-76.77" cy="506.42" r="20.00"/>
+                <circle class="nad-winding" cx="-76.77" cy="506.42" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/IEEE_30_bus.svg
+++ b/src/test/resources/IEEE_30_bus.svg
@@ -161,123 +161,123 @@
     <g class="nad-vl-nodes">
         <g transform="translate(565.06,-817.84)" id="0" class="nad-vl120to180">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(210.04,69.85)" id="2" class="nad-vl30to50">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-610.23,747.39)" id="4" class="nad-vl0to30">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(1145.30,-81.29)" id="6" class="nad-vl30to50">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(1588.70,194.19)" id="8" class="nad-vl0to30">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(913.52,122.69)" id="10" class="nad-vl30to50">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(487.32,-474.91)" id="12" class="nad-vl30to50">
             <desc>VL15</desc>
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(1396.87,-367.51)" id="14" class="nad-vl30to50">
             <desc>VL16</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(921.96,-302.15)" id="16" class="nad-vl30to50">
             <desc>VL17</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(290.45,-1130.66)" id="18" class="nad-vl30to50">
             <desc>VL18</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(-82.84,-1218.43)" id="20" class="nad-vl30to50">
             <desc>VL19</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(180.70,-263.40)" id="22" class="nad-vl120to180">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(-34.48,-735.42)" id="24" class="nad-vl30to50">
             <desc>VL20</desc>
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(387.95,405.49)" id="26" class="nad-vl30to50">
             <desc>VL21</desc>
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
         <g transform="translate(-140.57,127.31)" id="28" class="nad-vl30to50">
             <desc>VL22</desc>
-            <circle class="nad-busnode" r="27.50" id="29"/>
+            <circle r="27.50" id="29" class="nad-busnode"/>
         </g>
         <g transform="translate(-407.83,-535.70)" id="30" class="nad-vl30to50">
             <desc>VL23</desc>
-            <circle class="nad-busnode" r="27.50" id="31"/>
+            <circle r="27.50" id="31" class="nad-busnode"/>
         </g>
         <g transform="translate(-785.89,-44.13)" id="32" class="nad-vl30to50">
             <desc>VL24</desc>
-            <circle class="nad-busnode" r="27.50" id="33"/>
+            <circle r="27.50" id="33" class="nad-busnode"/>
         </g>
         <g transform="translate(-1136.46,521.59)" id="34" class="nad-vl30to50">
             <desc>VL25</desc>
-            <circle class="nad-busnode" r="27.50" id="35"/>
+            <circle r="27.50" id="35" class="nad-busnode"/>
         </g>
         <g transform="translate(-1561.04,399.29)" id="36" class="nad-vl30to50">
             <desc>VL26</desc>
-            <circle class="nad-busnode" r="27.50" id="37"/>
+            <circle r="27.50" id="37" class="nad-busnode"/>
         </g>
         <g transform="translate(-831.63,1168.73)" id="38" class="nad-vl30to50">
             <desc>VL27</desc>
-            <circle class="nad-busnode" r="27.50" id="39"/>
+            <circle r="27.50" id="39" class="nad-busnode"/>
         </g>
         <g transform="translate(-213.94,1050.08)" id="40" class="nad-vl120to180">
             <desc>VL28</desc>
-            <circle class="nad-busnode" r="27.50" id="41"/>
+            <circle r="27.50" id="41" class="nad-busnode"/>
         </g>
         <g transform="translate(-759.33,1607.48)" id="42" class="nad-vl30to50">
             <desc>VL29</desc>
-            <circle class="nad-busnode" r="27.50" id="43"/>
+            <circle r="27.50" id="43" class="nad-busnode"/>
         </g>
         <g transform="translate(901.51,-716.33)" id="44" class="nad-vl120to180">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="45"/>
+            <circle r="27.50" id="45" class="nad-busnode"/>
         </g>
         <g transform="translate(-1075.65,1516.77)" id="46" class="nad-vl30to50">
             <desc>VL30</desc>
-            <circle class="nad-busnode" r="27.50" id="47"/>
+            <circle r="27.50" id="47" class="nad-busnode"/>
         </g>
         <g transform="translate(605.40,-102.54)" id="48" class="nad-vl120to180">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="49"/>
+            <circle r="27.50" id="49" class="nad-busnode"/>
         </g>
         <g transform="translate(-325.24,-198.83)" id="50" class="nad-vl120to180">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="51"/>
+            <circle r="27.50" id="51" class="nad-busnode"/>
         </g>
         <g transform="translate(71.61,428.90)" id="52" class="nad-vl120to180">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="53"/>
+            <circle r="27.50" id="53" class="nad-busnode"/>
         </g>
         <g transform="translate(-458.72,201.69)" id="54" class="nad-vl120to180">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="55"/>
+            <circle r="27.50" id="55" class="nad-busnode"/>
         </g>
         <g transform="translate(173.93,995.43)" id="56" class="nad-vl120to180">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="57"/>
+            <circle r="27.50" id="57" class="nad-busnode"/>
         </g>
         <g transform="translate(-207.43,574.68)" id="58" class="nad-vl0to30">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="59"/>
+            <circle r="27.50" id="59" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -303,186 +303,186 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-269.69,-93.47)" id="0">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="1" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(846.23,833.49)" id="2">
             <desc>VL10</desc>
-            <circle class="nad-busnode" r="27.50" id="4" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M53.508,-21.052 A57.500,57.500 129.056 0 1 -17.367,54.815 L-6.663,31.810 A32.500,32.500 -117.559 0 0 31.283,-8.810 Z M-30.917,48.481 A57.500,57.500 201.050 1 1 46.268,-34.140 L24.087,-21.819 A32.500,32.500 -189.553 1 0 -20.132,25.514 Z " id="3" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="4" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M53.508,-21.052 A57.500,57.500 129.056 0 1 -17.367,54.815 L-6.663,31.810 A32.500,32.500 -117.559 0 0 31.283,-8.810 Z M-30.917,48.481 A57.500,57.500 201.050 1 1 46.268,-34.140 L24.087,-21.819 A32.500,32.500 -189.553 1 0 -20.132,25.514 Z " id="3" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(1241.95,134.97)" id="5">
             <desc>VL11</desc>
-            <circle class="nad-busnode" r="17.50" id="8" class="nad-vl0to30-2"/>
-            <path class="nad-busnode" d="M-0.823,-37.491 A37.500,37.500 123.223 0 1 31.814,19.853 L20.502,9.268 A22.500,22.500 -107.944 0 0 2.501,-22.361 Z M21.571,30.675 A37.500,37.500 190.940 1 1 -15.358,-34.211 L-11.862,-19.119 A22.500,22.500 -175.661 0 0 10.381,19.962 Z " id="6" class="nad-vl0to30-0"/>
-            <path class="nad-busnode" d="M-52.215,-24.079 A57.500,57.500 45.053 0 1 -19.845,-53.967 L-16.488,-39.171 A42.500,42.500 -39.778 0 0 -37.734,-19.555 Z M-5.255,-57.259 A57.500,57.500 131.195 0 1 46.547,33.758 L35.516,23.342 A42.500,42.500 -125.919 0 0 -1.932,-42.456 Z M20.797,53.607 A57.500,57.500 62.951 0 1 -38.286,42.901 L-26.809,32.978 A42.500,42.500 -57.675 0 0 13.532,40.288 Z M-48.055,31.575 A57.500,57.500 14.503 0 1 -54.431,18.534 L-39.559,15.536 A42.500,42.500 -9.228 0 0 -36.555,21.678 Z M-57.370,3.868 A57.500,57.500 13.667 0 1 -56.659,-9.797 L-42.167,-5.306 A42.500,42.500 -8.392 0 0 -42.490,0.905 Z " id="7" class="nad-vl0to30-2"/>
+            <circle r="17.50" id="8" class="nad-vl0to30-2 nad-busnode"/>
+            <path d="M-0.823,-37.491 A37.500,37.500 123.223 0 1 31.814,19.853 L20.502,9.268 A22.500,22.500 -107.944 0 0 2.501,-22.361 Z M21.571,30.675 A37.500,37.500 190.940 1 1 -15.358,-34.211 L-11.862,-19.119 A22.500,22.500 -175.661 0 0 10.381,19.962 Z " id="6" class="nad-vl0to30-0 nad-busnode"/>
+            <path d="M-52.215,-24.079 A57.500,57.500 45.053 0 1 -19.845,-53.967 L-16.488,-39.171 A42.500,42.500 -39.778 0 0 -37.734,-19.555 Z M-5.255,-57.259 A57.500,57.500 131.195 0 1 46.547,33.758 L35.516,23.342 A42.500,42.500 -125.919 0 0 -1.932,-42.456 Z M20.797,53.607 A57.500,57.500 62.951 0 1 -38.286,42.901 L-26.809,32.978 A42.500,42.500 -57.675 0 0 13.532,40.288 Z M-48.055,31.575 A57.500,57.500 14.503 0 1 -54.431,18.534 L-39.559,15.536 A42.500,42.500 -9.228 0 0 -36.555,21.678 Z M-57.370,3.868 A57.500,57.500 13.667 0 1 -56.659,-9.797 L-42.167,-5.306 A42.500,42.500 -8.392 0 0 -42.490,0.905 Z " id="7" class="nad-vl0to30-2 nad-busnode"/>
         </g>
         <g transform="translate(408.55,427.89)" id="9">
             <desc>VL12</desc>
-            <circle class="nad-busnode" r="27.50" id="10" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="10" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(740.31,235.48)" id="11">
             <desc>VL13</desc>
-            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M-17.080,-54.905 A57.500,57.500 35.636 0 1 18.107,-54.574 L7.093,-31.716 A32.500,32.500 -24.138 0 0 -6.497,-31.844 Z M31.571,-48.058 A57.500,57.500 95.315 0 1 44.927,35.886 L27.297,17.638 A32.500,32.500 -83.817 0 0 20.475,-25.239 Z M34.151,46.260 A57.500,57.500 47.479 0 1 -11.013,56.435 L-2.998,32.361 A32.500,32.500 -35.981 0 0 16.587,27.949 Z M-25.196,51.686 A57.500,57.500 121.784 0 1 -30.663,-48.642 L-19.998,-25.619 A32.500,32.500 -110.287 0 0 -17.096,27.640 Z " id="12" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="13" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M-17.080,-54.905 A57.500,57.500 35.636 0 1 18.107,-54.574 L7.093,-31.716 A32.500,32.500 -24.138 0 0 -6.497,-31.844 Z M31.571,-48.058 A57.500,57.500 95.315 0 1 44.927,35.886 L27.297,17.638 A32.500,32.500 -83.817 0 0 20.475,-25.239 Z M34.151,46.260 A57.500,57.500 47.479 0 1 -11.013,56.435 L-2.998,32.361 A32.500,32.500 -35.981 0 0 16.587,27.949 Z M-25.196,51.686 A57.500,57.500 121.784 0 1 -30.663,-48.642 L-19.998,-25.619 A32.500,32.500 -110.287 0 0 -17.096,27.640 Z " id="12" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(605.92,-65.16)" id="14">
             <desc>VL14</desc>
-            <circle class="nad-busnode" r="27.50" id="16" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M10.668,-56.502 A57.500,57.500 28.805 0 1 36.572,-44.370 L18.055,-27.023 A32.500,32.500 -17.307 0 0 9.198,-31.171 Z M46.779,-33.436 A57.500,57.500 301.302 1 1 -4.266,-57.342 L-5.645,-32.006 A32.500,32.500 -289.804 1 0 28.200,-16.155 Z " id="15" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="16" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M10.668,-56.502 A57.500,57.500 28.805 0 1 36.572,-44.370 L18.055,-27.023 A32.500,32.500 -17.307 0 0 9.198,-31.171 Z M46.779,-33.436 A57.500,57.500 301.302 1 1 -4.266,-57.342 L-5.645,-32.006 A32.500,32.500 -289.804 1 0 28.200,-16.155 Z " id="15" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(143.15,20.88)" id="17">
             <desc>VL15</desc>
-            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M11.751,-56.286 A57.500,57.500 188.441 1 1 -19.886,53.952 L-8.129,31.467 A32.500,32.500 -176.944 0 0 9.795,-30.989 Z M-33.128,46.997 A57.500,57.500 141.665 0 1 -3.164,-57.413 L-5.030,-32.108 A32.500,32.500 -130.168 0 0 -21.291,24.555 Z " id="18" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="19" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M11.751,-56.286 A57.500,57.500 188.441 1 1 -19.886,53.952 L-8.129,31.467 A32.500,32.500 -176.944 0 0 9.795,-30.989 Z M-33.128,46.997 A57.500,57.500 141.665 0 1 -3.164,-57.413 L-5.030,-32.108 A32.500,32.500 -130.168 0 0 -21.291,24.555 Z " id="18" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(-0.01,374.43)" id="20">
             <desc>VL16</desc>
-            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="21" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(5.89,-216.42)" id="22">
             <desc>VL17</desc>
-            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="23" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(-944.26,1444.53)" id="24">
             <desc>VL19</desc>
-            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl0to30-3"/>
+            <circle r="27.50" id="25" class="nad-vl0to30-3 nad-busnode"/>
         </g>
         <g transform="translate(-736.48,-15.02)" id="26">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="27" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(-588.77,1088.92)" id="28">
             <desc>VL20</desc>
-            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl0to30-3"/>
-            <path class="nad-busnode" d="M23.444,52.504 A57.500,57.500 61.578 0 1 -35.017,45.608 L-17.111,27.631 A32.500,32.500 -50.081 0 0 10.212,30.854 Z M-45.596,35.033 A57.500,57.500 268.528 1 1 36.192,44.681 L22.883,23.078 A32.500,32.500 -257.031 1 0 -27.625,17.120 Z " id="30" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="29" class="nad-vl0to30-3 nad-busnode"/>
+            <path d="M23.444,52.504 A57.500,57.500 61.578 0 1 -35.017,45.608 L-17.111,27.631 A32.500,32.500 -50.081 0 0 10.212,30.854 Z M-45.596,35.033 A57.500,57.500 268.528 1 1 36.192,44.681 L22.883,23.078 A32.500,32.500 -257.031 1 0 -27.625,17.120 Z " id="30" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-395.93,177.02)" id="31">
             <desc>VL22</desc>
-            <circle class="nad-busnode" r="27.50" id="32" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="32" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-910.76,-412.51)" id="33">
             <desc>VL23</desc>
-            <circle class="nad-busnode" r="27.50" id="34" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="34" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-1281.09,-717.24)" id="35">
             <desc>VL24</desc>
-            <circle class="nad-busnode" r="17.50" id="38" class="nad-vl0to30-4"/>
-            <path class="nad-busnode" d="M-14.526,-34.572 A37.500,37.500 219.591 1 1 -10.839,35.899 L-3.582,22.213 A22.500,22.500 -204.312 1 0 -5.881,-21.718 Z M-23.963,28.844 A37.500,37.500 94.572 0 1 -26.842,-26.186 L-18.051,-13.431 A22.500,22.500 -79.293 0 0 -16.551,15.242 Z " id="37" class="nad-vl0to30-5"/>
-            <path class="nad-busnode" d="M-25.904,-51.334 A57.500,57.500 42.544 0 1 15.625,-55.336 L9.654,-41.389 A42.500,42.500 -37.268 0 0 -17.380,-38.784 Z M29.368,-49.434 A57.500,57.500 68.157 0 1 56.812,8.868 L42.249,4.615 A42.500,42.500 -62.882 0 0 23.366,-35.501 Z M52.603,23.221 A57.500,57.500 77.563 0 1 -11.347,56.369 L-6.461,42.006 A42.500,42.500 -72.288 0 0 38.049,18.934 Z M-33.581,46.675 A57.500,57.500 102.544 0 1 -38.268,-42.916 L-29.715,-30.386 A42.500,42.500 -97.268 0 0 -26.382,33.320 Z " id="36" class="nad-vl0to30-1"/>
+            <circle r="17.50" id="38" class="nad-vl0to30-4 nad-busnode"/>
+            <path d="M-14.526,-34.572 A37.500,37.500 219.591 1 1 -10.839,35.899 L-3.582,22.213 A22.500,22.500 -204.312 1 0 -5.881,-21.718 Z M-23.963,28.844 A37.500,37.500 94.572 0 1 -26.842,-26.186 L-18.051,-13.431 A22.500,22.500 -79.293 0 0 -16.551,15.242 Z " id="37" class="nad-vl0to30-5 nad-busnode"/>
+            <path d="M-25.904,-51.334 A57.500,57.500 42.544 0 1 15.625,-55.336 L9.654,-41.389 A42.500,42.500 -37.268 0 0 -17.380,-38.784 Z M29.368,-49.434 A57.500,57.500 68.157 0 1 56.812,8.868 L42.249,4.615 A42.500,42.500 -62.882 0 0 23.366,-35.501 Z M52.603,23.221 A57.500,57.500 77.563 0 1 -11.347,56.369 L-6.461,42.006 A42.500,42.500 -72.288 0 0 38.049,18.934 Z M-33.581,46.675 A57.500,57.500 102.544 0 1 -38.268,-42.916 L-29.715,-30.386 A42.500,42.500 -97.268 0 0 -26.382,33.320 Z " id="36" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-1535.07,-244.76)" id="39">
             <desc>VL27</desc>
-            <circle class="nad-busnode" r="27.50" id="40" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="40" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(-1348.15,290.37)" id="41">
             <desc>VL28</desc>
-            <circle class="nad-busnode" r="27.50" id="42" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="42" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(-693.77,399.71)" id="43">
             <desc>VL3</desc>
-            <circle class="nad-busnode" r="27.50" id="44" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="44" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(-1062.06,-1227.28)" id="45">
             <desc>VL30</desc>
-            <circle class="nad-busnode" r="27.50" id="46" class="nad-vl0to30-5"/>
+            <circle r="27.50" id="46" class="nad-vl0to30-5 nad-busnode"/>
         </g>
         <g transform="translate(-640.82,-1554.26)" id="47">
             <desc>VL31</desc>
-            <circle class="nad-busnode" r="27.50" id="48" class="nad-vl0to30-5"/>
+            <circle r="27.50" id="48" class="nad-vl0to30-5 nad-busnode"/>
         </g>
         <g transform="translate(-103.26,-1734.24)" id="49">
             <desc>VL32</desc>
-            <circle class="nad-busnode" r="27.50" id="51" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M53.279,21.624 A57.500,57.500 28.489 0 1 36.513,44.419 L23.049,22.913 A32.500,32.500 -16.991 0 0 28.738,15.177 Z M23.821,52.334 A57.500,57.500 301.618 1 1 57.054,7.151 L32.490,0.791 A32.500,32.500 -290.120 1 0 10.433,30.780 Z " id="50" class="nad-vl0to30-5"/>
+            <circle r="27.50" id="51" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M53.279,21.624 A57.500,57.500 28.489 0 1 36.513,44.419 L23.049,22.913 A32.500,32.500 -16.991 0 0 28.738,15.177 Z M23.821,52.334 A57.500,57.500 301.618 1 1 57.054,7.151 L32.490,0.791 A32.500,32.500 -290.120 1 0 10.433,30.780 Z " id="50" class="nad-vl0to30-5 nad-busnode"/>
         </g>
         <g transform="translate(-160.71,-2128.26)" id="52">
             <desc>VL33</desc>
-            <circle class="nad-busnode" r="27.50" id="53" class="nad-vl0to30-5"/>
+            <circle r="27.50" id="53" class="nad-vl0to30-5 nad-busnode"/>
         </g>
         <g transform="translate(472.67,-1584.04)" id="54">
             <desc>VL35</desc>
-            <circle class="nad-busnode" r="27.50" id="55" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="55" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(990.15,-1220.07)" id="56">
             <desc>VL36</desc>
-            <circle class="nad-busnode" r="27.50" id="57" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="57" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(923.97,-881.50)" id="58">
             <desc>VL37</desc>
-            <circle class="nad-busnode" r="27.50" id="59" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="59" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(472.29,-345.80)" id="60">
             <desc>VL38</desc>
-            <circle class="nad-busnode" r="27.50" id="61" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="61" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(1418.63,-953.01)" id="62">
             <desc>VL39</desc>
-            <circle class="nad-busnode" r="27.50" id="63" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M16.580,-55.058 A57.500,57.500 237.541 1 1 -55.355,15.560 L-30.249,11.884 A32.500,32.500 -226.043 1 0 12.441,-30.024 Z M-57.495,0.756 A57.500,57.500 92.566 0 1 1.818,-57.471 L-2.231,-32.423 A32.500,32.500 -81.068 0 0 -32.377,-2.830 Z " id="64" class="nad-vl0to30-2"/>
+            <circle r="27.50" id="63" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M16.580,-55.058 A57.500,57.500 237.541 1 1 -55.355,15.560 L-30.249,11.884 A32.500,32.500 -226.043 1 0 12.441,-30.024 Z M-57.495,0.756 A57.500,57.500 92.566 0 1 1.818,-57.471 L-2.231,-32.423 A32.500,32.500 -81.068 0 0 -32.377,-2.830 Z " id="64" class="nad-vl0to30-2 nad-busnode"/>
         </g>
         <g transform="translate(-1160.19,1084.54)" id="65">
             <desc>VL4</desc>
-            <circle class="nad-busnode" r="27.50" id="67" class="nad-vl0to30-3"/>
-            <path class="nad-busnode" d="M44.607,36.283 A57.500,57.500 12.446 0 1 35.739,45.044 L22.649,23.308 A32.500,32.500 -0.949 0 0 23.032,22.930 Z M22.912,52.738 A57.500,57.500 79.883 0 1 -47.893,31.820 L-25.132,20.606 A32.500,32.500 -68.385 0 0 9.899,30.956 Z M-54.480,18.391 A57.500,57.500 222.831 1 1 52.456,23.550 L30.833,10.274 A32.500,32.500 -211.333 1 0 -31.679,7.258 Z " id="66" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="67" class="nad-vl0to30-3 nad-busnode"/>
+            <path d="M44.607,36.283 A57.500,57.500 12.446 0 1 35.739,45.044 L22.649,23.308 A32.500,32.500 -0.949 0 0 23.032,22.930 Z M22.912,52.738 A57.500,57.500 79.883 0 1 -47.893,31.820 L-25.132,20.606 A32.500,32.500 -68.385 0 0 9.899,30.956 Z M-54.480,18.391 A57.500,57.500 222.831 1 1 52.456,23.550 L30.833,10.274 A32.500,32.500 -211.333 1 0 -31.679,7.258 Z " id="66" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(1440.50,-562.18)" id="68">
             <desc>VL40</desc>
-            <circle class="nad-busnode" r="27.50" id="69" class="nad-vl0to30-1"/>
-            <path class="nad-busnode" d="M-26.033,-51.269 A57.500,57.500 64.196 0 1 34.825,-45.754 L16.995,-27.703 A32.500,32.500 -52.698 0 0 -11.737,-30.306 Z M45.448,-35.224 A57.500,57.500 265.911 1 1 -38.375,-42.820 L-24.006,-21.908 A32.500,32.500 -254.413 1 0 27.553,-17.236 Z " id="70" class="nad-vl0to30-2"/>
+            <circle r="27.50" id="69" class="nad-vl0to30-1 nad-busnode"/>
+            <path d="M-26.033,-51.269 A57.500,57.500 64.196 0 1 34.825,-45.754 L16.995,-27.703 A32.500,32.500 -52.698 0 0 -11.737,-30.306 Z M45.448,-35.224 A57.500,57.500 265.911 1 1 -38.375,-42.820 L-24.006,-21.908 A32.500,32.500 -254.413 1 0 27.553,-17.236 Z " id="70" class="nad-vl0to30-2 nad-busnode"/>
         </g>
         <g transform="translate(1654.22,-148.09)" id="71">
             <desc>VL42</desc>
-            <circle class="nad-busnode" r="27.50" id="72" class="nad-vl0to30-2"/>
+            <circle r="27.50" id="72" class="nad-vl0to30-2 nad-busnode"/>
         </g>
         <g transform="translate(188.38,-578.05)" id="73">
             <desc>VL44</desc>
-            <circle class="nad-busnode" r="27.50" id="74" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="74" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(973.47,-408.27)" id="75">
             <desc>VL47</desc>
-            <circle class="nad-busnode" r="27.50" id="76" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="76" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(916.67,-128.87)" id="77">
             <desc>VL48</desc>
-            <circle class="nad-busnode" r="27.50" id="78" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="78" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-1505.20,1031.73)" id="79">
             <desc>VL5</desc>
-            <circle class="nad-busnode" r="27.50" id="80" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="80" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(1152.75,663.93)" id="81">
             <desc>VL50</desc>
-            <circle class="nad-busnode" r="27.50" id="82" class="nad-vl0to30-1"/>
+            <circle r="27.50" id="82" class="nad-vl0to30-1 nad-busnode"/>
         </g>
         <g transform="translate(-302.76,1464.80)" id="83">
             <desc>VL52</desc>
-            <circle class="nad-busnode" r="27.50" id="84" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="84" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(140.43,1652.22)" id="85">
             <desc>VL53</desc>
-            <circle class="nad-busnode" r="27.50" id="86" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="86" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(476.73,1343.65)" id="87">
             <desc>VL54</desc>
-            <circle class="nad-busnode" r="27.50" id="88" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="88" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(-1040.78,847.06)" id="89">
             <desc>VL6</desc>
-            <circle class="nad-busnode" r="27.50" id="90" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="90" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(-743.08,832.53)" id="91">
             <desc>VL7</desc>
-            <circle class="nad-busnode" r="27.50" id="92" class="nad-vl0to30-0"/>
-            <path class="nad-busnode" d="M0.105,-57.500 A57.500,57.500 85.824 0 1 57.355,-4.082 L32.024,-5.543 A32.500,32.500 -74.327 0 0 3.315,-32.331 Z M56.467,10.849 A57.500,57.500 158.855 0 1 -56.579,10.251 L-31.238,8.968 A32.500,32.500 -147.358 0 0 31.142,9.298 Z M-57.308,-4.689 A57.500,57.500 70.481 0 1 -14.729,-55.582 L-11.430,-30.424 A32.500,32.500 -58.983 0 0 -31.963,-5.882 Z " id="93" class="nad-vl0to30-4"/>
+            <circle r="27.50" id="92" class="nad-vl0to30-0 nad-busnode"/>
+            <path d="M0.105,-57.500 A57.500,57.500 85.824 0 1 57.355,-4.082 L32.024,-5.543 A32.500,32.500 -74.327 0 0 3.315,-32.331 Z M56.467,10.849 A57.500,57.500 158.855 0 1 -56.579,10.251 L-31.238,8.968 A32.500,32.500 -147.358 0 0 31.142,9.298 Z M-57.308,-4.689 A57.500,57.500 70.481 0 1 -14.729,-55.582 L-11.430,-30.424 A32.500,32.500 -58.983 0 0 -31.963,-5.882 Z " id="93" class="nad-vl0to30-4 nad-busnode"/>
         </g>
         <g transform="translate(-287.14,859.63)" id="94">
             <desc>VL8</desc>
-            <circle class="nad-busnode" r="27.50" id="95" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="95" class="nad-vl0to30-0 nad-busnode"/>
         </g>
         <g transform="translate(550.55,731.35)" id="96">
             <desc>VL9</desc>
-            <circle class="nad-busnode" r="27.50" id="98" class="nad-vl0to30-4"/>
-            <path class="nad-busnode" d="M-14.249,55.706 A57.500,57.500 336.144 1 1 9.498,56.710 L8.552,31.355 A32.500,32.500 -324.646 1 0 -11.167,30.521 Z " id="97" class="nad-vl0to30-0"/>
+            <circle r="27.50" id="98" class="nad-vl0to30-4 nad-busnode"/>
+            <path d="M-14.249,55.706 A57.500,57.500 336.144 1 1 9.498,56.710 L8.552,31.355 A32.500,32.500 -324.646 1 0 -11.167,30.521 Z " id="97" class="nad-vl0to30-0 nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/IEEE_57_bus.svg
+++ b/src/test/resources/IEEE_57_bus.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="909.76" viewBox="-1735.07 -2343.26 3689.28 4195.48" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightgrey)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightgrey)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: var(--nad-vl-color, #808080); stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -92,7 +90,7 @@
 .nad-vl300to500-7 {--nad-vl-color: #ef9a9a}
 .nad-vl300to500-8 {--nad-vl-color: #f44336}
 .nad-vl300to500-9 {--nad-vl-color: #c62828}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -305,193 +303,193 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-269.69,-93.47)" id="0">
             <desc>VL1</desc>
-            <circle r="27.50" id="1" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="1" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(846.23,833.49)" id="2">
             <desc>VL10</desc>
-            <circle r="27.50" id="4" class="nad-vl0to30-1"/>
-            <path d="M53.508,-21.052 A57.500,57.500 129.056 0 1 -17.367,54.815 L-6.663,31.810 A32.500,32.500 -117.559 0 0 31.283,-8.810 Z M-30.917,48.481 A57.500,57.500 201.050 1 1 46.268,-34.140 L24.087,-21.819 A32.500,32.500 -189.553 1 0 -20.132,25.514 Z " id="3" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="4" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M53.508,-21.052 A57.500,57.500 129.056 0 1 -17.367,54.815 L-6.663,31.810 A32.500,32.500 -117.559 0 0 31.283,-8.810 Z M-30.917,48.481 A57.500,57.500 201.050 1 1 46.268,-34.140 L24.087,-21.819 A32.500,32.500 -189.553 1 0 -20.132,25.514 Z " id="3" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1241.95,134.97)" id="5">
             <desc>VL11</desc>
-            <circle r="17.50" id="8" class="nad-vl0to30-2"/>
-            <path d="M-0.823,-37.491 A37.500,37.500 123.223 0 1 31.814,19.853 L20.502,9.268 A22.500,22.500 -107.944 0 0 2.501,-22.361 Z M21.571,30.675 A37.500,37.500 190.940 1 1 -15.358,-34.211 L-11.862,-19.119 A22.500,22.500 -175.661 0 0 10.381,19.962 Z " id="6" class="nad-vl0to30-0"/>
-            <path d="M-52.215,-24.079 A57.500,57.500 45.053 0 1 -19.845,-53.967 L-16.488,-39.171 A42.500,42.500 -39.778 0 0 -37.734,-19.555 Z M-5.255,-57.259 A57.500,57.500 131.195 0 1 46.547,33.758 L35.516,23.342 A42.500,42.500 -125.919 0 0 -1.932,-42.456 Z M20.797,53.607 A57.500,57.500 62.951 0 1 -38.286,42.901 L-26.809,32.978 A42.500,42.500 -57.675 0 0 13.532,40.288 Z M-48.055,31.575 A57.500,57.500 14.503 0 1 -54.431,18.534 L-39.559,15.536 A42.500,42.500 -9.228 0 0 -36.555,21.678 Z M-57.370,3.868 A57.500,57.500 13.667 0 1 -56.659,-9.797 L-42.167,-5.306 A42.500,42.500 -8.392 0 0 -42.490,0.905 Z " id="7" class="nad-vl0to30-2"/>
+            <circle class="nad-busnode" r="17.50" id="8" class="nad-vl0to30-2"/>
+            <path class="nad-busnode" d="M-0.823,-37.491 A37.500,37.500 123.223 0 1 31.814,19.853 L20.502,9.268 A22.500,22.500 -107.944 0 0 2.501,-22.361 Z M21.571,30.675 A37.500,37.500 190.940 1 1 -15.358,-34.211 L-11.862,-19.119 A22.500,22.500 -175.661 0 0 10.381,19.962 Z " id="6" class="nad-vl0to30-0"/>
+            <path class="nad-busnode" d="M-52.215,-24.079 A57.500,57.500 45.053 0 1 -19.845,-53.967 L-16.488,-39.171 A42.500,42.500 -39.778 0 0 -37.734,-19.555 Z M-5.255,-57.259 A57.500,57.500 131.195 0 1 46.547,33.758 L35.516,23.342 A42.500,42.500 -125.919 0 0 -1.932,-42.456 Z M20.797,53.607 A57.500,57.500 62.951 0 1 -38.286,42.901 L-26.809,32.978 A42.500,42.500 -57.675 0 0 13.532,40.288 Z M-48.055,31.575 A57.500,57.500 14.503 0 1 -54.431,18.534 L-39.559,15.536 A42.500,42.500 -9.228 0 0 -36.555,21.678 Z M-57.370,3.868 A57.500,57.500 13.667 0 1 -56.659,-9.797 L-42.167,-5.306 A42.500,42.500 -8.392 0 0 -42.490,0.905 Z " id="7" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(408.55,427.89)" id="9">
             <desc>VL12</desc>
-            <circle r="27.50" id="10" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="10" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(740.31,235.48)" id="11">
             <desc>VL13</desc>
-            <circle r="27.50" id="13" class="nad-vl0to30-1"/>
-            <path d="M-17.080,-54.905 A57.500,57.500 35.636 0 1 18.107,-54.574 L7.093,-31.716 A32.500,32.500 -24.138 0 0 -6.497,-31.844 Z M31.571,-48.058 A57.500,57.500 95.315 0 1 44.927,35.886 L27.297,17.638 A32.500,32.500 -83.817 0 0 20.475,-25.239 Z M34.151,46.260 A57.500,57.500 47.479 0 1 -11.013,56.435 L-2.998,32.361 A32.500,32.500 -35.981 0 0 16.587,27.949 Z M-25.196,51.686 A57.500,57.500 121.784 0 1 -30.663,-48.642 L-19.998,-25.619 A32.500,32.500 -110.287 0 0 -17.096,27.640 Z " id="12" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="13" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M-17.080,-54.905 A57.500,57.500 35.636 0 1 18.107,-54.574 L7.093,-31.716 A32.500,32.500 -24.138 0 0 -6.497,-31.844 Z M31.571,-48.058 A57.500,57.500 95.315 0 1 44.927,35.886 L27.297,17.638 A32.500,32.500 -83.817 0 0 20.475,-25.239 Z M34.151,46.260 A57.500,57.500 47.479 0 1 -11.013,56.435 L-2.998,32.361 A32.500,32.500 -35.981 0 0 16.587,27.949 Z M-25.196,51.686 A57.500,57.500 121.784 0 1 -30.663,-48.642 L-19.998,-25.619 A32.500,32.500 -110.287 0 0 -17.096,27.640 Z " id="12" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(605.92,-65.16)" id="14">
             <desc>VL14</desc>
-            <circle r="27.50" id="16" class="nad-vl0to30-1"/>
-            <path d="M10.668,-56.502 A57.500,57.500 28.805 0 1 36.572,-44.370 L18.055,-27.023 A32.500,32.500 -17.307 0 0 9.198,-31.171 Z M46.779,-33.436 A57.500,57.500 301.302 1 1 -4.266,-57.342 L-5.645,-32.006 A32.500,32.500 -289.804 1 0 28.200,-16.155 Z " id="15" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="16" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M10.668,-56.502 A57.500,57.500 28.805 0 1 36.572,-44.370 L18.055,-27.023 A32.500,32.500 -17.307 0 0 9.198,-31.171 Z M46.779,-33.436 A57.500,57.500 301.302 1 1 -4.266,-57.342 L-5.645,-32.006 A32.500,32.500 -289.804 1 0 28.200,-16.155 Z " id="15" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(143.15,20.88)" id="17">
             <desc>VL15</desc>
-            <circle r="27.50" id="19" class="nad-vl0to30-1"/>
-            <path d="M11.751,-56.286 A57.500,57.500 188.441 1 1 -19.886,53.952 L-8.129,31.467 A32.500,32.500 -176.944 0 0 9.795,-30.989 Z M-33.128,46.997 A57.500,57.500 141.665 0 1 -3.164,-57.413 L-5.030,-32.108 A32.500,32.500 -130.168 0 0 -21.291,24.555 Z " id="18" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="19" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M11.751,-56.286 A57.500,57.500 188.441 1 1 -19.886,53.952 L-8.129,31.467 A32.500,32.500 -176.944 0 0 9.795,-30.989 Z M-33.128,46.997 A57.500,57.500 141.665 0 1 -3.164,-57.413 L-5.030,-32.108 A32.500,32.500 -130.168 0 0 -21.291,24.555 Z " id="18" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-0.01,374.43)" id="20">
             <desc>VL16</desc>
-            <circle r="27.50" id="21" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="21" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(5.89,-216.42)" id="22">
             <desc>VL17</desc>
-            <circle r="27.50" id="23" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="23" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-944.26,1444.53)" id="24">
             <desc>VL19</desc>
-            <circle r="27.50" id="25" class="nad-vl0to30-3"/>
+            <circle class="nad-busnode" r="27.50" id="25" class="nad-vl0to30-3"/>
         </g>
         <g transform="translate(-736.48,-15.02)" id="26">
             <desc>VL2</desc>
-            <circle r="27.50" id="27" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="27" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-588.77,1088.92)" id="28">
             <desc>VL20</desc>
-            <circle r="27.50" id="29" class="nad-vl0to30-3"/>
-            <path d="M23.444,52.504 A57.500,57.500 61.578 0 1 -35.017,45.608 L-17.111,27.631 A32.500,32.500 -50.081 0 0 10.212,30.854 Z M-45.596,35.033 A57.500,57.500 268.528 1 1 36.192,44.681 L22.883,23.078 A32.500,32.500 -257.031 1 0 -27.625,17.120 Z " id="30" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="29" class="nad-vl0to30-3"/>
+            <path class="nad-busnode" d="M23.444,52.504 A57.500,57.500 61.578 0 1 -35.017,45.608 L-17.111,27.631 A32.500,32.500 -50.081 0 0 10.212,30.854 Z M-45.596,35.033 A57.500,57.500 268.528 1 1 36.192,44.681 L22.883,23.078 A32.500,32.500 -257.031 1 0 -27.625,17.120 Z " id="30" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-395.93,177.02)" id="31">
             <desc>VL22</desc>
-            <circle r="27.50" id="32" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="32" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-910.76,-412.51)" id="33">
             <desc>VL23</desc>
-            <circle r="27.50" id="34" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="34" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-1281.09,-717.24)" id="35">
             <desc>VL24</desc>
-            <circle r="17.50" id="38" class="nad-vl0to30-4"/>
-            <path d="M-14.526,-34.572 A37.500,37.500 219.591 1 1 -10.839,35.899 L-3.582,22.213 A22.500,22.500 -204.312 1 0 -5.881,-21.718 Z M-23.963,28.844 A37.500,37.500 94.572 0 1 -26.842,-26.186 L-18.051,-13.431 A22.500,22.500 -79.293 0 0 -16.551,15.242 Z " id="37" class="nad-vl0to30-5"/>
-            <path d="M-25.904,-51.334 A57.500,57.500 42.544 0 1 15.625,-55.336 L9.654,-41.389 A42.500,42.500 -37.268 0 0 -17.380,-38.784 Z M29.368,-49.434 A57.500,57.500 68.157 0 1 56.812,8.868 L42.249,4.615 A42.500,42.500 -62.882 0 0 23.366,-35.501 Z M52.603,23.221 A57.500,57.500 77.563 0 1 -11.347,56.369 L-6.461,42.006 A42.500,42.500 -72.288 0 0 38.049,18.934 Z M-33.581,46.675 A57.500,57.500 102.544 0 1 -38.268,-42.916 L-29.715,-30.386 A42.500,42.500 -97.268 0 0 -26.382,33.320 Z " id="36" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="17.50" id="38" class="nad-vl0to30-4"/>
+            <path class="nad-busnode" d="M-14.526,-34.572 A37.500,37.500 219.591 1 1 -10.839,35.899 L-3.582,22.213 A22.500,22.500 -204.312 1 0 -5.881,-21.718 Z M-23.963,28.844 A37.500,37.500 94.572 0 1 -26.842,-26.186 L-18.051,-13.431 A22.500,22.500 -79.293 0 0 -16.551,15.242 Z " id="37" class="nad-vl0to30-5"/>
+            <path class="nad-busnode" d="M-25.904,-51.334 A57.500,57.500 42.544 0 1 15.625,-55.336 L9.654,-41.389 A42.500,42.500 -37.268 0 0 -17.380,-38.784 Z M29.368,-49.434 A57.500,57.500 68.157 0 1 56.812,8.868 L42.249,4.615 A42.500,42.500 -62.882 0 0 23.366,-35.501 Z M52.603,23.221 A57.500,57.500 77.563 0 1 -11.347,56.369 L-6.461,42.006 A42.500,42.500 -72.288 0 0 38.049,18.934 Z M-33.581,46.675 A57.500,57.500 102.544 0 1 -38.268,-42.916 L-29.715,-30.386 A42.500,42.500 -97.268 0 0 -26.382,33.320 Z " id="36" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-1535.07,-244.76)" id="39">
             <desc>VL27</desc>
-            <circle r="27.50" id="40" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="40" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(-1348.15,290.37)" id="41">
             <desc>VL28</desc>
-            <circle r="27.50" id="42" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="42" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(-693.77,399.71)" id="43">
             <desc>VL3</desc>
-            <circle r="27.50" id="44" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="44" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-1062.06,-1227.28)" id="45">
             <desc>VL30</desc>
-            <circle r="27.50" id="46" class="nad-vl0to30-5"/>
+            <circle class="nad-busnode" r="27.50" id="46" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-640.82,-1554.26)" id="47">
             <desc>VL31</desc>
-            <circle r="27.50" id="48" class="nad-vl0to30-5"/>
+            <circle class="nad-busnode" r="27.50" id="48" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-103.26,-1734.24)" id="49">
             <desc>VL32</desc>
-            <circle r="27.50" id="51" class="nad-vl0to30-1"/>
-            <path d="M53.279,21.624 A57.500,57.500 28.489 0 1 36.513,44.419 L23.049,22.913 A32.500,32.500 -16.991 0 0 28.738,15.177 Z M23.821,52.334 A57.500,57.500 301.618 1 1 57.054,7.151 L32.490,0.791 A32.500,32.500 -290.120 1 0 10.433,30.780 Z " id="50" class="nad-vl0to30-5"/>
+            <circle class="nad-busnode" r="27.50" id="51" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M53.279,21.624 A57.500,57.500 28.489 0 1 36.513,44.419 L23.049,22.913 A32.500,32.500 -16.991 0 0 28.738,15.177 Z M23.821,52.334 A57.500,57.500 301.618 1 1 57.054,7.151 L32.490,0.791 A32.500,32.500 -290.120 1 0 10.433,30.780 Z " id="50" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(-160.71,-2128.26)" id="52">
             <desc>VL33</desc>
-            <circle r="27.50" id="53" class="nad-vl0to30-5"/>
+            <circle class="nad-busnode" r="27.50" id="53" class="nad-vl0to30-5"/>
         </g>
         <g transform="translate(472.67,-1584.04)" id="54">
             <desc>VL35</desc>
-            <circle r="27.50" id="55" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="55" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(990.15,-1220.07)" id="56">
             <desc>VL36</desc>
-            <circle r="27.50" id="57" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="57" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(923.97,-881.50)" id="58">
             <desc>VL37</desc>
-            <circle r="27.50" id="59" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="59" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(472.29,-345.80)" id="60">
             <desc>VL38</desc>
-            <circle r="27.50" id="61" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="61" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(1418.63,-953.01)" id="62">
             <desc>VL39</desc>
-            <circle r="27.50" id="63" class="nad-vl0to30-1"/>
-            <path d="M16.580,-55.058 A57.500,57.500 237.541 1 1 -55.355,15.560 L-30.249,11.884 A32.500,32.500 -226.043 1 0 12.441,-30.024 Z M-57.495,0.756 A57.500,57.500 92.566 0 1 1.818,-57.471 L-2.231,-32.423 A32.500,32.500 -81.068 0 0 -32.377,-2.830 Z " id="64" class="nad-vl0to30-2"/>
+            <circle class="nad-busnode" r="27.50" id="63" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M16.580,-55.058 A57.500,57.500 237.541 1 1 -55.355,15.560 L-30.249,11.884 A32.500,32.500 -226.043 1 0 12.441,-30.024 Z M-57.495,0.756 A57.500,57.500 92.566 0 1 1.818,-57.471 L-2.231,-32.423 A32.500,32.500 -81.068 0 0 -32.377,-2.830 Z " id="64" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(-1160.19,1084.54)" id="65">
             <desc>VL4</desc>
-            <circle r="27.50" id="67" class="nad-vl0to30-3"/>
-            <path d="M44.607,36.283 A57.500,57.500 12.446 0 1 35.739,45.044 L22.649,23.308 A32.500,32.500 -0.949 0 0 23.032,22.930 Z M22.912,52.738 A57.500,57.500 79.883 0 1 -47.893,31.820 L-25.132,20.606 A32.500,32.500 -68.385 0 0 9.899,30.956 Z M-54.480,18.391 A57.500,57.500 222.831 1 1 52.456,23.550 L30.833,10.274 A32.500,32.500 -211.333 1 0 -31.679,7.258 Z " id="66" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="67" class="nad-vl0to30-3"/>
+            <path class="nad-busnode" d="M44.607,36.283 A57.500,57.500 12.446 0 1 35.739,45.044 L22.649,23.308 A32.500,32.500 -0.949 0 0 23.032,22.930 Z M22.912,52.738 A57.500,57.500 79.883 0 1 -47.893,31.820 L-25.132,20.606 A32.500,32.500 -68.385 0 0 9.899,30.956 Z M-54.480,18.391 A57.500,57.500 222.831 1 1 52.456,23.550 L30.833,10.274 A32.500,32.500 -211.333 1 0 -31.679,7.258 Z " id="66" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1440.50,-562.18)" id="68">
             <desc>VL40</desc>
-            <circle r="27.50" id="69" class="nad-vl0to30-1"/>
-            <path d="M-26.033,-51.269 A57.500,57.500 64.196 0 1 34.825,-45.754 L16.995,-27.703 A32.500,32.500 -52.698 0 0 -11.737,-30.306 Z M45.448,-35.224 A57.500,57.500 265.911 1 1 -38.375,-42.820 L-24.006,-21.908 A32.500,32.500 -254.413 1 0 27.553,-17.236 Z " id="70" class="nad-vl0to30-2"/>
+            <circle class="nad-busnode" r="27.50" id="69" class="nad-vl0to30-1"/>
+            <path class="nad-busnode" d="M-26.033,-51.269 A57.500,57.500 64.196 0 1 34.825,-45.754 L16.995,-27.703 A32.500,32.500 -52.698 0 0 -11.737,-30.306 Z M45.448,-35.224 A57.500,57.500 265.911 1 1 -38.375,-42.820 L-24.006,-21.908 A32.500,32.500 -254.413 1 0 27.553,-17.236 Z " id="70" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(1654.22,-148.09)" id="71">
             <desc>VL42</desc>
-            <circle r="27.50" id="72" class="nad-vl0to30-2"/>
+            <circle class="nad-busnode" r="27.50" id="72" class="nad-vl0to30-2"/>
         </g>
         <g transform="translate(188.38,-578.05)" id="73">
             <desc>VL44</desc>
-            <circle r="27.50" id="74" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="74" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(973.47,-408.27)" id="75">
             <desc>VL47</desc>
-            <circle r="27.50" id="76" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="76" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(916.67,-128.87)" id="77">
             <desc>VL48</desc>
-            <circle r="27.50" id="78" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="78" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-1505.20,1031.73)" id="79">
             <desc>VL5</desc>
-            <circle r="27.50" id="80" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="80" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(1152.75,663.93)" id="81">
             <desc>VL50</desc>
-            <circle r="27.50" id="82" class="nad-vl0to30-1"/>
+            <circle class="nad-busnode" r="27.50" id="82" class="nad-vl0to30-1"/>
         </g>
         <g transform="translate(-302.76,1464.80)" id="83">
             <desc>VL52</desc>
-            <circle r="27.50" id="84" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="84" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(140.43,1652.22)" id="85">
             <desc>VL53</desc>
-            <circle r="27.50" id="86" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="86" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(476.73,1343.65)" id="87">
             <desc>VL54</desc>
-            <circle r="27.50" id="88" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="88" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(-1040.78,847.06)" id="89">
             <desc>VL6</desc>
-            <circle r="27.50" id="90" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="90" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(-743.08,832.53)" id="91">
             <desc>VL7</desc>
-            <circle r="27.50" id="92" class="nad-vl0to30-0"/>
-            <path d="M0.105,-57.500 A57.500,57.500 85.824 0 1 57.355,-4.082 L32.024,-5.543 A32.500,32.500 -74.327 0 0 3.315,-32.331 Z M56.467,10.849 A57.500,57.500 158.855 0 1 -56.579,10.251 L-31.238,8.968 A32.500,32.500 -147.358 0 0 31.142,9.298 Z M-57.308,-4.689 A57.500,57.500 70.481 0 1 -14.729,-55.582 L-11.430,-30.424 A32.500,32.500 -58.983 0 0 -31.963,-5.882 Z " id="93" class="nad-vl0to30-4"/>
+            <circle class="nad-busnode" r="27.50" id="92" class="nad-vl0to30-0"/>
+            <path class="nad-busnode" d="M0.105,-57.500 A57.500,57.500 85.824 0 1 57.355,-4.082 L32.024,-5.543 A32.500,32.500 -74.327 0 0 3.315,-32.331 Z M56.467,10.849 A57.500,57.500 158.855 0 1 -56.579,10.251 L-31.238,8.968 A32.500,32.500 -147.358 0 0 31.142,9.298 Z M-57.308,-4.689 A57.500,57.500 70.481 0 1 -14.729,-55.582 L-11.430,-30.424 A32.500,32.500 -58.983 0 0 -31.963,-5.882 Z " id="93" class="nad-vl0to30-4"/>
         </g>
         <g transform="translate(-287.14,859.63)" id="94">
             <desc>VL8</desc>
-            <circle r="27.50" id="95" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="95" class="nad-vl0to30-0"/>
         </g>
         <g transform="translate(550.55,731.35)" id="96">
             <desc>VL9</desc>
-            <circle r="27.50" id="98" class="nad-vl0to30-4"/>
-            <path d="M-14.249,55.706 A57.500,57.500 336.144 1 1 9.498,56.710 L8.552,31.355 A32.500,32.500 -324.646 1 0 -11.167,30.521 Z " id="97" class="nad-vl0to30-0"/>
+            <circle class="nad-busnode" r="27.50" id="98" class="nad-vl0to30-4"/>
+            <path class="nad-busnode" d="M-14.249,55.706 A57.500,57.500 336.144 1 1 9.498,56.710 L8.552,31.355 A32.500,32.500 -324.646 1 0 -11.167,30.521 Z " id="97" class="nad-vl0to30-0"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="99">
             <desc>L1-2-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-294.84,-89.25 -503.09,-54.25"/>
+                <polyline class="nad-edge-path" points="-294.84,-89.25 -503.09,-54.25"/>
                 <g class="nad-edge-infos" transform="translate(-326.89,-83.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.54)">
@@ -510,7 +508,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-711.34,-19.25 -503.09,-54.25"/>
+                <polyline class="nad-edge-path" points="-711.34,-19.25 -503.09,-54.25"/>
                 <g class="nad-edge-infos" transform="translate(-679.28,-24.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.46)">
@@ -532,7 +530,7 @@
         <g id="100">
             <desc>L1-15-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-245.12,-86.67 -77.73,-40.30"/>
+                <polyline class="nad-edge-path" points="-245.12,-86.67 -77.73,-40.30"/>
                 <g class="nad-edge-infos" transform="translate(-213.80,-77.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.48)">
@@ -551,7 +549,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="89.66,6.06 -77.73,-40.30"/>
+                <polyline class="nad-edge-path" points="89.66,6.06 -77.73,-40.30"/>
                 <g class="nad-edge-infos" transform="translate(58.34,-2.61)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.52)">
@@ -573,7 +571,7 @@
         <g id="101">
             <desc>L1-16-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-256.96,-71.38 -134.85,140.48"/>
+                <polyline class="nad-edge-path" points="-256.96,-71.38 -134.85,140.48"/>
                 <g class="nad-edge-infos" transform="translate(-240.73,-43.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.04)">
@@ -592,7 +590,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-12.74,352.34 -134.85,140.48"/>
+                <polyline class="nad-edge-path" points="-12.74,352.34 -134.85,140.48"/>
                 <g class="nad-edge-infos" transform="translate(-28.97,324.18)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-29.96)">
@@ -614,7 +612,7 @@
         <g id="102">
             <desc>L1-17-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-246.40,-103.86 -131.90,-154.95"/>
+                <polyline class="nad-edge-path" points="-246.40,-103.86 -131.90,-154.95"/>
                 <g class="nad-edge-infos" transform="translate(-216.72,-117.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.96)">
@@ -633,7 +631,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-17.40,-206.03 -131.90,-154.95"/>
+                <polyline class="nad-edge-path" points="-17.40,-206.03 -131.90,-154.95"/>
                 <g class="nad-edge-infos" transform="translate(-47.08,-192.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.04)">
@@ -655,7 +653,7 @@
         <g id="103">
             <desc>L9-10-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="603.01,749.47 698.39,782.42"/>
+                <polyline class="nad-edge-path" points="603.01,749.47 698.39,782.42"/>
                 <g class="nad-edge-infos" transform="translate(633.73,760.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.06)">
@@ -674,7 +672,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="793.77,815.36 698.39,782.42"/>
+                <polyline class="nad-edge-path" points="793.77,815.36 698.39,782.42"/>
                 <g class="nad-edge-infos" transform="translate(763.05,804.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.94)">
@@ -696,7 +694,7 @@
         <g id="104">
             <desc>L10-12-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="805.52,795.76 616.39,620.49"/>
+                <polyline class="nad-edge-path" points="805.52,795.76 616.39,620.49"/>
                 <g class="nad-edge-infos" transform="translate(781.68,773.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-47.18)">
@@ -715,7 +713,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="427.26,445.23 616.39,620.49"/>
+                <polyline class="nad-edge-path" points="427.26,445.23 616.39,620.49"/>
                 <g class="nad-edge-infos" transform="translate(451.09,467.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.82)">
@@ -737,7 +735,7 @@
         <g id="105">
             <desc>L50-51-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="1130.44,676.27 999.49,748.71"/>
+                <polyline class="nad-edge-path" points="1130.44,676.27 999.49,748.71"/>
                 <g class="nad-edge-infos" transform="translate(1102.00,692.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-118.95)">
@@ -756,7 +754,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="868.54,821.14 999.49,748.71"/>
+                <polyline class="nad-edge-path" points="868.54,821.14 999.49,748.71"/>
                 <g class="nad-edge-infos" transform="translate(923.23,790.89)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.05)">
@@ -778,7 +776,7 @@
         <g id="106">
             <desc>T10-51-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M878.02,878.98 L892.05,899.06 C914.97,931.85 896.43,949.59 886.47,950.45"/>
+                <path class="nad-edge-path" d="M878.02,878.98 L892.05,899.06 C914.97,931.85 896.43,949.59 886.47,950.45"/>
                 <g class="nad-edge-infos" transform="translate(892.05,899.06)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.05)">
@@ -795,10 +793,10 @@
                         <text transform="rotate(55.05)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="866.54" cy="952.18" r="20.00"/>
+                <circle class="nad-winding" cx="866.54" cy="952.18" r="20.00"/>
             </g>
             <g class="nad-vl0to30-1">
-                <path d="M835.43,856.59 L812.35,905.96 C795.41,942.20 816.73,956.49 826.69,955.63"/>
+                <path class="nad-edge-path" d="M835.43,856.59 L812.35,905.96 C795.41,942.20 816.73,956.49 826.69,955.63"/>
                 <g class="nad-edge-infos" transform="translate(812.35,905.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.95)">
@@ -815,13 +813,13 @@
                         <text transform="rotate(-64.95)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="846.61" cy="953.90" r="20.00"/>
+                <circle class="nad-winding" cx="846.61" cy="953.90" r="20.00"/>
             </g>
         </g>
         <g id="107">
             <desc>L9-11-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="592.58,695.10 903.82,426.63"/>
+                <polyline class="nad-edge-path" points="592.58,695.10 903.82,426.63"/>
                 <g class="nad-edge-infos" transform="translate(617.19,673.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(49.22)">
@@ -840,7 +838,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="1215.07,158.15 903.82,426.63"/>
+                <polyline class="nad-edge-path" points="1215.07,158.15 903.82,426.63"/>
                 <g class="nad-edge-infos" transform="translate(1175.32,192.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-130.78)">
@@ -862,7 +860,7 @@
         <g id="108">
             <desc>L11-13-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="1207.14,141.94 1000.94,183.26"/>
+                <polyline class="nad-edge-path" points="1207.14,141.94 1000.94,183.26"/>
                 <g class="nad-edge-infos" transform="translate(1155.67,152.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-101.33)">
@@ -881,7 +879,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="794.73,224.58 1000.94,183.26"/>
+                <polyline class="nad-edge-path" points="794.73,224.58 1000.94,183.26"/>
                 <g class="nad-edge-infos" transform="translate(826.59,218.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(78.67)">
@@ -903,7 +901,7 @@
         <g id="109">
             <desc>L41-42-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="1287.71,103.55 1460.45,-15.05"/>
+                <polyline class="nad-edge-path" points="1287.71,103.55 1460.45,-15.05"/>
                 <g class="nad-edge-infos" transform="translate(1314.50,85.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(55.53)">
@@ -922,7 +920,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="1633.19,-133.65 1460.45,-15.05"/>
+                <polyline class="nad-edge-path" points="1633.19,-133.65 1460.45,-15.05"/>
                 <g class="nad-edge-infos" transform="translate(1606.40,-115.26)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-124.47)">
@@ -944,7 +942,7 @@
         <g id="110">
             <desc>L41-43-1</desc>
             <g class="nad-vl0to30-2">
-                <path d="M1295.15,119.14 L1318.63,112.15 C1356.97,100.73 1367.96,123.92 1358.67,162.83"/>
+                <path class="nad-edge-path" d="M1295.15,119.14 L1318.63,112.15 C1356.97,100.73 1367.96,123.92 1358.67,162.83"/>
                 <g class="nad-edge-infos" transform="translate(1318.63,112.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(73.42)">
@@ -963,7 +961,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-2">
-                <path d="M1253.21,145.62 L1300.05,189.96 C1329.11,217.46 1349.39,201.74 1358.67,162.83"/>
+                <path class="nad-edge-path" d="M1253.21,145.62 L1300.05,189.96 C1329.11,217.46 1349.39,201.74 1358.67,162.83"/>
                 <g class="nad-edge-infos" transform="translate(1300.05,189.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(133.42)">
@@ -985,7 +983,7 @@
         <g id="111">
             <desc>L56-41-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="1425.30,-508.80 1341.23,-213.60"/>
+                <polyline class="nad-edge-path" points="1425.30,-508.80 1341.23,-213.60"/>
                 <g class="nad-edge-infos" transform="translate(1416.40,-477.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-164.10)">
@@ -1004,7 +1002,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="1257.15,81.59 1341.23,-213.60"/>
+                <polyline class="nad-edge-path" points="1257.15,81.59 1341.23,-213.60"/>
                 <g class="nad-edge-infos" transform="translate(1266.06,50.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(15.90)">
@@ -1026,7 +1024,7 @@
         <g id="112">
             <desc>T11-41-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M1258.99,166.11 L1280.34,205.15 C1299.54,240.25 1279.17,255.86 1269.17,255.63"/>
+                <path class="nad-edge-path" d="M1258.99,166.11 L1280.34,205.15 C1299.54,240.25 1279.17,255.86 1269.17,255.63"/>
                 <g class="nad-edge-infos" transform="translate(1280.34,205.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(151.32)">
@@ -1043,10 +1041,10 @@
                         <text transform="rotate(61.32)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1249.18" cy="255.17" r="20.00"/>
+                <circle class="nad-winding" cx="1249.18" cy="255.17" r="20.00"/>
             </g>
             <g class="nad-vl0to30-2">
-                <path d="M1213.10,182.38 L1200.36,203.31 C1179.57,237.48 1199.19,254.01 1209.19,254.24"/>
+                <path class="nad-edge-path" d="M1213.10,182.38 L1200.36,203.31 C1179.57,237.48 1199.19,254.01 1209.19,254.24"/>
                 <g class="nad-edge-infos" transform="translate(1200.36,203.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-148.68)">
@@ -1063,13 +1061,13 @@
                         <text transform="rotate(-58.68)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="1229.19" cy="254.71" r="20.00"/>
+                <circle class="nad-winding" cx="1229.19" cy="254.71" r="20.00"/>
             </g>
         </g>
         <g id="113">
             <desc>T11-43-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M1208.06,124.42 L1165.56,111.20 C1127.37,99.32 1131.16,73.94 1138.51,67.15"/>
+                <path class="nad-edge-path" d="M1208.06,124.42 L1165.56,111.20 C1127.37,99.32 1131.16,73.94 1138.51,67.15"/>
                 <g class="nad-edge-infos" transform="translate(1165.56,111.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-72.72)">
@@ -1086,10 +1084,10 @@
                         <text transform="rotate(-342.72)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="1153.20" cy="53.59" r="20.00"/>
+                <circle class="nad-winding" cx="1153.20" cy="53.59" r="20.00"/>
             </g>
             <g class="nad-vl0to30-2">
-                <path d="M1238.54,119.85 L1224.34,56.93 C1215.54,17.91 1189.94,19.67 1182.59,26.45"/>
+                <path class="nad-edge-path" d="M1238.54,119.85 L1224.34,56.93 C1215.54,17.91 1189.94,19.67 1182.59,26.45"/>
                 <g class="nad-edge-infos" transform="translate(1224.34,56.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-12.72)">
@@ -1106,13 +1104,13 @@
                         <text transform="rotate(-282.72)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="1167.89" cy="40.02" r="20.00"/>
+                <circle class="nad-winding" cx="1167.89" cy="40.02" r="20.00"/>
             </g>
         </g>
         <g id="114">
             <desc>L9-12-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="527.03,681.08 473.19,566.04"/>
+                <polyline class="nad-edge-path" points="527.03,681.08 473.19,566.04"/>
                 <g class="nad-edge-infos" transform="translate(513.25,651.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-25.08)">
@@ -1131,7 +1129,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="419.36,450.99 473.19,566.04"/>
+                <polyline class="nad-edge-path" points="419.36,450.99 473.19,566.04"/>
                 <g class="nad-edge-infos" transform="translate(433.13,480.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(154.92)">
@@ -1153,7 +1151,7 @@
         <g id="115">
             <desc>L12-13-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="430.61,415.10 561.45,339.21"/>
+                <polyline class="nad-edge-path" points="430.61,415.10 561.45,339.21"/>
                 <g class="nad-edge-infos" transform="translate(458.72,398.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(59.89)">
@@ -1172,7 +1170,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="692.30,263.33 561.45,339.21"/>
+                <polyline class="nad-edge-path" points="692.30,263.33 561.45,339.21"/>
                 <g class="nad-edge-infos" transform="translate(664.18,279.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.11)">
@@ -1194,7 +1192,7 @@
         <g id="116">
             <desc>L12-16-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="383.27,424.58 204.27,401.16"/>
+                <polyline class="nad-edge-path" points="383.27,424.58 204.27,401.16"/>
                 <g class="nad-edge-infos" transform="translate(351.04,420.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.54)">
@@ -1213,7 +1211,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="25.28,377.74 204.27,401.16"/>
+                <polyline class="nad-edge-path" points="25.28,377.74 204.27,401.16"/>
                 <g class="nad-edge-infos" transform="translate(57.50,381.95)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.46)">
@@ -1235,7 +1233,7 @@
         <g id="117">
             <desc>L12-17-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="395.04,406.27 207.22,105.74"/>
+                <polyline class="nad-edge-path" points="395.04,406.27 207.22,105.74"/>
                 <g class="nad-edge-infos" transform="translate(377.81,378.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-32.00)">
@@ -1254,7 +1252,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="19.40,-194.79 207.22,105.74"/>
+                <polyline class="nad-edge-path" points="19.40,-194.79 207.22,105.74"/>
                 <g class="nad-edge-infos" transform="translate(36.62,-167.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.00)">
@@ -1276,7 +1274,7 @@
         <g id="118">
             <desc>L9-13-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="570.39,679.52 645.43,483.42"/>
+                <polyline class="nad-edge-path" points="570.39,679.52 645.43,483.42"/>
                 <g class="nad-edge-infos" transform="translate(582.00,649.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(20.94)">
@@ -1295,7 +1293,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="720.47,287.32 645.43,483.42"/>
+                <polyline class="nad-edge-path" points="720.47,287.32 645.43,483.42"/>
                 <g class="nad-edge-infos" transform="translate(708.86,317.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-159.06)">
@@ -1317,7 +1315,7 @@
         <g id="119">
             <desc>L13-14-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="717.66,184.82 673.11,85.16"/>
+                <polyline class="nad-edge-path" points="717.66,184.82 673.11,85.16"/>
                 <g class="nad-edge-infos" transform="translate(704.40,155.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.08)">
@@ -1336,7 +1334,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="628.57,-14.50 673.11,85.16"/>
+                <polyline class="nad-edge-path" points="628.57,-14.50 673.11,85.16"/>
                 <g class="nad-edge-infos" transform="translate(641.83,15.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.92)">
@@ -1358,7 +1356,7 @@
         <g id="120">
             <desc>L13-15-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="688.08,216.71 441.73,128.18"/>
+                <polyline class="nad-edge-path" points="688.08,216.71 441.73,128.18"/>
                 <g class="nad-edge-infos" transform="translate(657.49,205.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.23)">
@@ -1377,7 +1375,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="195.38,39.65 441.73,128.18"/>
+                <polyline class="nad-edge-path" points="195.38,39.65 441.73,128.18"/>
                 <g class="nad-edge-infos" transform="translate(225.96,50.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.77)">
@@ -1399,7 +1397,7 @@
         <g id="121">
             <desc>L48-49-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="905.56,-105.91 828.49,53.31"/>
+                <polyline class="nad-edge-path" points="905.56,-105.91 828.49,53.31"/>
                 <g class="nad-edge-infos" transform="translate(891.40,-76.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-154.17)">
@@ -1418,7 +1416,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="751.42,212.53 828.49,53.31"/>
+                <polyline class="nad-edge-path" points="751.42,212.53 828.49,53.31"/>
                 <g class="nad-edge-infos" transform="translate(778.65,156.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(25.83)">
@@ -1440,7 +1438,7 @@
         <g id="122">
             <desc>L49-50-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="757.99,253.86 946.53,449.71"/>
+                <polyline class="nad-edge-path" points="757.99,253.86 946.53,449.71"/>
                 <g class="nad-edge-infos" transform="translate(801.34,298.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.09)">
@@ -1459,7 +1457,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="1135.07,645.56 946.53,449.71"/>
+                <polyline class="nad-edge-path" points="1135.07,645.56 946.53,449.71"/>
                 <g class="nad-edge-infos" transform="translate(1112.53,622.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.91)">
@@ -1481,7 +1479,7 @@
         <g id="123">
             <desc>L38-49-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="482.97,-322.64 606.30,-55.16"/>
+                <polyline class="nad-edge-path" points="482.97,-322.64 606.30,-55.16"/>
                 <g class="nad-edge-infos" transform="translate(496.57,-293.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.25)">
@@ -1500,7 +1498,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="729.63,212.33 606.30,-55.16"/>
+                <polyline class="nad-edge-path" points="729.63,212.33 606.30,-55.16"/>
                 <g class="nad-edge-infos" transform="translate(703.46,155.57)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.75)">
@@ -1522,7 +1520,7 @@
         <g id="124">
             <desc>T13-49-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M777.07,277.06 L793.30,295.42 C819.80,325.38 803.40,345.12 793.60,347.11"/>
+                <path class="nad-edge-path" d="M777.07,277.06 L793.30,295.42 C819.80,325.38 803.40,345.12 793.60,347.11"/>
                 <g class="nad-edge-infos" transform="translate(793.30,295.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.52)">
@@ -1539,10 +1537,10 @@
                         <text transform="rotate(48.52)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="774.00" cy="351.09" r="20.00"/>
+                <circle class="nad-winding" cx="774.00" cy="351.09" r="20.00"/>
             </g>
             <g class="nad-vl0to30-1">
-                <path d="M732.21,259.66 L714.90,311.34 C702.20,349.27 725.00,361.05 734.80,359.05"/>
+                <path class="nad-edge-path" d="M732.21,259.66 L714.90,311.34 C702.20,349.27 725.00,361.05 734.80,359.05"/>
                 <g class="nad-edge-infos" transform="translate(714.90,311.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.48)">
@@ -1559,13 +1557,13 @@
                         <text transform="rotate(-71.48)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="754.40" cy="355.07" r="20.00"/>
+                <circle class="nad-winding" cx="754.40" cy="355.07" r="20.00"/>
             </g>
         </g>
         <g id="125">
             <desc>L14-15-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="551.35,-55.02 374.53,-22.14"/>
+                <polyline class="nad-edge-path" points="551.35,-55.02 374.53,-22.14"/>
                 <g class="nad-edge-infos" transform="translate(519.40,-49.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.53)">
@@ -1584,7 +1582,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="197.71,10.73 374.53,-22.14"/>
+                <polyline class="nad-edge-path" points="197.71,10.73 374.53,-22.14"/>
                 <g class="nad-edge-infos" transform="translate(229.66,4.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.47)">
@@ -1606,7 +1604,7 @@
         <g id="126">
             <desc>L46-47-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="624.56,-82.57 789.69,-236.72"/>
+                <polyline class="nad-edge-path" points="624.56,-82.57 789.69,-236.72"/>
                 <g class="nad-edge-infos" transform="translate(670.25,-125.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.97)">
@@ -1625,7 +1623,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="954.83,-390.87 789.69,-236.72"/>
+                <polyline class="nad-edge-path" points="954.83,-390.87 789.69,-236.72"/>
                 <g class="nad-edge-infos" transform="translate(931.07,-368.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-133.03)">
@@ -1647,7 +1645,7 @@
         <g id="127">
             <desc>T14-46-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M559.49,-95.57 L538.99,-108.99 C505.53,-130.91 516.14,-154.27 525.07,-158.78"/>
+                <path class="nad-edge-path" d="M559.49,-95.57 L538.99,-108.99 C505.53,-130.91 516.14,-154.27 525.07,-158.78"/>
                 <g class="nad-edge-infos" transform="translate(538.99,-108.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-56.78)">
@@ -1664,10 +1662,10 @@
                         <text transform="rotate(-326.78)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="542.92" cy="-167.79" r="20.00"/>
+                <circle class="nad-winding" cx="542.92" cy="-167.79" r="20.00"/>
             </g>
             <g class="nad-vl0to30-1">
-                <path d="M607.35,-90.62 L610.41,-145.04 C612.66,-184.98 587.56,-190.32 578.63,-185.81"/>
+                <path class="nad-edge-path" d="M607.35,-90.62 L610.41,-145.04 C612.66,-184.98 587.56,-190.32 578.63,-185.81"/>
                 <g class="nad-edge-infos" transform="translate(610.41,-145.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(3.22)">
@@ -1684,13 +1682,13 @@
                         <text transform="rotate(-86.78)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="560.78" cy="-176.80" r="20.00"/>
+                <circle class="nad-winding" cx="560.78" cy="-176.80" r="20.00"/>
             </g>
         </g>
         <g id="128">
             <desc>L3-15-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-670.54,389.20 -288.98,216.48"/>
+                <polyline class="nad-edge-path" points="-670.54,389.20 -288.98,216.48"/>
                 <g class="nad-edge-infos" transform="translate(-640.93,375.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(65.65)">
@@ -1709,7 +1707,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="92.59,43.77 -288.98,216.48"/>
+                <polyline class="nad-edge-path" points="92.59,43.77 -288.98,216.48"/>
                 <g class="nad-edge-infos" transform="translate(62.98,57.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-114.35)">
@@ -1731,7 +1729,7 @@
         <g id="129">
             <desc>L44-45-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="186.46,-552.63 165.76,-278.59"/>
+                <polyline class="nad-edge-path" points="186.46,-552.63 165.76,-278.59"/>
                 <g class="nad-edge-infos" transform="translate(184.01,-520.22)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-175.68)">
@@ -1750,7 +1748,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="145.07,-4.55 165.76,-278.59"/>
+                <polyline class="nad-edge-path" points="145.07,-4.55 165.76,-278.59"/>
                 <g class="nad-edge-infos" transform="translate(149.77,-66.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(4.32)">
@@ -1772,7 +1770,7 @@
         <g id="130">
             <desc>T15-45-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M172.80,67.79 L185.89,88.51 C207.26,122.32 187.92,139.18 177.93,139.58"/>
+                <path class="nad-edge-path" d="M172.80,67.79 L185.89,88.51 C207.26,122.32 187.92,139.18 177.93,139.58"/>
                 <g class="nad-edge-infos" transform="translate(185.89,88.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(147.71)">
@@ -1789,10 +1787,10 @@
                         <text transform="rotate(57.71)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="157.94" cy="140.38" r="20.00"/>
+                <circle class="nad-winding" cx="157.94" cy="140.38" r="20.00"/>
             </g>
             <g class="nad-vl0to30-1">
-                <path d="M131.29,43.46 L105.95,91.71 C87.35,127.12 107.98,142.38 117.97,141.98"/>
+                <path class="nad-edge-path" d="M131.29,43.46 L105.95,91.71 C87.35,127.12 107.98,142.38 117.97,141.98"/>
                 <g class="nad-edge-infos" transform="translate(105.95,91.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-152.29)">
@@ -1809,13 +1807,13 @@
                         <text transform="rotate(-62.29)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="137.96" cy="141.18" r="20.00"/>
+                <circle class="nad-winding" cx="137.96" cy="141.18" r="20.00"/>
             </g>
         </g>
         <g id="131">
             <desc>L18-19-1</desc>
             <g class="nad-vl0to30-3">
-                <polyline points="-1147.07,1106.41 -1052.22,1264.54"/>
+                <polyline class="nad-edge-path" points="-1147.07,1106.41 -1052.22,1264.54"/>
                 <g class="nad-edge-infos" transform="translate(-1114.92,1160.01)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(149.04)">
@@ -1834,7 +1832,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="-957.38,1422.67 -1052.22,1264.54"/>
+                <polyline class="nad-edge-path" points="-957.38,1422.67 -1052.22,1264.54"/>
                 <g class="nad-edge-infos" transform="translate(-974.09,1394.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-30.96)">
@@ -1856,7 +1854,7 @@
         <g id="132">
             <desc>L19-20-1</desc>
             <g class="nad-vl0to30-3">
-                <polyline points="-926.23,1426.50 -766.51,1266.73"/>
+                <polyline class="nad-edge-path" points="-926.23,1426.50 -766.51,1266.73"/>
                 <g class="nad-edge-infos" transform="translate(-903.25,1403.51)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.99)">
@@ -1875,7 +1873,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-3">
-                <polyline points="-606.80,1106.96 -766.51,1266.73"/>
+                <polyline class="nad-edge-path" points="-606.80,1106.96 -766.51,1266.73"/>
                 <g class="nad-edge-infos" transform="translate(-650.98,1151.16)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.01)">
@@ -1897,7 +1895,7 @@
         <g id="133">
             <desc>L2-3-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-733.87,10.35 -715.12,192.35"/>
+                <polyline class="nad-edge-path" points="-733.87,10.35 -715.12,192.35"/>
                 <g class="nad-edge-infos" transform="translate(-730.54,42.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(174.12)">
@@ -1916,7 +1914,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-696.38,374.34 -715.12,192.35"/>
+                <polyline class="nad-edge-path" points="-696.38,374.34 -715.12,192.35"/>
                 <g class="nad-edge-infos" transform="translate(-699.71,342.02)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-5.88)">
@@ -1938,7 +1936,7 @@
         <g id="134">
             <desc>L21-22-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="-577.29,1034.62 -489.25,618.30"/>
+                <polyline class="nad-edge-path" points="-577.29,1034.62 -489.25,618.30"/>
                 <g class="nad-edge-infos" transform="translate(-570.56,1002.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
@@ -1957,7 +1955,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="-401.20,201.97 -489.25,618.30"/>
+                <polyline class="nad-edge-path" points="-401.20,201.97 -489.25,618.30"/>
                 <g class="nad-edge-infos" transform="translate(-407.93,233.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
@@ -1979,7 +1977,7 @@
         <g id="135">
             <desc>T21-20-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M-533.29,1087.43 L-508.80,1086.78 C-468.81,1085.71 -464.21,1110.95 -468.98,1119.74"/>
+                <path class="nad-edge-path" d="M-533.29,1087.43 L-508.80,1086.78 C-468.81,1085.71 -464.21,1110.95 -468.98,1119.74"/>
                 <g class="nad-edge-infos" transform="translate(-508.80,1086.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(88.47)">
@@ -1996,10 +1994,10 @@
                         <text transform="rotate(-1.53)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-478.51" cy="1137.33" r="20.00"/>
+                <circle class="nad-winding" cx="-478.51" cy="1137.33" r="20.00"/>
             </g>
             <g class="nad-vl0to30-3">
-                <path d="M-575.43,1110.66 L-546.93,1157.11 C-526.01,1191.20 -502.34,1181.28 -497.58,1172.49"/>
+                <path class="nad-edge-path" d="M-575.43,1110.66 L-546.93,1157.11 C-526.01,1191.20 -502.34,1181.28 -497.58,1172.49"/>
                 <g class="nad-edge-infos" transform="translate(-546.93,1157.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.47)">
@@ -2016,13 +2014,13 @@
                         <text transform="rotate(58.47)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-488.04" cy="1154.91" r="20.00"/>
+                <circle class="nad-winding" cx="-488.04" cy="1154.91" r="20.00"/>
             </g>
         </g>
         <g id="136">
             <desc>L22-23-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="-412.70,157.82 -653.34,-117.74"/>
+                <polyline class="nad-edge-path" points="-412.70,157.82 -653.34,-117.74"/>
                 <g class="nad-edge-infos" transform="translate(-434.08,133.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-41.13)">
@@ -2041,7 +2039,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="-893.98,-393.30 -653.34,-117.74"/>
+                <polyline class="nad-edge-path" points="-893.98,-393.30 -653.34,-117.74"/>
                 <g class="nad-edge-infos" transform="translate(-872.60,-368.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.87)">
@@ -2063,7 +2061,7 @@
         <g id="137">
             <desc>L22-38-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="-374.08,163.87 38.18,-84.39"/>
+                <polyline class="nad-edge-path" points="-374.08,163.87 38.18,-84.39"/>
                 <g class="nad-edge-infos" transform="translate(-346.24,147.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(58.94)">
@@ -2082,7 +2080,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="450.44,-332.65 38.18,-84.39"/>
+                <polyline class="nad-edge-path" points="450.44,-332.65 38.18,-84.39"/>
                 <g class="nad-edge-infos" transform="translate(422.60,-315.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-121.06)">
@@ -2104,7 +2102,7 @@
         <g id="138">
             <desc>L23-24-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="-930.45,-428.71 -1084.34,-555.34"/>
+                <polyline class="nad-edge-path" points="-930.45,-428.71 -1084.34,-555.34"/>
                 <g class="nad-edge-infos" transform="translate(-955.54,-449.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.55)">
@@ -2123,7 +2121,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="-1238.23,-681.97 -1084.34,-555.34"/>
+                <polyline class="nad-edge-path" points="-1238.23,-681.97 -1084.34,-555.34"/>
                 <g class="nad-edge-infos" transform="translate(-1213.14,-661.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.45)">
@@ -2145,7 +2143,7 @@
         <g id="139">
             <desc>L25-30-1</desc>
             <g class="nad-vl0to30-5">
-                <polyline points="-1267.08,-749.86 -1169.60,-976.85"/>
+                <polyline class="nad-edge-path" points="-1267.08,-749.86 -1169.60,-976.85"/>
                 <g class="nad-edge-infos" transform="translate(-1246.37,-798.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.24)">
@@ -2164,7 +2162,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-1072.12,-1203.85 -1169.60,-976.85"/>
+                <polyline class="nad-edge-path" points="-1072.12,-1203.85 -1169.60,-976.85"/>
                 <g class="nad-edge-infos" transform="translate(-1084.94,-1173.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.76)">
@@ -2186,7 +2184,7 @@
         <g id="140">
             <desc>L26-27-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="-1288.43,-703.58 -1405.71,-485.40"/>
+                <polyline class="nad-edge-path" points="-1288.43,-703.58 -1405.71,-485.40"/>
                 <g class="nad-edge-infos" transform="translate(-1322.76,-639.73)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.74)">
@@ -2205,7 +2203,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="-1522.99,-267.22 -1405.71,-485.40"/>
+                <polyline class="nad-edge-path" points="-1522.99,-267.22 -1405.71,-485.40"/>
                 <g class="nad-edge-infos" transform="translate(-1507.61,-295.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(28.26)">
@@ -2227,7 +2225,7 @@
         <g id="141">
             <desc>T24-25-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M-1244.57,-675.44 L-1228.45,-656.99 C-1202.13,-626.87 -1218.65,-607.23 -1228.46,-605.30"/>
+                <path class="nad-edge-path" d="M-1244.57,-675.44 L-1228.45,-656.99 C-1202.13,-626.87 -1218.65,-607.23 -1228.46,-605.30"/>
                 <g class="nad-edge-infos" transform="translate(-1228.45,-656.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(138.85)">
@@ -2244,10 +2242,10 @@
                         <text transform="rotate(48.85)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1248.08" cy="-601.43" r="20.00"/>
+                <circle class="nad-winding" cx="-1248.08" cy="-601.43" r="20.00"/>
             </g>
             <g class="nad-vl0to30-5">
-                <path d="M-1292.56,-683.64 L-1306.94,-641.53 C-1319.87,-603.68 -1297.14,-591.77 -1287.33,-593.70"/>
+                <path class="nad-edge-path" d="M-1292.56,-683.64 L-1306.94,-641.53 C-1319.87,-603.68 -1297.14,-591.77 -1287.33,-593.70"/>
                 <g class="nad-edge-infos" transform="translate(-1306.94,-641.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-161.15)">
@@ -2264,13 +2262,13 @@
                         <text transform="rotate(-71.15)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1267.71" cy="-597.57" r="20.00"/>
+                <circle class="nad-winding" cx="-1267.71" cy="-597.57" r="20.00"/>
             </g>
         </g>
         <g id="142">
             <desc>T24-25-2</desc>
             <g class="nad-vl0to30-1">
-                <path d="M-1240.94,-755.55 L-1223.21,-772.46 C-1194.27,-800.08 -1173.92,-784.44 -1171.56,-774.72"/>
+                <path class="nad-edge-path" d="M-1240.94,-755.55 L-1223.21,-772.46 C-1194.27,-800.08 -1173.92,-784.44 -1171.56,-774.72"/>
                 <g class="nad-edge-infos" transform="translate(-1223.21,-772.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(46.34)">
@@ -2287,10 +2285,10 @@
                         <text transform="rotate(-43.66)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1166.84" cy="-755.28" r="20.00"/>
+                <circle class="nad-winding" cx="-1166.84" cy="-755.28" r="20.00"/>
             </g>
             <g class="nad-vl0to30-5">
-                <path d="M-1247.02,-707.25 L-1204.32,-694.72 C-1165.94,-683.47 -1155.04,-706.70 -1157.40,-716.41"/>
+                <path class="nad-edge-path" d="M-1247.02,-707.25 L-1204.32,-694.72 C-1165.94,-683.47 -1155.04,-706.70 -1157.40,-716.41"/>
                 <g class="nad-edge-infos" transform="translate(-1204.32,-694.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(106.34)">
@@ -2307,13 +2305,13 @@
                         <text transform="rotate(16.34)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1162.12" cy="-735.85" r="20.00"/>
+                <circle class="nad-winding" cx="-1162.12" cy="-735.85" r="20.00"/>
             </g>
         </g>
         <g id="143">
             <desc>T24-26-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M-1336.44,-713.12 L-1360.87,-711.31 C-1400.76,-708.35 -1406.55,-733.34 -1402.21,-742.35"/>
+                <path class="nad-edge-path" d="M-1336.44,-713.12 L-1360.87,-711.31 C-1400.76,-708.35 -1406.55,-733.34 -1402.21,-742.35"/>
                 <g class="nad-edge-infos" transform="translate(-1360.87,-711.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-94.25)">
@@ -2330,10 +2328,10 @@
                         <text transform="rotate(-4.25)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1393.52" cy="-760.36" r="20.00"/>
+                <circle class="nad-winding" cx="-1393.52" cy="-760.36" r="20.00"/>
             </g>
             <g class="nad-vl0to30-4">
-                <path d="M-1289.81,-730.05 L-1326.11,-783.37 C-1348.63,-816.43 -1371.80,-805.40 -1376.14,-796.39"/>
+                <path class="nad-edge-path" d="M-1289.81,-730.05 L-1326.11,-783.37 C-1348.63,-816.43 -1371.80,-805.40 -1376.14,-796.39"/>
                 <g class="nad-edge-infos" transform="translate(-1326.11,-783.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.25)">
@@ -2350,13 +2348,13 @@
                         <text transform="rotate(-304.25)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1384.83" cy="-778.38" r="20.00"/>
+                <circle class="nad-winding" cx="-1384.83" cy="-778.38" r="20.00"/>
             </g>
         </g>
         <g id="144">
             <desc>L27-28-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="-1526.66,-220.69 -1441.61,22.81"/>
+                <polyline class="nad-edge-path" points="-1526.66,-220.69 -1441.61,22.81"/>
                 <g class="nad-edge-infos" transform="translate(-1515.94,-190.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.75)">
@@ -2375,7 +2373,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="-1356.56,266.30 -1441.61,22.81"/>
+                <polyline class="nad-edge-path" points="-1356.56,266.30 -1441.61,22.81"/>
                 <g class="nad-edge-infos" transform="translate(-1367.28,235.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.25)">
@@ -2397,7 +2395,7 @@
         <g id="145">
             <desc>L28-29-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="-1329.16,307.39 -1056.78,551.44"/>
+                <polyline class="nad-edge-path" points="-1329.16,307.39 -1056.78,551.44"/>
                 <g class="nad-edge-infos" transform="translate(-1304.95,329.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(131.86)">
@@ -2416,7 +2414,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="-784.41,795.49 -1056.78,551.44"/>
+                <polyline class="nad-edge-path" points="-784.41,795.49 -1056.78,551.44"/>
                 <g class="nad-edge-infos" transform="translate(-808.62,773.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-48.14)">
@@ -2438,7 +2436,7 @@
         <g id="146">
             <desc>L3-4-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-708.12,420.79 -918.53,729.73"/>
+                <polyline class="nad-edge-path" points="-708.12,420.79 -918.53,729.73"/>
                 <g class="nad-edge-infos" transform="translate(-726.42,447.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-145.74)">
@@ -2457,7 +2455,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-1128.95,1038.67 -918.53,729.73"/>
+                <polyline class="nad-edge-path" points="-1128.95,1038.67 -918.53,729.73"/>
                 <g class="nad-edge-infos" transform="translate(-1110.65,1011.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(34.26)">
@@ -2479,7 +2477,7 @@
         <g id="147">
             <desc>L30-31-1</desc>
             <g class="nad-vl0to30-5">
-                <polyline points="-1041.91,-1242.92 -851.44,-1390.77"/>
+                <polyline class="nad-edge-path" points="-1041.91,-1242.92 -851.44,-1390.77"/>
                 <g class="nad-edge-infos" transform="translate(-1016.24,-1262.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.18)">
@@ -2498,7 +2496,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-660.96,-1538.62 -851.44,-1390.77"/>
+                <polyline class="nad-edge-path" points="-660.96,-1538.62 -851.44,-1390.77"/>
                 <g class="nad-edge-infos" transform="translate(-686.64,-1518.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-127.82)">
@@ -2520,7 +2518,7 @@
         <g id="148">
             <desc>L31-32-1</desc>
             <g class="nad-vl0to30-5">
-                <polyline points="-616.64,-1562.35 -386.26,-1639.49"/>
+                <polyline class="nad-edge-path" points="-616.64,-1562.35 -386.26,-1639.49"/>
                 <g class="nad-edge-infos" transform="translate(-585.82,-1572.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(71.49)">
@@ -2539,7 +2537,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-155.89,-1716.62 -386.26,-1639.49"/>
+                <polyline class="nad-edge-path" points="-155.89,-1716.62 -386.26,-1639.49"/>
                 <g class="nad-edge-infos" transform="translate(-186.71,-1706.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-108.51)">
@@ -2561,7 +2559,7 @@
         <g id="149">
             <desc>L32-33-1</desc>
             <g class="nad-vl0to30-5">
-                <polyline points="-111.27,-1789.16 -134.15,-1946.09"/>
+                <polyline class="nad-edge-path" points="-111.27,-1789.16 -134.15,-1946.09"/>
                 <g class="nad-edge-infos" transform="translate(-115.96,-1821.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-8.30)">
@@ -2580,7 +2578,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-5">
-                <polyline points="-157.03,-2103.03 -134.15,-1946.09"/>
+                <polyline class="nad-edge-path" points="-157.03,-2103.03 -134.15,-1946.09"/>
                 <g class="nad-edge-infos" transform="translate(-152.34,-2070.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(171.70)">
@@ -2602,7 +2600,7 @@
         <g id="150">
             <desc>L34-35-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="-78.59,-1727.81 184.70,-1659.14"/>
+                <polyline class="nad-edge-path" points="-78.59,-1727.81 184.70,-1659.14"/>
                 <g class="nad-edge-infos" transform="translate(-18.11,-1712.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.62)">
@@ -2621,7 +2619,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="448.00,-1590.47 184.70,-1659.14"/>
+                <polyline class="nad-edge-path" points="448.00,-1590.47 184.70,-1659.14"/>
                 <g class="nad-edge-infos" transform="translate(416.55,-1598.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.38)">
@@ -2643,7 +2641,7 @@
         <g id="151">
             <desc>T34-32-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M-89.77,-1712.60 L-60.93,-1666.36 C-39.77,-1632.42 -59.21,-1615.67 -69.20,-1615.33"/>
+                <path class="nad-edge-path" d="M-89.77,-1712.60 L-60.93,-1666.36 C-39.77,-1632.42 -59.21,-1615.67 -69.20,-1615.33"/>
                 <g class="nad-edge-infos" transform="translate(-60.93,-1666.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(148.05)">
@@ -2660,10 +2658,10 @@
                         <text transform="rotate(58.05)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-89.19" cy="-1614.65" r="20.00"/>
+                <circle class="nad-winding" cx="-89.19" cy="-1614.65" r="20.00"/>
             </g>
             <g class="nad-vl0to30-5">
-                <path d="M-129.36,-1685.26 L-140.88,-1663.64 C-159.70,-1628.34 -139.16,-1612.95 -129.17,-1613.29"/>
+                <path class="nad-edge-path" d="M-129.36,-1685.26 L-140.88,-1663.64 C-159.70,-1628.34 -139.16,-1612.95 -129.17,-1613.29"/>
                 <g class="nad-edge-infos" transform="translate(-140.88,-1663.64)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-151.95)">
@@ -2680,13 +2678,13 @@
                         <text transform="rotate(-61.95)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-109.18" cy="-1613.97" r="20.00"/>
+                <circle class="nad-winding" cx="-109.18" cy="-1613.97" r="20.00"/>
             </g>
         </g>
         <g id="152">
             <desc>L35-36-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="493.53,-1569.37 731.41,-1402.05"/>
+                <polyline class="nad-edge-path" points="493.53,-1569.37 731.41,-1402.05"/>
                 <g class="nad-edge-infos" transform="translate(520.11,-1550.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(125.12)">
@@ -2705,7 +2703,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="969.29,-1234.74 731.41,-1402.05"/>
+                <polyline class="nad-edge-path" points="969.29,-1234.74 731.41,-1402.05"/>
                 <g class="nad-edge-infos" transform="translate(942.71,-1253.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-54.88)">
@@ -2727,7 +2725,7 @@
         <g id="153">
             <desc>L36-37-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="985.26,-1195.04 957.06,-1050.78"/>
+                <polyline class="nad-edge-path" points="985.26,-1195.04 957.06,-1050.78"/>
                 <g class="nad-edge-infos" transform="translate(979.03,-1163.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.94)">
@@ -2746,7 +2744,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="928.87,-906.52 957.06,-1050.78"/>
+                <polyline class="nad-edge-path" points="928.87,-906.52 957.06,-1050.78"/>
                 <g class="nad-edge-infos" transform="translate(935.10,-938.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.06)">
@@ -2768,7 +2766,7 @@
         <g id="154">
             <desc>L36-40-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="1004.56,-1199.02 1215.33,-891.12"/>
+                <polyline class="nad-edge-path" points="1004.56,-1199.02 1215.33,-891.12"/>
                 <g class="nad-edge-infos" transform="translate(1022.91,-1172.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.61)">
@@ -2787,7 +2785,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="1426.10,-583.22 1215.33,-891.12"/>
+                <polyline class="nad-edge-path" points="1426.10,-583.22 1215.33,-891.12"/>
                 <g class="nad-edge-infos" transform="translate(1390.79,-634.79)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.39)">
@@ -2809,7 +2807,7 @@
         <g id="155">
             <desc>L37-38-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="907.54,-862.00 698.13,-613.65"/>
+                <polyline class="nad-edge-path" points="907.54,-862.00 698.13,-613.65"/>
                 <g class="nad-edge-infos" transform="translate(886.59,-837.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-139.86)">
@@ -2828,7 +2826,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="488.73,-365.30 698.13,-613.65"/>
+                <polyline class="nad-edge-path" points="488.73,-365.30 698.13,-613.65"/>
                 <g class="nad-edge-infos" transform="translate(509.68,-390.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(40.14)">
@@ -2850,7 +2848,7 @@
         <g id="156">
             <desc>L37-39-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="949.21,-885.14 1171.30,-917.25"/>
+                <polyline class="nad-edge-path" points="949.21,-885.14 1171.30,-917.25"/>
                 <g class="nad-edge-infos" transform="translate(981.38,-889.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.77)">
@@ -2869,7 +2867,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="1393.40,-949.36 1171.30,-917.25"/>
+                <polyline class="nad-edge-path" points="1393.40,-949.36 1171.30,-917.25"/>
                 <g class="nad-edge-infos" transform="translate(1331.54,-940.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.23)">
@@ -2891,7 +2889,7 @@
         <g id="157">
             <desc>L38-44-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="452.55,-361.95 330.33,-461.93"/>
+                <polyline class="nad-edge-path" points="452.55,-361.95 330.33,-461.93"/>
                 <g class="nad-edge-infos" transform="translate(427.40,-382.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.71)">
@@ -2910,7 +2908,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="208.12,-561.91 330.33,-461.93"/>
+                <polyline class="nad-edge-path" points="208.12,-561.91 330.33,-461.93"/>
                 <g class="nad-edge-infos" transform="translate(233.27,-541.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.29)">
@@ -2932,7 +2930,7 @@
         <g id="158">
             <desc>L38-48-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="495.20,-334.61 694.48,-237.33"/>
+                <polyline class="nad-edge-path" points="495.20,-334.61 694.48,-237.33"/>
                 <g class="nad-edge-infos" transform="translate(524.41,-320.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(116.02)">
@@ -2951,7 +2949,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="893.75,-140.05 694.48,-237.33"/>
+                <polyline class="nad-edge-path" points="893.75,-140.05 694.48,-237.33"/>
                 <g class="nad-edge-infos" transform="translate(864.55,-154.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-63.98)">
@@ -2973,7 +2971,7 @@
         <g id="159">
             <desc>L57-56-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="1421.73,-897.60 1429.57,-757.59"/>
+                <polyline class="nad-edge-path" points="1421.73,-897.60 1429.57,-757.59"/>
                 <g class="nad-edge-infos" transform="translate(1423.55,-865.15)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(176.80)">
@@ -2992,7 +2990,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="1437.40,-617.59 1429.57,-757.59"/>
+                <polyline class="nad-edge-path" points="1437.40,-617.59 1429.57,-757.59"/>
                 <g class="nad-edge-infos" transform="translate(1435.58,-650.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-3.20)">
@@ -3014,7 +3012,7 @@
         <g id="160">
             <desc>T39-57-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M1422.75,-978.18 L1431.54,-1031.96 C1438.00,-1071.44 1463.66,-1071.22 1471.40,-1064.89"/>
+                <path class="nad-edge-path" d="M1422.75,-978.18 L1431.54,-1031.96 C1438.00,-1071.44 1463.66,-1071.22 1471.40,-1064.89"/>
                 <g class="nad-edge-infos" transform="translate(1431.54,-1031.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.29)">
@@ -3031,10 +3029,10 @@
                         <text transform="rotate(-80.71)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1486.88" cy="-1052.22" r="20.00"/>
+                <circle class="nad-winding" cx="1486.88" cy="-1052.22" r="20.00"/>
             </g>
             <g class="nad-vl0to30-2">
-                <path d="M1470.55,-972.64 L1493.46,-981.31 C1530.88,-995.46 1525.58,-1020.57 1517.84,-1026.90"/>
+                <path class="nad-edge-path" d="M1470.55,-972.64 L1493.46,-981.31 C1530.88,-995.46 1525.58,-1020.57 1517.84,-1026.90"/>
                 <g class="nad-edge-infos" transform="translate(1493.46,-981.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(69.29)">
@@ -3051,13 +3049,13 @@
                         <text transform="rotate(-20.71)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1502.36" cy="-1039.56" r="20.00"/>
+                <circle class="nad-winding" cx="1502.36" cy="-1039.56" r="20.00"/>
             </g>
         </g>
         <g id="161">
             <desc>L4-5-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-1215.05,1076.14 -1347.52,1055.87"/>
+                <polyline class="nad-edge-path" points="-1215.05,1076.14 -1347.52,1055.87"/>
                 <g class="nad-edge-infos" transform="translate(-1247.18,1071.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-81.30)">
@@ -3076,7 +3074,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-1479.99,1035.59 -1347.52,1055.87"/>
+                <polyline class="nad-edge-path" points="-1479.99,1035.59 -1347.52,1055.87"/>
                 <g class="nad-edge-infos" transform="translate(-1447.87,1040.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(98.70)">
@@ -3098,7 +3096,7 @@
         <g id="162">
             <desc>L4-6-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-1135.26,1034.96 -1093.75,952.40"/>
+                <polyline class="nad-edge-path" points="-1135.26,1034.96 -1093.75,952.40"/>
                 <g class="nad-edge-infos" transform="translate(-1120.66,1005.92)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(26.69)">
@@ -3117,7 +3115,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-1052.24,869.85 -1093.75,952.40"/>
+                <polyline class="nad-edge-path" points="-1052.24,869.85 -1093.75,952.40"/>
                 <g class="nad-edge-infos" transform="translate(-1066.84,898.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-153.31)">
@@ -3139,7 +3137,7 @@
         <g id="163">
             <desc>T4-18-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M-1111.35,1058.19 L-1089.78,1046.55 C-1054.58,1027.56 -1039.09,1048.01 -1039.38,1058.01"/>
+                <path class="nad-edge-path" d="M-1111.35,1058.19 L-1089.78,1046.55 C-1054.58,1027.56 -1039.09,1048.01 -1039.38,1058.01"/>
                 <g class="nad-edge-infos" transform="translate(-1089.78,1046.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(61.65)">
@@ -3156,10 +3154,10 @@
                         <text transform="rotate(-28.35)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1039.95" cy="1078.00" r="20.00"/>
+                <circle class="nad-winding" cx="-1039.95" cy="1078.00" r="20.00"/>
             </g>
             <g class="nad-vl0to30-3">
-                <path d="M-1138.48,1097.92 L-1092.09,1126.52 C-1058.04,1147.51 -1041.39,1127.98 -1041.10,1117.99"/>
+                <path class="nad-edge-path" d="M-1138.48,1097.92 L-1092.09,1126.52 C-1058.04,1147.51 -1041.39,1127.98 -1041.10,1117.99"/>
                 <g class="nad-edge-infos" transform="translate(-1092.09,1126.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.65)">
@@ -3176,13 +3174,13 @@
                         <text transform="rotate(31.65)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1040.53" cy="1097.99" r="20.00"/>
+                <circle class="nad-winding" cx="-1040.53" cy="1097.99" r="20.00"/>
             </g>
         </g>
         <g id="164">
             <desc>T4-18-2</desc>
             <g class="nad-vl0to30-0">
-                <path d="M-1163.94,1139.91 L-1165.59,1164.36 C-1168.30,1204.27 -1193.86,1206.47 -1202.17,1200.89"/>
+                <path class="nad-edge-path" d="M-1163.94,1139.91 L-1165.59,1164.36 C-1168.30,1204.27 -1193.86,1206.47 -1202.17,1200.89"/>
                 <g class="nad-edge-infos" transform="translate(-1165.59,1164.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-176.13)">
@@ -3199,10 +3197,10 @@
                         <text transform="rotate(-86.13)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1218.77" cy="1189.75" r="20.00"/>
+                <circle class="nad-winding" cx="-1218.77" cy="1189.75" r="20.00"/>
             </g>
             <g class="nad-vl0to30-3">
-                <path d="M-1183.08,1095.77 L-1232.02,1119.77 C-1267.93,1137.38 -1260.28,1161.88 -1251.98,1167.45"/>
+                <path class="nad-edge-path" d="M-1183.08,1095.77 L-1232.02,1119.77 C-1267.93,1137.38 -1260.28,1161.88 -1251.98,1167.45"/>
                 <g class="nad-edge-infos" transform="translate(-1232.02,1119.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.13)">
@@ -3219,13 +3217,13 @@
                         <text transform="rotate(-26.13)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1235.38" cy="1178.60" r="20.00"/>
+                <circle class="nad-winding" cx="-1235.38" cy="1178.60" r="20.00"/>
             </g>
         </g>
         <g id="165">
             <desc>L56-42-1</desc>
             <g class="nad-vl0to30-2">
-                <polyline points="1465.95,-512.86 1554.24,-341.80"/>
+                <polyline class="nad-edge-path" points="1465.95,-512.86 1554.24,-341.80"/>
                 <g class="nad-edge-infos" transform="translate(1480.86,-483.98)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(152.70)">
@@ -3244,7 +3242,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-2">
-                <polyline points="1642.52,-170.75 1554.24,-341.80"/>
+                <polyline class="nad-edge-path" points="1642.52,-170.75 1554.24,-341.80"/>
                 <g class="nad-edge-infos" transform="translate(1627.62,-199.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-27.30)">
@@ -3266,7 +3264,7 @@
         <g id="166">
             <desc>T40-56-1</desc>
             <g class="nad-vl0to30-1">
-                <path d="M1458.45,-580.29 L1496.82,-618.99 C1524.98,-647.40 1545.75,-632.33 1548.38,-622.68"/>
+                <path class="nad-edge-path" d="M1458.45,-580.29 L1496.82,-618.99 C1524.98,-647.40 1545.75,-632.33 1548.38,-622.68"/>
                 <g class="nad-edge-infos" transform="translate(1496.82,-618.99)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.75)">
@@ -3283,10 +3281,10 @@
                         <text transform="rotate(-45.25)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1553.64" cy="-603.39" r="20.00"/>
+                <circle class="nad-winding" cx="1553.64" cy="-603.39" r="20.00"/>
             </g>
             <g class="nad-vl0to30-2">
-                <path d="M1494.17,-548.05 L1517.86,-541.81 C1556.55,-531.62 1566.80,-555.15 1564.17,-564.80"/>
+                <path class="nad-edge-path" d="M1494.17,-548.05 L1517.86,-541.81 C1556.55,-531.62 1566.80,-555.15 1564.17,-564.80"/>
                 <g class="nad-edge-infos" transform="translate(1517.86,-541.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.75)">
@@ -3303,13 +3301,13 @@
                         <text transform="rotate(14.75)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1558.90" cy="-584.09" r="20.00"/>
+                <circle class="nad-winding" cx="1558.90" cy="-584.09" r="20.00"/>
             </g>
         </g>
         <g id="167">
             <desc>L47-48-1</desc>
             <g class="nad-vl0to30-1">
-                <polyline points="968.39,-383.28 945.07,-268.57"/>
+                <polyline class="nad-edge-path" points="968.39,-383.28 945.07,-268.57"/>
                 <g class="nad-edge-infos" transform="translate(961.92,-351.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.51)">
@@ -3328,7 +3326,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-1">
-                <polyline points="921.75,-153.85 945.07,-268.57"/>
+                <polyline class="nad-edge-path" points="921.75,-153.85 945.07,-268.57"/>
                 <g class="nad-edge-infos" transform="translate(928.22,-185.70)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.49)">
@@ -3350,7 +3348,7 @@
         <g id="168">
             <desc>L5-6-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-1481.50,1022.31 -1272.99,939.40"/>
+                <polyline class="nad-edge-path" points="-1481.50,1022.31 -1272.99,939.40"/>
                 <g class="nad-edge-infos" transform="translate(-1451.30,1010.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(68.32)">
@@ -3369,7 +3367,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-1064.48,856.49 -1272.99,939.40"/>
+                <polyline class="nad-edge-path" points="-1064.48,856.49 -1272.99,939.40"/>
                 <g class="nad-edge-infos" transform="translate(-1094.68,868.50)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-111.68)">
@@ -3391,7 +3389,7 @@
         <g id="169">
             <desc>L29-52-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="-711.36,878.07 -514.35,1160.97"/>
+                <polyline class="nad-edge-path" points="-711.36,878.07 -514.35,1160.97"/>
                 <g class="nad-edge-infos" transform="translate(-692.79,904.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(145.15)">
@@ -3410,7 +3408,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="-317.33,1443.88 -514.35,1160.97"/>
+                <polyline class="nad-edge-path" points="-317.33,1443.88 -514.35,1160.97"/>
                 <g class="nad-edge-infos" transform="translate(-335.91,1417.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-34.85)">
@@ -3432,7 +3430,7 @@
         <g id="170">
             <desc>L52-53-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="-279.27,1474.73 -81.16,1558.51"/>
+                <polyline class="nad-edge-path" points="-279.27,1474.73 -81.16,1558.51"/>
                 <g class="nad-edge-infos" transform="translate(-249.34,1487.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(112.92)">
@@ -3451,7 +3449,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="116.95,1642.29 -81.16,1558.51"/>
+                <polyline class="nad-edge-path" points="116.95,1642.29 -81.16,1558.51"/>
                 <g class="nad-edge-infos" transform="translate(87.01,1629.63)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-67.08)">
@@ -3473,7 +3471,7 @@
         <g id="171">
             <desc>L53-54-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="159.22,1634.98 308.58,1497.93"/>
+                <polyline class="nad-edge-path" points="159.22,1634.98 308.58,1497.93"/>
                 <g class="nad-edge-infos" transform="translate(183.17,1613.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(47.46)">
@@ -3492,7 +3490,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="457.94,1360.89 308.58,1497.93"/>
+                <polyline class="nad-edge-path" points="457.94,1360.89 308.58,1497.93"/>
                 <g class="nad-edge-infos" transform="translate(433.99,1382.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-132.54)">
@@ -3514,7 +3512,7 @@
         <g id="172">
             <desc>L54-55-1</desc>
             <g class="nad-vl0to30-4">
-                <polyline points="479.78,1318.33 513.64,1037.50"/>
+                <polyline class="nad-edge-path" points="479.78,1318.33 513.64,1037.50"/>
                 <g class="nad-edge-infos" transform="translate(483.67,1286.07)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(6.87)">
@@ -3533,7 +3531,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-4">
-                <polyline points="547.50,756.67 513.64,1037.50"/>
+                <polyline class="nad-edge-path" points="547.50,756.67 513.64,1037.50"/>
                 <g class="nad-edge-infos" transform="translate(540.02,818.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-173.13)">
@@ -3555,7 +3553,7 @@
         <g id="173">
             <desc>L6-7-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-1015.31,845.82 -891.93,839.80"/>
+                <polyline class="nad-edge-path" points="-1015.31,845.82 -891.93,839.80"/>
                 <g class="nad-edge-infos" transform="translate(-982.85,844.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(87.20)">
@@ -3574,7 +3572,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-768.55,833.77 -891.93,839.80"/>
+                <polyline class="nad-edge-path" points="-768.55,833.77 -891.93,839.80"/>
                 <g class="nad-edge-infos" transform="translate(-830.97,836.82)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.80)">
@@ -3596,7 +3594,7 @@
         <g id="174">
             <desc>L6-8-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-1015.29,847.49 -663.96,853.35"/>
+                <polyline class="nad-edge-path" points="-1015.29,847.49 -663.96,853.35"/>
                 <g class="nad-edge-infos" transform="translate(-982.79,848.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(90.96)">
@@ -3615,7 +3613,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-312.64,859.21 -663.96,853.35"/>
+                <polyline class="nad-edge-path" points="-312.64,859.21 -663.96,853.35"/>
                 <g class="nad-edge-infos" transform="translate(-345.14,858.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-89.04)">
@@ -3637,7 +3635,7 @@
         <g id="175">
             <desc>L7-8-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-717.62,834.04 -515.11,846.08"/>
+                <polyline class="nad-edge-path" points="-717.62,834.04 -515.11,846.08"/>
                 <g class="nad-edge-infos" transform="translate(-655.23,837.75)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.40)">
@@ -3656,7 +3654,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="-312.60,858.12 -515.11,846.08"/>
+                <polyline class="nad-edge-path" points="-312.60,858.12 -515.11,846.08"/>
                 <g class="nad-edge-infos" transform="translate(-345.04,856.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.60)">
@@ -3678,7 +3676,7 @@
         <g id="176">
             <desc>T7-29-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M-746.35,807.24 L-753.34,753.19 C-758.47,713.52 -733.82,706.38 -724.59,710.22"/>
+                <path class="nad-edge-path" d="M-746.35,807.24 L-753.34,753.19 C-758.47,713.52 -733.82,706.38 -724.59,710.22"/>
                 <g class="nad-edge-infos" transform="translate(-753.34,753.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.37)">
@@ -3695,10 +3693,10 @@
                         <text transform="rotate(-277.37)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-706.13" cy="717.92" r="20.00"/>
+                <circle class="nad-winding" cx="-706.13" cy="717.92" r="20.00"/>
             </g>
             <g class="nad-vl0to30-4">
-                <path d="M-698.97,798.84 L-679.50,783.97 C-647.71,759.69 -659.98,737.16 -669.21,733.31"/>
+                <path class="nad-edge-path" d="M-698.97,798.84 L-679.50,783.97 C-647.71,759.69 -659.98,737.16 -669.21,733.31"/>
                 <g class="nad-edge-infos" transform="translate(-679.50,783.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(52.63)">
@@ -3715,13 +3713,13 @@
                         <text transform="rotate(-37.37)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-687.67" cy="725.62" r="20.00"/>
+                <circle class="nad-winding" cx="-687.67" cy="725.62" r="20.00"/>
             </g>
         </g>
         <g id="177">
             <desc>L8-9-1</desc>
             <g class="nad-vl0to30-0">
-                <polyline points="-261.94,855.77 116.88,797.76"/>
+                <polyline class="nad-edge-path" points="-261.94,855.77 116.88,797.76"/>
                 <g class="nad-edge-infos" transform="translate(-229.81,850.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.29)">
@@ -3740,7 +3738,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30-0">
-                <polyline points="495.69,739.75 116.88,797.76"/>
+                <polyline class="nad-edge-path" points="495.69,739.75 116.88,797.76"/>
                 <g class="nad-edge-infos" transform="translate(463.57,744.67)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.71)">
@@ -3762,7 +3760,7 @@
         <g id="178">
             <desc>T9-55-1</desc>
             <g class="nad-vl0to30-0">
-                <path d="M599.57,757.38 L621.21,768.87 C656.54,787.62 648.11,811.86 639.63,817.17"/>
+                <path class="nad-edge-path" d="M599.57,757.38 L621.21,768.87 C656.54,787.62 648.11,811.86 639.63,817.17"/>
                 <g class="nad-edge-infos" transform="translate(621.21,768.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.97)">
@@ -3779,10 +3777,10 @@
                         <text transform="rotate(27.97)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="622.68" cy="827.77" r="20.00"/>
+                <circle class="nad-winding" cx="622.68" cy="827.77" r="20.00"/>
             </g>
             <g class="nad-vl0to30-4">
-                <path d="M551.46,756.84 L553.39,811.30 C554.81,851.28 580.29,854.30 588.77,848.99"/>
+                <path class="nad-edge-path" d="M551.46,756.84 L553.39,811.30 C554.81,851.28 580.29,854.30 588.77,848.99"/>
                 <g class="nad-edge-infos" transform="translate(553.39,811.30)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(177.97)">
@@ -3799,7 +3797,7 @@
                         <text transform="rotate(87.97)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="605.73" cy="838.38" r="20.00"/>
+                <circle class="nad-winding" cx="605.73" cy="838.38" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/current_limits.svg
+++ b/src/test/resources/current_limits.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/current_limits.svg
+++ b/src/test/resources/current_limits.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4" class="nad-overload">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(119.59,-46.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -94,7 +92,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-44.74,125.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="-1600.60 -842.67 2972.09 1631.71" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -107,55 +105,55 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1079.96,333.71)" id="0" class="nad-vl180to300">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-1400.60,110.15)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-652.84,449.89)" id="4" class="nad-vl180to300">
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(1071.49,-357.56)" id="6" class="nad-vl0to30">
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(-133.04,361.83)" id="8" class="nad-vl180to300">
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(696.57,-44.99)" id="10" class="nad-vl50to70">
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(394.71,18.56)" id="12" class="nad-vl0to30">
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(890.04,196.72)" id="14" class="nad-vl50to70">
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(388.39,-480.46)" id="16" class="nad-vl0to30">
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(27.07,-527.58)" id="18" class="nad-vl0to30">
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(-353.26,-627.67)" id="20" class="nad-vl0to30">
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(-201.99,-255.59)" id="22" class="nad-vl0to30">
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(36.97,46.15)" id="24" class="nad-vl0to30">
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(197.15,589.04)" id="26" class="nad-vl0to30">
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
         <g transform="translate(531.12,540.93)" id="28" class="nad-vl0to30">
-            <circle r="27.50" id="29"/>
+            <circle class="nad-busnode" r="27.50" id="29"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="30">
             <g class="nad-vl180to300">
-                <polyline points="-1055.35,340.40 -866.40,391.80"/>
+                <polyline class="nad-edge-path" points="-1055.35,340.40 -866.40,391.80"/>
                 <g class="nad-edge-infos" transform="translate(-1023.99,348.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.22)">
@@ -174,7 +172,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-677.45,443.20 -866.40,391.80"/>
+                <polyline class="nad-edge-path" points="-677.45,443.20 -866.40,391.80"/>
                 <g class="nad-edge-infos" transform="translate(-708.81,434.66)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.78)">
@@ -195,7 +193,7 @@
         </g>
         <g id="31">
             <g class="nad-vl300to500">
-                <polyline points="-1379.68,124.73 -1264.89,204.77"/>
+                <polyline class="nad-edge-path" points="-1379.68,124.73 -1264.89,204.77"/>
                 <g class="nad-edge-infos" transform="translate(-1353.02,143.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(124.88)">
@@ -212,10 +210,10 @@
                         <text transform="rotate(34.88)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1248.48" cy="216.21" r="20.00"/>
+                <circle class="nad-winding" cx="-1248.48" cy="216.21" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-1100.88,319.12 -1215.67,239.09"/>
+                <polyline class="nad-edge-path" points="-1100.88,319.12 -1215.67,239.09"/>
                 <g class="nad-edge-infos" transform="translate(-1127.53,300.54)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-55.12)">
@@ -232,12 +230,12 @@
                         <text transform="rotate(-325.12)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1232.08" cy="227.65" r="20.00"/>
+                <circle class="nad-winding" cx="-1232.08" cy="227.65" r="20.00"/>
             </g>
         </g>
         <g id="32">
             <g class="nad-vl180to300">
-                <polyline points="-627.70,445.63 -392.94,405.86"/>
+                <polyline class="nad-edge-path" points="-627.70,445.63 -392.94,405.86"/>
                 <g class="nad-edge-infos" transform="translate(-595.66,440.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(80.39)">
@@ -256,7 +254,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-158.18,366.09 -392.94,405.86"/>
+                <polyline class="nad-edge-path" points="-158.18,366.09 -392.94,405.86"/>
                 <g class="nad-edge-infos" transform="translate(-190.22,371.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-99.61)">
@@ -277,7 +275,7 @@
         </g>
         <g id="33">
             <g class="nad-vl50to70">
-                <polyline points="716.16,-61.32 860.99,-182.07"/>
+                <polyline class="nad-edge-path" points="716.16,-61.32 860.99,-182.07"/>
                 <g class="nad-edge-infos" transform="translate(741.12,-82.13)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(50.18)">
@@ -294,10 +292,10 @@
                         <text transform="rotate(-39.82)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="876.35" cy="-194.88" r="20.00"/>
+                <circle class="nad-winding" cx="876.35" cy="-194.88" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1051.91,-341.24 907.07,-220.49"/>
+                <polyline class="nad-edge-path" points="1051.91,-341.24 907.07,-220.49"/>
                 <g class="nad-edge-infos" transform="translate(1026.95,-320.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-129.82)">
@@ -314,12 +312,12 @@
                         <text transform="rotate(-39.82)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="891.71" cy="-207.68" r="20.00"/>
+                <circle class="nad-winding" cx="891.71" cy="-207.68" r="20.00"/>
             </g>
         </g>
         <g id="34">
             <g class="nad-vl180to300">
-                <polyline points="-110.14,350.60 254.83,171.63"/>
+                <polyline class="nad-edge-path" points="-110.14,350.60 254.83,171.63"/>
                 <g class="nad-edge-infos" transform="translate(-80.96,336.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.88)">
@@ -336,10 +334,10 @@
                         <text transform="rotate(-26.12)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="272.79" cy="162.82" r="20.00"/>
+                <circle class="nad-winding" cx="272.79" cy="162.82" r="20.00"/>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="673.67,-33.76 308.70,145.21"/>
+                <polyline class="nad-edge-path" points="673.67,-33.76 308.70,145.21"/>
                 <g class="nad-edge-infos" transform="translate(644.49,-19.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.12)">
@@ -356,12 +354,12 @@
                         <text transform="rotate(-26.12)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="290.75" cy="154.02" r="20.00"/>
+                <circle class="nad-winding" cx="290.75" cy="154.02" r="20.00"/>
             </g>
         </g>
         <g id="35">
             <g class="nad-vl50to70">
-                <polyline points="712.50,-25.08 793.31,75.87"/>
+                <polyline class="nad-edge-path" points="712.50,-25.08 793.31,75.87"/>
                 <g class="nad-edge-infos" transform="translate(732.81,0.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(141.33)">
@@ -380,7 +378,7 @@
                 </g>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="874.11,176.81 793.31,75.87"/>
+                <polyline class="nad-edge-path" points="874.11,176.81 793.31,75.87"/>
                 <g class="nad-edge-infos" transform="translate(853.80,151.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-38.67)">
@@ -401,7 +399,7 @@
         </g>
         <g id="36">
             <g class="nad-vl0to30">
-                <polyline points="394.38,-6.93 391.55,-230.95"/>
+                <polyline class="nad-edge-path" points="394.38,-6.93 391.55,-230.95"/>
                 <g class="nad-edge-infos" transform="translate(393.97,-39.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.72)">
@@ -420,7 +418,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="388.72,-454.96 391.55,-230.95"/>
+                <polyline class="nad-edge-path" points="388.72,-454.96 391.55,-230.95"/>
                 <g class="nad-edge-infos" transform="translate(389.13,-422.46)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.28)">
@@ -441,7 +439,7 @@
         </g>
         <g id="37">
             <g class="nad-vl0to30">
-                <polyline points="-178.82,-244.94 96.36,-118.51"/>
+                <polyline class="nad-edge-path" points="-178.82,-244.94 96.36,-118.51"/>
                 <g class="nad-edge-infos" transform="translate(-149.28,-231.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(114.68)">
@@ -460,7 +458,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="371.54,7.92 96.36,-118.51"/>
+                <polyline class="nad-edge-path" points="371.54,7.92 96.36,-118.51"/>
                 <g class="nad-edge-infos" transform="translate(342.00,-5.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-65.32)">
@@ -481,7 +479,7 @@
         </g>
         <g id="38">
             <g class="nad-vl0to30">
-                <polyline points="524.68,516.26 462.91,279.75"/>
+                <polyline class="nad-edge-path" points="524.68,516.26 462.91,279.75"/>
                 <g class="nad-edge-infos" transform="translate(516.46,484.81)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.64)">
@@ -500,7 +498,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="401.15,43.24 462.91,279.75"/>
+                <polyline class="nad-edge-path" points="401.15,43.24 462.91,279.75"/>
                 <g class="nad-edge-infos" transform="translate(409.36,74.68)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.36)">
@@ -521,7 +519,7 @@
         </g>
         <g id="39">
             <g class="nad-vl50to70">
-                <polyline points="866.05,188.09 670.61,117.80"/>
+                <polyline class="nad-edge-path" points="866.05,188.09 670.61,117.80"/>
                 <g class="nad-edge-infos" transform="translate(835.47,177.09)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-70.22)">
@@ -538,10 +536,10 @@
                         <text transform="rotate(-340.22)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="651.79" cy="111.03" r="20.00"/>
+                <circle class="nad-winding" cx="651.79" cy="111.03" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="418.70,27.19 614.15,97.49"/>
+                <polyline class="nad-edge-path" points="418.70,27.19 614.15,97.49"/>
                 <g class="nad-edge-infos" transform="translate(449.28,38.19)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(109.78)">
@@ -558,12 +556,12 @@
                         <text transform="rotate(19.78)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="632.97" cy="104.26" r="20.00"/>
+                <circle class="nad-winding" cx="632.97" cy="104.26" r="20.00"/>
             </g>
         </g>
         <g id="40">
             <g class="nad-vl0to30">
-                <polyline points="363.11,-483.75 207.73,-504.02"/>
+                <polyline class="nad-edge-path" points="363.11,-483.75 207.73,-504.02"/>
                 <g class="nad-edge-infos" transform="translate(330.88,-487.96)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.57)">
@@ -582,7 +580,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="52.35,-524.28 207.73,-504.02"/>
+                <polyline class="nad-edge-path" points="52.35,-524.28 207.73,-504.02"/>
                 <g class="nad-edge-infos" transform="translate(84.58,-520.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.43)">
@@ -603,7 +601,7 @@
         </g>
         <g id="41">
             <g class="nad-vl0to30">
-                <polyline points="2.41,-534.07 -163.09,-577.62"/>
+                <polyline class="nad-edge-path" points="2.41,-534.07 -163.09,-577.62"/>
                 <g class="nad-edge-infos" transform="translate(-29.02,-542.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.26)">
@@ -622,7 +620,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-328.60,-621.18 -163.09,-577.62"/>
+                <polyline class="nad-edge-path" points="-328.60,-621.18 -163.09,-577.62"/>
                 <g class="nad-edge-infos" transform="translate(-297.17,-612.91)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.74)">
@@ -643,7 +641,7 @@
         </g>
         <g id="42">
             <g class="nad-vl0to30">
-                <polyline points="27.51,-502.09 32.02,-240.72"/>
+                <polyline class="nad-edge-path" points="27.51,-502.09 32.02,-240.72"/>
                 <g class="nad-edge-infos" transform="translate(28.07,-469.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(179.01)">
@@ -662,7 +660,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="36.53,20.65 32.02,-240.72"/>
+                <polyline class="nad-edge-path" points="36.53,20.65 32.02,-240.72"/>
                 <g class="nad-edge-infos" transform="translate(35.97,-11.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-0.99)">
@@ -683,7 +681,7 @@
         </g>
         <g id="43">
             <g class="nad-vl0to30">
-                <polyline points="-343.65,-604.04 -277.62,-441.63"/>
+                <polyline class="nad-edge-path" points="-343.65,-604.04 -277.62,-441.63"/>
                 <g class="nad-edge-infos" transform="translate(-331.41,-573.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(157.88)">
@@ -702,7 +700,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-211.59,-279.21 -277.62,-441.63"/>
+                <polyline class="nad-edge-path" points="-211.59,-279.21 -277.62,-441.63"/>
                 <g class="nad-edge-infos" transform="translate(-223.83,-309.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-22.12)">
@@ -723,7 +721,7 @@
         </g>
         <g id="44">
             <g class="nad-vl0to30">
-                <polyline points="44.18,70.60 117.06,317.59"/>
+                <polyline class="nad-edge-path" points="44.18,70.60 117.06,317.59"/>
                 <g class="nad-edge-infos" transform="translate(53.38,101.78)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(163.56)">
@@ -742,7 +740,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="189.93,564.58 117.06,317.59"/>
+                <polyline class="nad-edge-path" points="189.93,564.58 117.06,317.59"/>
                 <g class="nad-edge-infos" transform="translate(180.73,533.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-16.44)">
@@ -763,7 +761,7 @@
         </g>
         <g id="45">
             <g class="nad-vl0to30">
-                <polyline points="222.39,585.40 364.13,564.99"/>
+                <polyline class="nad-edge-path" points="222.39,585.40 364.13,564.99"/>
                 <g class="nad-edge-infos" transform="translate(254.55,580.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(81.80)">
@@ -782,7 +780,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="505.88,544.57 364.13,564.99"/>
+                <polyline class="nad-edge-path" points="505.88,544.57 364.13,564.99"/>
                 <g class="nad-edge-infos" transform="translate(473.71,549.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-98.20)">

--- a/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.0.svg
@@ -105,49 +105,49 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1079.96,333.71)" id="0" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-1400.60,110.15)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-652.84,449.89)" id="4" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(1071.49,-357.56)" id="6" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-133.04,361.83)" id="8" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(696.57,-44.99)" id="10" class="nad-vl50to70">
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(394.71,18.56)" id="12" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(890.04,196.72)" id="14" class="nad-vl50to70">
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(388.39,-480.46)" id="16" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(27.07,-527.58)" id="18" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(-353.26,-627.67)" id="20" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(-201.99,-255.59)" id="22" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(36.97,46.15)" id="24" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(197.15,589.04)" id="26" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
         <g transform="translate(531.12,540.93)" id="28" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="29"/>
+            <circle r="27.50" id="29" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -105,49 +105,49 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1786.74,291.69)" id="0" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-2026.74,-33.30)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(-1451.50,634.69)" id="4" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(-556.38,362.32)" id="6" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(-1004.67,862.59)" id="8" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
         <g transform="translate(-454.23,759.76)" id="10" class="nad-vl50to70">
-            <circle class="nad-busnode" r="27.50" id="11"/>
+            <circle r="27.50" id="11" class="nad-busnode"/>
         </g>
         <g transform="translate(505.49,118.48)" id="12" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="13"/>
+            <circle r="27.50" id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(112.38,611.74)" id="14" class="nad-vl50to70">
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(717.25,-362.96)" id="16" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(819.43,-857.64)" id="18" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(268.32,-888.64)" id="20" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
         <g transform="translate(110.95,-398.21)" id="22" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="23"/>
+            <circle r="27.50" id="23" class="nad-busnode"/>
         </g>
         <g transform="translate(1359.11,-706.74)" id="24" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="25"/>
+            <circle r="27.50" id="25" class="nad-busnode"/>
         </g>
         <g transform="translate(1491.86,-198.36)" id="26" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="27"/>
+            <circle r="27.50" id="27" class="nad-busnode"/>
         </g>
         <g transform="translate(1137.19,196.56)" id="28" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="29"/>
+            <circle r="27.50" id="29" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
+++ b/src/test/resources/diamond-spring-repulsion-factor-0.2.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg viewBox="-2226.74 -1103.64 4018.60 2166.23" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -107,55 +105,55 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-1786.74,291.69)" id="0" class="nad-vl180to300">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-2026.74,-33.30)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(-1451.50,634.69)" id="4" class="nad-vl180to300">
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(-556.38,362.32)" id="6" class="nad-vl0to30">
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(-1004.67,862.59)" id="8" class="nad-vl180to300">
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
         <g transform="translate(-454.23,759.76)" id="10" class="nad-vl50to70">
-            <circle r="27.50" id="11"/>
+            <circle class="nad-busnode" r="27.50" id="11"/>
         </g>
         <g transform="translate(505.49,118.48)" id="12" class="nad-vl0to30">
-            <circle r="27.50" id="13"/>
+            <circle class="nad-busnode" r="27.50" id="13"/>
         </g>
         <g transform="translate(112.38,611.74)" id="14" class="nad-vl50to70">
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(717.25,-362.96)" id="16" class="nad-vl0to30">
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(819.43,-857.64)" id="18" class="nad-vl0to30">
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(268.32,-888.64)" id="20" class="nad-vl0to30">
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
         <g transform="translate(110.95,-398.21)" id="22" class="nad-vl0to30">
-            <circle r="27.50" id="23"/>
+            <circle class="nad-busnode" r="27.50" id="23"/>
         </g>
         <g transform="translate(1359.11,-706.74)" id="24" class="nad-vl0to30">
-            <circle r="27.50" id="25"/>
+            <circle class="nad-busnode" r="27.50" id="25"/>
         </g>
         <g transform="translate(1491.86,-198.36)" id="26" class="nad-vl0to30">
-            <circle r="27.50" id="27"/>
+            <circle class="nad-busnode" r="27.50" id="27"/>
         </g>
         <g transform="translate(1137.19,196.56)" id="28" class="nad-vl0to30">
-            <circle r="27.50" id="29"/>
+            <circle class="nad-busnode" r="27.50" id="29"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="30">
             <g class="nad-vl180to300">
-                <polyline points="-1768.92,309.92 -1619.12,463.19"/>
+                <polyline class="nad-edge-path" points="-1768.92,309.92 -1619.12,463.19"/>
                 <g class="nad-edge-infos" transform="translate(-1746.20,333.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(135.65)">
@@ -174,7 +172,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-1469.32,616.45 -1619.12,463.19"/>
+                <polyline class="nad-edge-path" points="-1469.32,616.45 -1619.12,463.19"/>
                 <g class="nad-edge-infos" transform="translate(-1492.04,593.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-44.35)">
@@ -195,7 +193,7 @@
         </g>
         <g id="31">
             <g class="nad-vl300to500">
-                <polyline points="-2011.59,-12.79 -1924.56,105.06"/>
+                <polyline class="nad-edge-path" points="-2011.59,-12.79 -1924.56,105.06"/>
                 <g class="nad-edge-infos" transform="translate(-1992.28,13.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(143.55)">
@@ -212,10 +210,10 @@
                         <text transform="rotate(53.55)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-1912.68" cy="121.15" r="20.00"/>
+                <circle class="nad-winding" cx="-1912.68" cy="121.15" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-1801.89,271.17 -1888.92,153.33"/>
+                <polyline class="nad-edge-path" points="-1801.89,271.17 -1888.92,153.33"/>
                 <g class="nad-edge-infos" transform="translate(-1821.20,245.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-36.45)">
@@ -232,12 +230,12 @@
                         <text transform="rotate(-306.45)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-1900.80" cy="137.24" r="20.00"/>
+                <circle class="nad-winding" cx="-1900.80" cy="137.24" r="20.00"/>
             </g>
         </g>
         <g id="32">
             <g class="nad-vl180to300">
-                <polyline points="-1428.78,646.27 -1228.08,748.64"/>
+                <polyline class="nad-edge-path" points="-1428.78,646.27 -1228.08,748.64"/>
                 <g class="nad-edge-infos" transform="translate(-1399.83,661.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(117.02)">
@@ -256,7 +254,7 @@
                 </g>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-1027.38,851.00 -1228.08,748.64"/>
+                <polyline class="nad-edge-path" points="-1027.38,851.00 -1228.08,748.64"/>
                 <g class="nad-edge-infos" transform="translate(-1056.34,836.23)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-62.98)">
@@ -277,7 +275,7 @@
         </g>
         <g id="33">
             <g class="nad-vl50to70">
-                <polyline points="-460.57,735.07 -497.83,590.10"/>
+                <polyline class="nad-edge-path" points="-460.57,735.07 -497.83,590.10"/>
                 <g class="nad-edge-infos" transform="translate(-468.66,703.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.41)">
@@ -294,10 +292,10 @@
                         <text transform="rotate(-284.41)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-502.81" cy="570.73" r="20.00"/>
+                <circle class="nad-winding" cx="-502.81" cy="570.73" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="-550.03,387.02 -512.77,531.99"/>
+                <polyline class="nad-edge-path" points="-550.03,387.02 -512.77,531.99"/>
                 <g class="nad-edge-infos" transform="translate(-541.94,418.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.59)">
@@ -314,12 +312,12 @@
                         <text transform="rotate(75.59)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-507.79" cy="551.36" r="20.00"/>
+                <circle class="nad-winding" cx="-507.79" cy="551.36" r="20.00"/>
             </g>
         </g>
         <g id="34">
             <g class="nad-vl180to300">
-                <polyline points="-979.60,857.90 -758.94,816.68"/>
+                <polyline class="nad-edge-path" points="-979.60,857.90 -758.94,816.68"/>
                 <g class="nad-edge-infos" transform="translate(-947.65,851.94)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(79.42)">
@@ -336,10 +334,10 @@
                         <text transform="rotate(-10.58)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-739.28" cy="813.01" r="20.00"/>
+                <circle class="nad-winding" cx="-739.28" cy="813.01" r="20.00"/>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="-479.29,764.45 -699.96,805.67"/>
+                <polyline class="nad-edge-path" points="-479.29,764.45 -699.96,805.67"/>
                 <g class="nad-edge-infos" transform="translate(-511.24,770.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-100.58)">
@@ -356,12 +354,12 @@
                         <text transform="rotate(-10.58)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-719.62" cy="809.34" r="20.00"/>
+                <circle class="nad-winding" cx="-719.62" cy="809.34" r="20.00"/>
             </g>
         </g>
         <g id="35">
             <g class="nad-vl50to70">
-                <polyline points="-429.55,753.32 -170.92,685.75"/>
+                <polyline class="nad-edge-path" points="-429.55,753.32 -170.92,685.75"/>
                 <g class="nad-edge-infos" transform="translate(-398.11,745.10)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(75.36)">
@@ -380,7 +378,7 @@
                 </g>
             </g>
             <g class="nad-vl50to70">
-                <polyline points="87.71,618.18 -170.92,685.75"/>
+                <polyline class="nad-edge-path" points="87.71,618.18 -170.92,685.75"/>
                 <g class="nad-edge-infos" transform="translate(56.26,626.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-104.64)">
@@ -401,7 +399,7 @@
         </g>
         <g id="36">
             <g class="nad-vl0to30">
-                <polyline points="515.76,95.14 611.37,-122.24"/>
+                <polyline class="nad-edge-path" points="515.76,95.14 611.37,-122.24"/>
                 <g class="nad-edge-infos" transform="translate(528.85,65.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(23.74)">
@@ -420,7 +418,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="706.98,-339.61 611.37,-122.24"/>
+                <polyline class="nad-edge-path" points="706.98,-339.61 611.37,-122.24"/>
                 <g class="nad-edge-infos" transform="translate(693.90,-309.86)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-156.26)">
@@ -441,7 +439,7 @@
         </g>
         <g id="37">
             <g class="nad-vl0to30">
-                <polyline points="126.42,-377.94 308.22,-139.86"/>
+                <polyline class="nad-edge-path" points="126.42,-377.94 308.22,-139.86"/>
                 <g class="nad-edge-infos" transform="translate(146.15,-352.11)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(142.63)">
@@ -460,7 +458,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="490.02,98.21 308.22,-139.86"/>
+                <polyline class="nad-edge-path" points="490.02,98.21 308.22,-139.86"/>
                 <g class="nad-edge-infos" transform="translate(470.29,72.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-37.37)">
@@ -481,7 +479,7 @@
         </g>
         <g id="38">
             <g class="nad-vl0to30">
-                <polyline points="1111.89,193.44 821.34,157.52"/>
+                <polyline class="nad-edge-path" points="1111.89,193.44 821.34,157.52"/>
                 <g class="nad-edge-infos" transform="translate(1079.63,189.45)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-82.95)">
@@ -500,7 +498,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="530.80,121.61 821.34,157.52"/>
+                <polyline class="nad-edge-path" points="530.80,121.61 821.34,157.52"/>
                 <g class="nad-edge-infos" transform="translate(563.06,125.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(97.05)">
@@ -521,7 +519,7 @@
         </g>
         <g id="39">
             <g class="nad-vl50to70">
-                <polyline points="128.27,591.80 290.24,388.57"/>
+                <polyline class="nad-edge-path" points="128.27,591.80 290.24,388.57"/>
                 <g class="nad-edge-infos" transform="translate(148.53,566.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(38.55)">
@@ -538,10 +536,10 @@
                         <text transform="rotate(-51.45)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="302.70" cy="372.93" r="20.00"/>
+                <circle class="nad-winding" cx="302.70" cy="372.93" r="20.00"/>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="489.60,138.42 327.63,341.65"/>
+                <polyline class="nad-edge-path" points="489.60,138.42 327.63,341.65"/>
                 <g class="nad-edge-infos" transform="translate(469.34,163.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-141.45)">
@@ -558,12 +556,12 @@
                         <text transform="rotate(-51.45)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="315.17" cy="357.29" r="20.00"/>
+                <circle class="nad-winding" cx="315.17" cy="357.29" r="20.00"/>
             </g>
         </g>
         <g id="40">
             <g class="nad-vl0to30">
-                <polyline points="722.41,-387.93 768.34,-610.30"/>
+                <polyline class="nad-edge-path" points="722.41,-387.93 768.34,-610.30"/>
                 <g class="nad-edge-infos" transform="translate(728.98,-419.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.67)">
@@ -582,7 +580,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="814.27,-832.67 768.34,-610.30"/>
+                <polyline class="nad-edge-path" points="814.27,-832.67 768.34,-610.30"/>
                 <g class="nad-edge-infos" transform="translate(807.70,-800.84)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.33)">
@@ -603,7 +601,7 @@
         </g>
         <g id="41">
             <g class="nad-vl0to30">
-                <polyline points="793.97,-859.08 543.88,-873.14"/>
+                <polyline class="nad-edge-path" points="793.97,-859.08 543.88,-873.14"/>
                 <g class="nad-edge-infos" transform="translate(761.52,-860.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-86.78)">
@@ -622,7 +620,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="293.78,-887.21 543.88,-873.14"/>
+                <polyline class="nad-edge-path" points="293.78,-887.21 543.88,-873.14"/>
                 <g class="nad-edge-infos" transform="translate(326.23,-885.39)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(93.22)">
@@ -643,7 +641,7 @@
         </g>
         <g id="42">
             <g class="nad-vl0to30">
-                <polyline points="843.99,-850.78 1089.27,-782.19"/>
+                <polyline class="nad-edge-path" points="843.99,-850.78 1089.27,-782.19"/>
                 <g class="nad-edge-infos" transform="translate(875.29,-842.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(105.62)">
@@ -662,7 +660,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1334.55,-713.61 1089.27,-782.19"/>
+                <polyline class="nad-edge-path" points="1334.55,-713.61 1089.27,-782.19"/>
                 <g class="nad-edge-infos" transform="translate(1303.25,-722.36)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-74.38)">
@@ -683,7 +681,7 @@
         </g>
         <g id="43">
             <g class="nad-vl0to30">
-                <polyline points="260.53,-864.36 189.63,-643.42"/>
+                <polyline class="nad-edge-path" points="260.53,-864.36 189.63,-643.42"/>
                 <g class="nad-edge-infos" transform="translate(250.60,-833.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-162.21)">
@@ -702,7 +700,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="118.74,-422.49 189.63,-643.42"/>
+                <polyline class="nad-edge-path" points="118.74,-422.49 189.63,-643.42"/>
                 <g class="nad-edge-infos" transform="translate(128.67,-453.43)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(17.79)">
@@ -723,7 +721,7 @@
         </g>
         <g id="44">
             <g class="nad-vl0to30">
-                <polyline points="1365.55,-682.07 1425.49,-452.55"/>
+                <polyline class="nad-edge-path" points="1365.55,-682.07 1425.49,-452.55"/>
                 <g class="nad-edge-infos" transform="translate(1373.77,-650.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(165.37)">
@@ -742,7 +740,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1485.42,-223.03 1425.49,-452.55"/>
+                <polyline class="nad-edge-path" points="1485.42,-223.03 1425.49,-452.55"/>
                 <g class="nad-edge-infos" transform="translate(1477.21,-254.47)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-14.63)">
@@ -763,7 +761,7 @@
         </g>
         <g id="45">
             <g class="nad-vl0to30">
-                <polyline points="1474.82,-179.38 1314.53,-0.90"/>
+                <polyline class="nad-edge-path" points="1474.82,-179.38 1314.53,-0.90"/>
                 <g class="nad-edge-infos" transform="translate(1453.10,-155.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-138.07)">
@@ -782,7 +780,7 @@
                 </g>
             </g>
             <g class="nad-vl0to30">
-                <polyline points="1154.23,177.59 1314.53,-0.90"/>
+                <polyline class="nad-edge-path" points="1154.23,177.59 1314.53,-0.90"/>
                 <g class="nad-edge-infos" transform="translate(1175.95,153.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(41.93)">

--- a/src/test/resources/edge_info_double_labels.svg
+++ b/src/test/resources/edge_info_double_labels.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="691.36" viewBox="-398.78 -437.73 1153.52 996.87" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -69,19 +67,19 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>
     <g class="nad-3wt-edges">
         <g id="7" class="nad-vl0to30">
-            <polyline points="-180.89,-204.55 49.18,31.35"/>
+            <polyline class="nad-edge-path" points="-180.89,-204.55 49.18,31.35"/>
             <g class="nad-edge-infos" transform="translate(-137.25,-159.81)">
                 <g class="nad-state-in">
                     <g transform="rotate(135.72)">
@@ -94,7 +92,7 @@
             </g>
         </g>
         <g id="8" class="nad-vl120to180">
-            <polyline points="-163.72,339.48 65.60,84.29"/>
+            <polyline class="nad-edge-path" points="-163.72,339.48 65.60,84.29"/>
             <g class="nad-edge-infos" transform="translate(-121.94,292.99)">
                 <g class="nad-state-in">
                     <g transform="rotate(41.94)">
@@ -107,7 +105,7 @@
             </g>
         </g>
         <g id="9" class="nad-vl30to50">
-            <polyline points="430.38,-57.84 103.24,43.60"/>
+            <polyline class="nad-edge-path" points="430.38,-57.84 103.24,43.60"/>
             <g class="nad-edge-infos" transform="translate(370.69,-39.33)">
                 <g class="nad-state-in">
                     <g transform="rotate(-107.23)">
@@ -122,9 +120,9 @@
     </g>
     <g class="nad-3wt-nodes">
         <g>
-            <circle class="nad-vl0to30" cx="63.86" cy="44.93" r="20.00"/>
-            <circle class="nad-vl120to180" cx="70.02" cy="64.79" r="20.00"/>
-            <circle class="nad-vl30to50" cx="84.13" cy="49.53" r="20.00"/>
+            <circle class="nad-vl0to30 nad-winding" cx="63.86" cy="44.93" r="20.00"/>
+            <circle class="nad-vl120to180 nad-winding" cx="70.02" cy="64.79" r="20.00"/>
+            <circle class="nad-vl30to50 nad-winding" cx="84.13" cy="49.53" r="20.00"/>
         </g>
     </g>
     <g class="nad-text-edges">

--- a/src/test/resources/edge_info_double_labels.svg
+++ b/src/test/resources/edge_info_double_labels.svg
@@ -67,13 +67,13 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-198.78,-222.73)" id="0" class="nad-vl0to30">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-179.95,359.14)" id="2" class="nad-vl120to180">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(454.74,-65.39)" id="4" class="nad-vl30to50">
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges"></g>

--- a/src/test/resources/edge_info_missing_label.svg
+++ b/src/test/resources/edge_info_missing_label.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/edge_info_missing_label.svg
+++ b/src/test/resources/edge_info_missing_label.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(133.38,-61.41)">
                     <g class="nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -86,7 +84,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-58.53,140.10)">
                     <g class="nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/edge_info_perpendicular_label.svg
+++ b/src/test/resources/edge_info_perpendicular_label.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/edge_info_perpendicular_label.svg
+++ b/src/test/resources/edge_info_perpendicular_label.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(105.79,-32.45)">
                     <g class="nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -88,7 +86,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-30.94,111.14)">
                     <g class="nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/edge_info_shift.svg
+++ b/src/test/resources/edge_info_shift.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="717.39" viewBox="-306.06 -354.87 838.58 751.99" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -73,21 +71,21 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-34.81,-139.87)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
-            <path d="M-43.666,37.411 A57.500,57.500 345.053 1 1 -32.539,47.407 L-15.615,28.503 A32.500,32.500 -333.556 1 0 -26.674,18.567 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
+            <path class="nad-busnode" d="M-43.666,37.411 A57.500,57.500 345.053 1 1 -32.539,47.407 L-15.615,28.503 A32.500,32.500 -333.556 1 0 -26.674,18.567 Z " id="2"/>
         </g>
         <g transform="translate(-106.06,197.12)" id="3" class="nad-vl300to500">
-            <circle r="27.50" id="4"/>
+            <circle class="nad-busnode" r="27.50" id="4"/>
         </g>
         <g transform="translate(232.52,76.75)" id="5" class="nad-vl180to300">
-            <circle r="27.50" id="6"/>
-            <path d="M-39.586,-41.704 A57.500,57.500 345.053 1 1 -49.003,-30.083 L-29.261,-14.143 A32.500,32.500 -333.556 1 0 -19.901,-25.694 Z " id="7"/>
+            <circle class="nad-busnode" r="27.50" id="6"/>
+            <path class="nad-busnode" d="M-39.586,-41.704 A57.500,57.500 345.053 1 1 -49.003,-30.083 L-29.261,-14.143 A32.500,32.500 -333.556 1 0 -19.901,-25.694 Z " id="7"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="8">
             <g class="nad-vl300to500">
-                <polyline points="-51.86,-120.91 -88.28,-80.37 -109.57,20.35"/>
+                <polyline class="nad-edge-path" points="-51.86,-120.91 -88.28,-80.37 -109.57,20.35"/>
                 <g class="nad-edge-infos" transform="translate(-92.42,-60.80)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
@@ -106,7 +104,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-113.97,172.88 -130.87,121.06 -109.57,20.35"/>
+                <polyline class="nad-edge-path" points="-113.97,172.88 -130.87,121.06 -109.57,20.35"/>
                 <g class="nad-edge-infos" transform="translate(-126.73,101.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
@@ -127,7 +125,7 @@
         </g>
         <g id="9">
             <g class="nad-vl300to500">
-                <polyline points="-17.61,-87.11 -10.01,-63.82 -31.30,36.90"/>
+                <polyline class="nad-edge-path" points="-17.61,-87.11 -10.01,-63.82 -31.30,36.90"/>
                 <g class="nad-edge-infos" transform="translate(-14.15,-44.25)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-168.06)">
@@ -146,7 +144,7 @@
                 </g>
             </g>
             <g class="nad-disconnected nad-vl300to500">
-                <polyline points="-89.02,178.15 -52.60,137.61 -31.30,36.90"/>
+                <polyline class="nad-edge-path" points="-89.02,178.15 -52.60,137.61 -31.30,36.90"/>
                 <g class="nad-edge-infos" transform="translate(-48.46,118.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(11.94)">
@@ -167,7 +165,7 @@
         </g>
         <g id="10">
             <g class="nad-vl300to500">
-                <polyline points="8.31,-104.93 87.20,-41.00"/>
+                <polyline class="nad-edge-path" points="8.31,-104.93 87.20,-41.00"/>
                 <g class="nad-edge-infos" transform="translate(25.79,-90.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(129.02)">
@@ -184,10 +182,10 @@
                         <text transform="rotate(39.02)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="102.74" cy="-28.41" r="20.00"/>
+                <circle class="nad-winding" cx="102.74" cy="-28.41" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="212.71,60.70 133.82,-3.23"/>
+                <polyline class="nad-edge-path" points="212.71,60.70 133.82,-3.23"/>
                 <g class="nad-edge-infos" transform="translate(171.92,27.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-50.98)">
@@ -204,12 +202,12 @@
                         <text transform="rotate(-320.98)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="118.28" cy="-15.82" r="20.00"/>
+                <circle class="nad-winding" cx="118.28" cy="-15.82" r="20.00"/>
             </g>
         </g>
         <g id="11">
             <g class="nad-vl300to500">
-                <polyline points="-82.04,188.58 20.83,152.01"/>
+                <polyline class="nad-edge-path" points="-82.04,188.58 20.83,152.01"/>
                 <g class="nad-edge-infos" transform="translate(-60.84,181.04)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(70.43)">
@@ -226,10 +224,10 @@
                         <text transform="rotate(-19.57)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="39.67" cy="145.31" r="20.00"/>
+                <circle class="nad-winding" cx="39.67" cy="145.31" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="180.23,95.34 77.36,131.91"/>
+                <polyline class="nad-edge-path" points="180.23,95.34 77.36,131.91"/>
                 <g class="nad-edge-infos" transform="translate(159.03,102.88)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-109.57)">
@@ -246,7 +244,7 @@
                         <text transform="rotate(-19.57)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="58.52" cy="138.61" r="20.00"/>
+                <circle class="nad-winding" cx="58.52" cy="138.61" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/edge_info_shift.svg
+++ b/src/test/resources/edge_info_shift.svg
@@ -71,15 +71,15 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(-34.81,-139.87)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
-            <path class="nad-busnode" d="M-43.666,37.411 A57.500,57.500 345.053 1 1 -32.539,47.407 L-15.615,28.503 A32.500,32.500 -333.556 1 0 -26.674,18.567 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M-43.666,37.411 A57.500,57.500 345.053 1 1 -32.539,47.407 L-15.615,28.503 A32.500,32.500 -333.556 1 0 -26.674,18.567 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-106.06,197.12)" id="3" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="4"/>
+            <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
         <g transform="translate(232.52,76.75)" id="5" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="6"/>
-            <path class="nad-busnode" d="M-39.586,-41.704 A57.500,57.500 345.053 1 1 -49.003,-30.083 L-29.261,-14.143 A32.500,32.500 -333.556 1 0 -19.901,-25.694 Z " id="7"/>
+            <circle r="27.50" id="6" class="nad-busnode"/>
+            <path d="M-39.586,-41.704 A57.500,57.500 345.053 1 1 -49.003,-30.083 L-29.261,-14.143 A32.500,32.500 -333.556 1 0 -19.901,-25.694 Z " id="7" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/hvdc-vl-depth-1.svg
+++ b/src/test/resources/hvdc-vl-depth-1.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="665.02" height="600.00" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -67,18 +65,18 @@
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
             <desc>VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
             <desc>VL2</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4" class="nad-hvdc-edge">
             <desc>HVDC</desc>
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(119.59,-46.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -97,7 +95,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-44.74,125.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/hvdc-vl-depth-1.svg
+++ b/src/test/resources/hvdc-vl-depth-1.svg
@@ -65,11 +65,11 @@
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
             <desc>VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
             <desc>VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="401.42" viewBox="-772.51 -434.74 1706.26 856.15" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -77,30 +75,30 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-572.51,61.14)" id="0" class="nad-vl180to300">
             <desc>S1VL1</desc>
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-168.80,45.83)" id="2" class="nad-vl300to500">
             <desc>S1VL2</desc>
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
         <g transform="translate(73.32,-219.74)" id="4" class="nad-vl300to500">
             <desc>S2VL1</desc>
-            <circle r="27.50" id="5"/>
+            <circle class="nad-busnode" r="27.50" id="5"/>
         </g>
         <g transform="translate(250.50,93.81)" id="6" class="nad-vl300to500">
             <desc>S3VL1</desc>
-            <circle r="27.50" id="7"/>
+            <circle class="nad-busnode" r="27.50" id="7"/>
         </g>
         <g transform="translate(633.74,221.41)" id="8" class="nad-vl300to500">
             <desc>S4VL1</desc>
-            <circle r="27.50" id="9"/>
+            <circle class="nad-busnode" r="27.50" id="9"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="10">
             <desc>TWT</desc>
             <g class="nad-vl180to300">
-                <polyline points="-547.03,60.17 -400.64,54.62"/>
+                <polyline class="nad-edge-path" points="-547.03,60.17 -400.64,54.62"/>
                 <g class="nad-edge-infos" transform="translate(-514.56,58.94)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(87.83)">
@@ -117,10 +115,10 @@
                         <text transform="rotate(-2.17)" x="19.00">-10</text>
                     </g>
                 </g>
-                <circle cx="-380.65" cy="53.86" r="20.00"/>
+                <circle class="nad-winding" cx="-380.65" cy="53.86" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-194.28,46.80 -340.68,52.35"/>
+                <polyline class="nad-edge-path" points="-194.28,46.80 -340.68,52.35"/>
                 <g class="nad-edge-infos" transform="translate(-226.76,48.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-92.17)">
@@ -137,13 +135,13 @@
                         <text transform="rotate(-2.17)" x="-19.00" style="text-anchor:end">5</text>
                     </g>
                 </g>
-                <circle cx="-360.67" cy="53.11" r="20.00"/>
+                <circle class="nad-winding" cx="-360.67" cy="53.11" r="20.00"/>
             </g>
         </g>
         <g id="11" class="nad-hvdc-edge">
             <desc>HVDC1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-151.62,26.99 -47.74,-86.96"/>
+                <polyline class="nad-edge-path" points="-151.62,26.99 -47.74,-86.96"/>
                 <g class="nad-edge-infos" transform="translate(-129.73,2.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(42.36)">
@@ -162,7 +160,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="56.14,-200.90 -47.74,-86.96"/>
+                <polyline class="nad-edge-path" points="56.14,-200.90 -47.74,-86.96"/>
                 <g class="nad-edge-infos" transform="translate(34.25,-176.88)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-137.64)">
@@ -185,7 +183,7 @@
         <g id="12" class="nad-hvdc-edge">
             <desc>HVDC2</desc>
             <g class="nad-vl300to500">
-                <polyline points="-143.47,48.73 40.85,69.82"/>
+                <polyline class="nad-edge-path" points="-143.47,48.73 40.85,69.82"/>
                 <g class="nad-edge-infos" transform="translate(-111.18,52.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(96.53)">
@@ -204,7 +202,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="225.16,90.92 40.85,69.82"/>
+                <polyline class="nad-edge-path" points="225.16,90.92 40.85,69.82"/>
                 <g class="nad-edge-infos" transform="translate(192.87,87.22)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-83.47)">
@@ -227,7 +225,7 @@
         <g id="13">
             <desc>LINE_S2S3</desc>
             <g class="nad-vl300to500">
-                <polyline points="85.87,-197.54 161.91,-62.96"/>
+                <polyline class="nad-edge-path" points="85.87,-197.54 161.91,-62.96"/>
                 <g class="nad-edge-infos" transform="translate(101.86,-169.24)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(150.53)">
@@ -246,7 +244,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="237.95,71.61 161.91,-62.96"/>
+                <polyline class="nad-edge-path" points="237.95,71.61 161.91,-62.96"/>
                 <g class="nad-edge-infos" transform="translate(221.96,43.32)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-29.47)">
@@ -268,7 +266,7 @@
         <g id="14">
             <desc>LINE_S3S4</desc>
             <g class="nad-vl300to500">
-                <polyline points="274.69,101.87 442.12,157.61"/>
+                <polyline class="nad-edge-path" points="274.69,101.87 442.12,157.61"/>
                 <g class="nad-edge-infos" transform="translate(305.53,112.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(108.41)">
@@ -287,7 +285,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="609.55,213.35 442.12,157.61"/>
+                <polyline class="nad-edge-path" points="609.55,213.35 442.12,157.61"/>
                 <g class="nad-edge-infos" transform="translate(578.71,203.09)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-71.59)">

--- a/src/test/resources/hvdc.svg
+++ b/src/test/resources/hvdc.svg
@@ -75,23 +75,23 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-572.51,61.14)" id="0" class="nad-vl180to300">
             <desc>S1VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-168.80,45.83)" id="2" class="nad-vl300to500">
             <desc>S1VL2</desc>
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
         <g transform="translate(73.32,-219.74)" id="4" class="nad-vl300to500">
             <desc>S2VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="5"/>
+            <circle r="27.50" id="5" class="nad-busnode"/>
         </g>
         <g transform="translate(250.50,93.81)" id="6" class="nad-vl300to500">
             <desc>S3VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="7"/>
+            <circle r="27.50" id="7" class="nad-busnode"/>
         </g>
         <g transform="translate(633.74,221.41)" id="8" class="nad-vl300to500">
             <desc>S4VL1</desc>
-            <circle class="nad-busnode" r="27.50" id="9"/>
+            <circle r="27.50" id="9" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/parallel_transformers.svg
+++ b/src/test/resources/parallel_transformers.svg
@@ -66,11 +66,11 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
-            <path class="nad-busnode" d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="3" class="nad-vl180to300">
-            <circle class="nad-busnode" r="27.50" id="4"/>
+            <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/parallel_transformers.svg
+++ b/src/test/resources/parallel_transformers.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="372.16" height="335.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -68,17 +66,17 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
-            <path d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
+            <path class="nad-busnode" d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="3" class="nad-vl180to300">
-            <circle r="27.50" id="4"/>
+            <circle class="nad-busnode" r="27.50" id="4"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="5">
             <g class="nad-vl300to500">
-                <polyline points="135.12,-81.73 82.84,-66.34 29.15,-9.96"/>
+                <polyline class="nad-edge-path" points="135.12,-81.73 82.84,-66.34 29.15,-9.96"/>
                 <g class="nad-edge-infos" transform="translate(62.15,-44.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -95,10 +93,10 @@
                         <text transform="rotate(-46.40)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="15.36" cy="4.52" r="20.00"/>
+                <circle class="nad-winding" cx="15.36" cy="4.52" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-78.74,142.84 -65.92,89.87 -12.23,33.49"/>
+                <polyline class="nad-edge-path" points="-78.74,142.84 -65.92,89.87 -12.23,33.49"/>
                 <g class="nad-edge-infos" transform="translate(-45.23,68.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
@@ -115,12 +113,12 @@
                         <text transform="rotate(-46.40)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="1.56" cy="19.00" r="20.00"/>
+                <circle class="nad-winding" cx="1.56" cy="19.00" r="20.00"/>
             </g>
         </g>
         <g id="6">
             <g class="nad-vl300to500">
-                <polyline points="146.53,-34.99 140.77,-11.17 87.08,45.21"/>
+                <polyline class="nad-edge-path" points="146.53,-34.99 140.77,-11.17 87.08,45.21"/>
                 <g class="nad-edge-infos" transform="translate(120.08,10.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -137,10 +135,10 @@
                         <text transform="rotate(-46.40)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="73.29" cy="59.69" r="20.00"/>
+                <circle class="nad-winding" cx="73.29" cy="59.69" r="20.00"/>
             </g>
             <g class="nad-vl180to300">
-                <polyline points="-60.27,160.42 -7.99,145.04 45.70,88.66"/>
+                <polyline class="nad-edge-path" points="-60.27,160.42 -7.99,145.04 45.70,88.66"/>
                 <g class="nad-edge-infos" transform="translate(12.70,123.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
@@ -157,7 +155,7 @@
                         <text transform="rotate(-46.40)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="59.49" cy="74.17" r="20.00"/>
+                <circle class="nad-winding" cx="59.49" cy="74.17" r="20.00"/>
             </g>
         </g>
     </g>

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="886.58" viewBox="-754.05 -1018.45 1759.67 1950.10" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -102,52 +100,52 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle r="27.50" id="1"/>
-            <path d="M-10.013,56.621 A57.500,57.500 22.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -11.300 0 0 -8.837,31.276 Z M-42.578,38.644 A57.500,57.500 27.309 0 1 -55.562,14.803 L-30.409,11.470 A32.500,32.500 -15.811 0 0 -26.133,19.322 Z M-57.500,-0.029 A57.500,57.500 265.053 1 1 4.930,57.288 L6.016,31.938 A32.500,32.500 -253.556 1 0 -32.335,-3.272 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
+            <path class="nad-busnode" d="M-10.013,56.621 A57.500,57.500 22.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -11.300 0 0 -8.837,31.276 Z M-42.578,38.644 A57.500,57.500 27.309 0 1 -55.562,14.803 L-30.409,11.470 A32.500,32.500 -15.811 0 0 -26.133,19.322 Z M-57.500,-0.029 A57.500,57.500 265.053 1 1 4.930,57.288 L6.016,31.938 A32.500,32.500 -253.556 1 0 -32.335,-3.272 Z " id="2"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle r="27.50" id="4"/>
+            <circle class="nad-busnode" r="27.50" id="4"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle r="27.50" id="6"/>
+            <circle class="nad-busnode" r="27.50" id="6"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle r="27.50" id="8"/>
+            <circle class="nad-busnode" r="27.50" id="8"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle r="27.50" id="10"/>
+            <circle class="nad-busnode" r="27.50" id="10"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle r="27.50" id="12"/>
-            <path d="M-35.426,-45.291 A57.500,57.500 52.278 0 1 14.150,-55.732 L4.802,-32.143 A32.500,32.500 -40.780 0 0 -17.358,-27.476 Z M28.045,-50.197 A57.500,57.500 65.053 0 1 57.342,4.257 L32.489,-0.852 A32.500,32.500 -53.556 0 0 18.614,-26.641 Z M54.304,18.903 A57.500,57.500 197.829 1 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -186.331 1 0 29.469,13.705 Z " id="13"/>
+            <circle class="nad-busnode" r="27.50" id="12"/>
+            <path class="nad-busnode" d="M-35.426,-45.291 A57.500,57.500 52.278 0 1 14.150,-55.732 L4.802,-32.143 A32.500,32.500 -40.780 0 0 -17.358,-27.476 Z M28.045,-50.197 A57.500,57.500 65.053 0 1 57.342,4.257 L32.489,-0.852 A32.500,32.500 -53.556 0 0 18.614,-26.641 Z M54.304,18.903 A57.500,57.500 197.829 1 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -186.331 1 0 29.469,13.705 Z " id="13"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -166,7 +164,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -188,7 +186,7 @@
         <g id="23">
             <desc>BBE1AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M-499.52,-204.65 L-553.56,-197.59 C-593.23,-192.41 -589.68,-259.64 -562.63,-289.11"/>
+                <path class="nad-edge-path" d="M-499.52,-204.65 L-553.56,-197.59 C-593.23,-192.41 -589.68,-259.64 -562.63,-289.11"/>
                 <g class="nad-edge-infos" transform="translate(-553.56,-197.59)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-97.44)">
@@ -207,7 +205,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-471.76,-263.40 L-470.67,-287.87 C-468.89,-327.83 -535.58,-318.58 -562.63,-289.11"/>
+                <path class="nad-edge-path" d="M-471.76,-263.40 L-470.67,-287.87 C-468.89,-327.83 -535.58,-318.58 -562.63,-289.11"/>
                 <g class="nad-edge-infos" transform="translate(-470.67,-287.87)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(2.56)">
@@ -229,7 +227,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -248,7 +246,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -270,7 +268,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-167.61,-516.61 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-167.61,-516.61 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-190.52,-493.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
@@ -289,7 +287,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-435.12,-247.33 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-435.12,-247.33 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-412.22,-270.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -311,7 +309,7 @@
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-419.20,-215.15 L-394.91,-218.32 C-355.25,-223.50 -358.79,-156.26 -365.55,-148.90"/>
+                <path class="nad-edge-path" d="M-419.20,-215.15 L-394.91,-218.32 C-355.25,-223.50 -358.79,-156.26 -365.55,-148.90"/>
                 <g class="nad-edge-infos" transform="translate(-394.91,-218.32)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(82.56)">
@@ -328,10 +326,10 @@
                         <text transform="rotate(-7.44)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-379.08" cy="-134.16" r="20.00"/>
+                <circle class="nad-winding" cx="-379.08" cy="-134.16" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-475.37,-182.48 L-477.80,-128.03 C-479.59,-88.07 -412.89,-97.33 -406.13,-104.70"/>
+                <path class="nad-edge-path" d="M-475.37,-182.48 L-477.80,-128.03 C-479.59,-88.07 -412.89,-97.33 -406.13,-104.70"/>
                 <g class="nad-edge-infos" transform="translate(-477.80,-128.03)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-177.44)">
@@ -348,13 +346,13 @@
                         <text transform="rotate(-87.44)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-392.60" cy="-119.43" r="20.00"/>
+                <circle class="nad-winding" cx="-392.60" cy="-119.43" r="20.00"/>
             </g>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-543.38,254.41 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-543.38,254.41 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-529.78,283.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -373,7 +371,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-382.79,602.89 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-382.79,602.89 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-396.39,573.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
@@ -395,7 +393,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="688.22,255.53 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="688.22,255.53 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(666.04,231.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
@@ -414,7 +412,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="467.55,19.25 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="467.55,19.25 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(489.74,43.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -436,7 +434,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="682.74,285.42 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="682.74,285.42 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(653.58,299.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
@@ -455,7 +453,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="397.79,425.55 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="397.79,425.55 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(426.95,411.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -477,7 +475,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="445.81,25.75 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="445.81,25.75 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(440.29,57.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
@@ -496,7 +494,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="379.24,411.67 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="379.24,411.67 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(384.77,379.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -518,7 +516,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="439.74,-22.66 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="439.74,-22.66 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(426.46,-52.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
@@ -537,7 +535,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="262.40,-419.00 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="262.40,-419.00 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(275.68,-389.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -559,7 +557,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="78.24,695.20 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="78.24,695.20 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(102.75,673.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -578,7 +576,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="355.68,453.55 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="355.68,453.55 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(331.17,474.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
@@ -600,7 +598,7 @@
         <g id="33">
             <desc>FFR1AA1  FFR2AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M61.36,736.83 L114.72,747.90 C153.89,756.03 128.47,818.38 93.25,837.33"/>
+                <path class="nad-edge-path" d="M61.36,736.83 L114.72,747.90 C153.89,756.03 128.47,818.38 93.25,837.33"/>
                 <g class="nad-edge-infos" transform="translate(114.72,747.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(101.72)">
@@ -619,7 +617,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M15.85,783.21 L6.79,805.97 C-8.02,843.13 58.02,856.28 93.25,837.33"/>
+                <path class="nad-edge-path" d="M15.85,783.21 L6.79,805.97 C-8.02,843.13 58.02,856.28 93.25,837.33"/>
                 <g class="nad-edge-infos" transform="translate(6.79,805.97)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-158.28)">
@@ -641,7 +639,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -660,7 +658,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -682,7 +680,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -701,7 +699,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -723,7 +721,7 @@
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-17.95,720.38 L-41.94,715.40 C-81.11,707.28 -55.69,644.93 -46.88,640.19"/>
+                <path class="nad-edge-path" d="M-17.95,720.38 L-41.94,715.40 C-81.11,707.28 -55.69,644.93 -46.88,640.19"/>
                 <g class="nad-edge-infos" transform="translate(-41.94,715.40)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-78.28)">
@@ -740,10 +738,10 @@
                         <text transform="rotate(-348.28)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-29.27" cy="630.71" r="20.00"/>
+                <circle class="nad-winding" cx="-29.27" cy="630.71" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M45.83,707.96 L66.00,657.33 C80.80,620.17 14.76,607.02 5.96,611.76"/>
+                <path class="nad-edge-path" d="M45.83,707.96 L66.00,657.33 C80.80,620.17 14.76,607.02 5.96,611.76"/>
                 <g class="nad-edge-infos" transform="translate(66.00,657.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(21.72)">
@@ -760,13 +758,13 @@
                         <text transform="rotate(-68.28)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="-11.66" cy="621.24" r="20.00"/>
+                <circle class="nad-winding" cx="-11.66" cy="621.24" r="20.00"/>
             </g>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="104.91,-785.55 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="104.91,-785.55 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(81.76,-762.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
@@ -785,7 +783,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-131.48,-552.60 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="-131.48,-552.60 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(-108.33,-575.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -807,7 +805,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="131.64,-779.44 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="131.64,-779.44 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(142.57,-748.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -826,7 +824,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="243.42,-466.29 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="243.42,-466.29 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(232.49,-496.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
@@ -848,7 +846,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-124.79,-528.98 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="-124.79,-528.98 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(-93.12,-521.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -867,7 +865,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="227.14,-448.00 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="227.14,-448.00 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(195.47,-455.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">

--- a/src/test/resources/simple-eu-loop100.svg
+++ b/src/test/resources/simple-eu-loop100.svg
@@ -100,45 +100,45 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
-            <path class="nad-busnode" d="M-10.013,56.621 A57.500,57.500 22.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -11.300 0 0 -8.837,31.276 Z M-42.578,38.644 A57.500,57.500 27.309 0 1 -55.562,14.803 L-30.409,11.470 A32.500,32.500 -15.811 0 0 -26.133,19.322 Z M-57.500,-0.029 A57.500,57.500 265.053 1 1 4.930,57.288 L6.016,31.938 A32.500,32.500 -253.556 1 0 -32.335,-3.272 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M-10.013,56.621 A57.500,57.500 22.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -11.300 0 0 -8.837,31.276 Z M-42.578,38.644 A57.500,57.500 27.309 0 1 -55.562,14.803 L-30.409,11.470 A32.500,32.500 -15.811 0 0 -26.133,19.322 Z M-57.500,-0.029 A57.500,57.500 265.053 1 1 4.930,57.288 L6.016,31.938 A32.500,32.500 -253.556 1 0 -32.335,-3.272 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="4"/>
+            <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="6"/>
+            <circle r="27.50" id="6" class="nad-busnode"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="8"/>
+            <circle r="27.50" id="8" class="nad-busnode"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="10"/>
+            <circle r="27.50" id="10" class="nad-busnode"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="12"/>
-            <path class="nad-busnode" d="M-35.426,-45.291 A57.500,57.500 52.278 0 1 14.150,-55.732 L4.802,-32.143 A32.500,32.500 -40.780 0 0 -17.358,-27.476 Z M28.045,-50.197 A57.500,57.500 65.053 0 1 57.342,4.257 L32.489,-0.852 A32.500,32.500 -53.556 0 0 18.614,-26.641 Z M54.304,18.903 A57.500,57.500 197.829 1 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -186.331 1 0 29.469,13.705 Z " id="13"/>
+            <circle r="27.50" id="12" class="nad-busnode"/>
+            <path d="M-35.426,-45.291 A57.500,57.500 52.278 0 1 14.150,-55.732 L4.802,-32.143 A32.500,32.500 -40.780 0 0 -17.358,-27.476 Z M28.045,-50.197 A57.500,57.500 65.053 0 1 57.342,4.257 L32.489,-0.852 A32.500,32.500 -53.556 0 0 18.614,-26.641 Z M54.304,18.903 A57.500,57.500 197.829 1 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -186.331 1 0 29.469,13.705 Z " id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -100,45 +100,45 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
-            <path class="nad-busnode" d="M0.029,-57.500 A57.500,57.500 55.053 0 1 47.148,-32.913 L24.652,-21.179 A32.500,32.500 -43.556 0 0 3.272,-32.335 Z M54.042,-19.639 A57.500,57.500 142.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -131.300 0 0 31.504,-7.985 Z M-42.578,38.644 A57.500,57.500 117.309 0 1 -14.803,-55.562 L-11.470,-30.409 A32.500,32.500 -105.811 0 0 -26.133,19.322 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M0.029,-57.500 A57.500,57.500 55.053 0 1 47.148,-32.913 L24.652,-21.179 A32.500,32.500 -43.556 0 0 3.272,-32.335 Z M54.042,-19.639 A57.500,57.500 142.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -131.300 0 0 31.504,-7.985 Z M-42.578,38.644 A57.500,57.500 117.309 0 1 -14.803,-55.562 L-11.470,-30.409 A32.500,32.500 -105.811 0 0 -26.133,19.322 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="4"/>
+            <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="6"/>
+            <circle r="27.50" id="6" class="nad-busnode"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="8"/>
+            <circle r="27.50" id="8" class="nad-busnode"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="10"/>
+            <circle r="27.50" id="10" class="nad-busnode"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="12"/>
-            <path class="nad-busnode" d="M-35.426,-45.291 A57.500,57.500 94.686 0 1 48.034,-31.607 L25.223,-20.495 A32.500,32.500 -83.189 0 0 -17.358,-27.476 Z M54.561,-18.149 A57.500,57.500 160.237 0 1 -45.210,35.529 L-23.414,22.540 A32.500,32.500 -148.739 0 0 31.711,-7.118 Z M-52.844,22.666 A57.500,57.500 60.237 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -48.739 0 0 -31.001,9.755 Z " id="13"/>
+            <circle r="27.50" id="12" class="nad-busnode"/>
+            <path d="M-35.426,-45.291 A57.500,57.500 94.686 0 1 48.034,-31.607 L25.223,-20.495 A32.500,32.500 -83.189 0 0 -17.358,-27.476 Z M54.561,-18.149 A57.500,57.500 160.237 0 1 -45.210,35.529 L-23.414,22.540 A32.500,32.500 -148.739 0 0 31.711,-7.118 Z M-52.844,22.666 A57.500,57.500 60.237 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -48.739 0 0 -31.001,9.755 Z " id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/simple-eu-loop80.svg
+++ b/src/test/resources/simple-eu-loop80.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="886.58" viewBox="-754.05 -1018.45 1759.67 1950.10" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -102,52 +100,52 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle r="27.50" id="1"/>
-            <path d="M0.029,-57.500 A57.500,57.500 55.053 0 1 47.148,-32.913 L24.652,-21.179 A32.500,32.500 -43.556 0 0 3.272,-32.335 Z M54.042,-19.639 A57.500,57.500 142.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -131.300 0 0 31.504,-7.985 Z M-42.578,38.644 A57.500,57.500 117.309 0 1 -14.803,-55.562 L-11.470,-30.409 A32.500,32.500 -105.811 0 0 -26.133,19.322 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
+            <path class="nad-busnode" d="M0.029,-57.500 A57.500,57.500 55.053 0 1 47.148,-32.913 L24.652,-21.179 A32.500,32.500 -43.556 0 0 3.272,-32.335 Z M54.042,-19.639 A57.500,57.500 142.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -131.300 0 0 31.504,-7.985 Z M-42.578,38.644 A57.500,57.500 117.309 0 1 -14.803,-55.562 L-11.470,-30.409 A32.500,32.500 -105.811 0 0 -26.133,19.322 Z " id="2"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle r="27.50" id="4"/>
+            <circle class="nad-busnode" r="27.50" id="4"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle r="27.50" id="6"/>
+            <circle class="nad-busnode" r="27.50" id="6"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle r="27.50" id="8"/>
+            <circle class="nad-busnode" r="27.50" id="8"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle r="27.50" id="10"/>
+            <circle class="nad-busnode" r="27.50" id="10"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle r="27.50" id="12"/>
-            <path d="M-35.426,-45.291 A57.500,57.500 94.686 0 1 48.034,-31.607 L25.223,-20.495 A32.500,32.500 -83.189 0 0 -17.358,-27.476 Z M54.561,-18.149 A57.500,57.500 160.237 0 1 -45.210,35.529 L-23.414,22.540 A32.500,32.500 -148.739 0 0 31.711,-7.118 Z M-52.844,22.666 A57.500,57.500 60.237 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -48.739 0 0 -31.001,9.755 Z " id="13"/>
+            <circle class="nad-busnode" r="27.50" id="12"/>
+            <path class="nad-busnode" d="M-35.426,-45.291 A57.500,57.500 94.686 0 1 48.034,-31.607 L25.223,-20.495 A32.500,32.500 -83.189 0 0 -17.358,-27.476 Z M54.561,-18.149 A57.500,57.500 160.237 0 1 -45.210,35.529 L-23.414,22.540 A32.500,32.500 -148.739 0 0 31.711,-7.118 Z M-52.844,22.666 A57.500,57.500 60.237 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -48.739 0 0 -31.001,9.755 Z " id="13"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -166,7 +164,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -188,7 +186,7 @@
         <g id="23">
             <desc>BBE1AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M-451.61,-219.71 L-403.24,-244.83 C-367.74,-263.26 -348.41,-220.91 -357.11,-181.87"/>
+                <path class="nad-edge-path" d="M-451.61,-219.71 L-403.24,-244.83 C-367.74,-263.26 -348.41,-220.91 -357.11,-181.87"/>
                 <g class="nad-edge-infos" transform="translate(-403.24,-244.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(62.56)">
@@ -207,7 +205,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-440.49,-163.89 L-425.60,-144.44 C-401.28,-112.68 -365.80,-142.82 -357.11,-181.87"/>
+                <path class="nad-edge-path" d="M-440.49,-163.89 L-425.60,-144.44 C-401.28,-112.68 -365.80,-142.82 -357.11,-181.87"/>
                 <g class="nad-edge-infos" transform="translate(-425.60,-144.44)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(142.56)">
@@ -229,7 +227,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -248,7 +246,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-169.70)">
@@ -270,7 +268,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-167.61,-516.61 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-167.61,-516.61 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-190.52,-493.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-135.19)">
@@ -289,7 +287,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-435.12,-247.33 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-435.12,-247.33 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-412.22,-270.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -311,7 +309,7 @@
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-529.68,-210.43 L-554.16,-211.52 C-594.12,-213.30 -589.68,-259.64 -582.92,-267.01"/>
+                <path class="nad-edge-path" d="M-529.68,-210.43 L-554.16,-211.52 C-594.12,-213.30 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-554.16,-211.52)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-87.44)">
@@ -328,10 +326,10 @@
                         <text transform="rotate(-357.44)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-569.39" cy="-281.74" r="20.00"/>
+                <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-477.54,-233.24 L-484.60,-287.28 C-489.79,-326.94 -535.58,-318.58 -542.34,-311.21"/>
+                <path class="nad-edge-path" d="M-477.54,-233.24 L-484.60,-287.28 C-489.79,-326.94 -535.58,-318.58 -542.34,-311.21"/>
                 <g class="nad-edge-infos" transform="translate(-484.60,-287.28)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-7.44)">
@@ -348,13 +346,13 @@
                         <text transform="rotate(-277.44)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-555.87" cy="-296.48" r="20.00"/>
+                <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-543.38,254.41 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-543.38,254.41 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-529.78,283.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -373,7 +371,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-382.79,602.89 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-382.79,602.89 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-396.39,573.37)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.74)">
@@ -395,7 +393,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="688.22,255.53 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="688.22,255.53 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(666.04,231.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-43.04)">
@@ -414,7 +412,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="467.55,19.25 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="467.55,19.25 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(489.74,43.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -436,7 +434,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="682.74,285.42 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="682.74,285.42 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(653.58,299.76)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-116.19)">
@@ -455,7 +453,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="397.79,425.55 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="397.79,425.55 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(426.95,411.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -477,7 +475,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="445.81,25.75 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="445.81,25.75 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(440.29,57.77)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-170.21)">
@@ -496,7 +494,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="379.24,411.67 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="379.24,411.67 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(384.77,379.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -518,7 +516,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="439.74,-22.66 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="439.74,-22.66 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(426.46,-52.33)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-24.10)">
@@ -537,7 +535,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="262.40,-419.00 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="262.40,-419.00 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(275.68,-389.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -559,7 +557,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="78.24,695.20 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="78.24,695.20 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(102.75,673.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -578,7 +576,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="355.68,453.55 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="355.68,453.55 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(331.17,474.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-131.06)">
@@ -600,7 +598,7 @@
         <g id="33">
             <desc>FFR1AA1  FFR2AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M59.34,720.52 L108.37,696.74 C144.36,679.29 162.53,722.15 152.76,760.94"/>
+                <path class="nad-edge-path" d="M59.34,720.52 L108.37,696.74 C144.36,679.29 162.53,722.15 152.76,760.94"/>
                 <g class="nad-edge-infos" transform="translate(108.37,696.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(64.13)">
@@ -619,7 +617,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M68.91,776.62 L83.27,796.48 C106.71,828.89 143.00,799.73 152.76,760.94"/>
+                <path class="nad-edge-path" d="M68.91,776.62 L83.27,796.48 C106.71,828.89 143.00,799.73 152.76,760.94"/>
                 <g class="nad-edge-infos" transform="translate(83.27,796.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(144.13)">
@@ -641,7 +639,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -660,7 +658,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -682,7 +680,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-75.51)">
@@ -701,7 +699,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -723,7 +721,7 @@
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M56.00,783.57 L64.65,806.49 C78.79,843.91 34.46,858.13 25.02,854.82"/>
+                <path class="nad-edge-path" d="M56.00,783.57 L64.65,806.49 C78.79,843.91 34.46,858.13 25.02,854.82"/>
                 <g class="nad-edge-infos" transform="translate(64.65,806.49)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(159.31)">
@@ -740,10 +738,10 @@
                         <text transform="rotate(69.31)" x="19.00">0</text>
                     </g>
                 </g>
-                <circle cx="6.14" cy="848.21" r="20.00"/>
+                <circle class="nad-winding" cx="6.14" cy="848.21" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M14.46,744.67 L-32.40,772.48 C-66.80,792.90 -41.04,831.67 -31.60,834.98"/>
+                <path class="nad-edge-path" d="M14.46,744.67 L-32.40,772.48 C-66.80,792.90 -41.04,831.67 -31.60,834.98"/>
                 <g class="nad-edge-infos" transform="translate(-32.40,772.48)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-120.69)">
@@ -760,13 +758,13 @@
                         <text transform="rotate(-30.69)" x="-19.00" style="text-anchor:end">0</text>
                     </g>
                 </g>
-                <circle cx="-12.73" cy="841.59" r="20.00"/>
+                <circle class="nad-winding" cx="-12.73" cy="841.59" r="20.00"/>
             </g>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="104.91,-785.55 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="104.91,-785.55 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(81.76,-762.74)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-134.58)">
@@ -785,7 +783,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-131.48,-552.60 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="-131.48,-552.60 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(-108.33,-575.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -807,7 +805,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="131.64,-779.44 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="131.64,-779.44 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(142.57,-748.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -826,7 +824,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="243.42,-466.29 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="243.42,-466.29 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(232.49,-496.90)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-19.64)">
@@ -848,7 +846,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-124.79,-528.98 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="-124.79,-528.98 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(-93.12,-521.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -867,7 +865,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="227.14,-448.00 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="227.14,-448.00 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(195.47,-455.29)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-77.04)">

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="886.58" viewBox="-754.05 -1018.45 1759.67 1950.10" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -102,52 +100,52 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle r="27.50" id="1"/>
-            <path d="M-9.957,-56.631 A57.500,57.500 75.053 0 1 52.147,-24.226 L27.955,-16.577 A32.500,32.500 -63.556 0 0 -2.393,-32.412 Z M56.631,-9.957 A57.500,57.500 132.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -121.300 0 0 32.412,-2.393 Z M-42.578,38.644 A57.500,57.500 107.309 0 1 -24.226,-52.147 L-16.577,-27.955 A32.500,32.500 -95.811 0 0 -26.133,19.322 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
+            <path class="nad-busnode" d="M-9.957,-56.631 A57.500,57.500 75.053 0 1 52.147,-24.226 L27.955,-16.577 A32.500,32.500 -63.556 0 0 -2.393,-32.412 Z M56.631,-9.957 A57.500,57.500 132.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -121.300 0 0 32.412,-2.393 Z M-42.578,38.644 A57.500,57.500 107.309 0 1 -24.226,-52.147 L-16.577,-27.955 A32.500,32.500 -95.811 0 0 -26.133,19.322 Z " id="2"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle r="27.50" id="4"/>
+            <circle class="nad-busnode" r="27.50" id="4"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle r="27.50" id="6"/>
+            <circle class="nad-busnode" r="27.50" id="6"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle r="27.50" id="8"/>
+            <circle class="nad-busnode" r="27.50" id="8"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle r="27.50" id="10"/>
+            <circle class="nad-busnode" r="27.50" id="10"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle r="27.50" id="12"/>
-            <path d="M-20.426,-53.750 A57.500,57.500 195.053 1 1 5.765,57.210 L6.481,31.847 A32.500,32.500 -183.556 1 0 -8.444,-31.384 Z M-9.186,56.762 A57.500,57.500 117.829 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -106.331 0 0 -8.380,31.401 Z " id="13"/>
+            <circle class="nad-busnode" r="27.50" id="12"/>
+            <path class="nad-busnode" d="M-20.426,-53.750 A57.500,57.500 195.053 1 1 5.765,57.210 L6.481,31.847 A32.500,32.500 -183.556 1 0 -8.444,-31.384 Z M-9.186,56.762 A57.500,57.500 117.829 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -106.331 0 0 -8.380,31.401 Z " id="13"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle r="27.50" id="15"/>
+            <circle class="nad-busnode" r="27.50" id="15"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle r="27.50" id="17"/>
+            <circle class="nad-busnode" r="27.50" id="17"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle r="27.50" id="19"/>
+            <circle class="nad-busnode" r="27.50" id="19"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle r="27.50" id="21"/>
+            <circle class="nad-busnode" r="27.50" id="21"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="22">
             <desc>BBE1AA1  BBE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-490.73,-188.51 -525.98,-146.94 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-531.34,-117.42)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
@@ -166,7 +164,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
+                <polyline class="nad-edge-path" points="-562.65,207.24 -581.02,155.93 -553.50,4.50"/>
                 <g class="nad-edge-infos" transform="translate(-575.65,126.42)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -188,7 +186,7 @@
         <g id="23">
             <desc>BBE1AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M-449.91,-215.60 L-397.92,-231.94 C-359.76,-243.93 -348.41,-220.91 -357.11,-181.87"/>
+                <path class="nad-edge-path" d="M-449.91,-215.60 L-397.92,-231.94 C-359.76,-243.93 -348.41,-220.91 -357.11,-181.87"/>
                 <g class="nad-edge-infos" transform="translate(-397.92,-231.94)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(72.56)">
@@ -207,7 +205,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-433.35,-170.42 L-415.31,-153.85 C-385.84,-126.80 -365.80,-142.82 -357.11,-181.87"/>
+                <path class="nad-edge-path" d="M-433.35,-170.42 L-415.31,-153.85 C-385.84,-126.80 -365.80,-142.82 -357.11,-181.87"/>
                 <g class="nad-edge-infos" transform="translate(-415.31,-153.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(132.56)">
@@ -229,7 +227,7 @@
         <g id="24">
             <desc>BBE2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-537.56,211.80 -502.31,170.24 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-496.94,140.72)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(10.30)">
@@ -248,7 +246,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
+                <polyline class="nad-edge-path" points="-455.53,-155.70 -447.27,-132.64 -474.79,18.80"/>
                 <g class="nad-edge-infos" transform="translate(-452.63,-103.12)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-169.70)">
@@ -270,7 +268,7 @@
         <g id="25">
             <desc>NNL2AA1  BBE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-167.61,-516.61 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-167.61,-516.61 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-190.52,-493.55)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-135.19)">
@@ -289,7 +287,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-435.12,-247.33 -301.37,-381.97"/>
+                <polyline class="nad-edge-path" points="-435.12,-247.33 -301.37,-381.97"/>
                 <g class="nad-edge-infos" transform="translate(-412.22,-270.38)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(44.81)">
@@ -311,7 +309,7 @@
         <g id="26">
             <desc>BBE1AA1  BBE3AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M-528.41,-220.02 L-552.32,-225.34 C-591.37,-234.04 -589.68,-259.64 -582.92,-267.01"/>
+                <path class="nad-edge-path" d="M-528.41,-220.02 L-552.32,-225.34 C-591.37,-234.04 -589.68,-259.64 -582.92,-267.01"/>
                 <g class="nad-edge-infos" transform="translate(-552.32,-225.34)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.44)">
@@ -328,10 +326,10 @@
                         <text transform="rotate(-347.44)" x="-19.00" style="text-anchor:end">8</text>
                     </g>
                 </g>
-                <circle cx="-569.39" cy="-281.74" r="20.00"/>
+                <circle class="nad-winding" cx="-569.39" cy="-281.74" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M-481.88,-232.28 L-498.22,-284.27 C-510.21,-322.43 -535.58,-318.58 -542.34,-311.21"/>
+                <path class="nad-edge-path" d="M-481.88,-232.28 L-498.22,-284.27 C-510.21,-322.43 -535.58,-318.58 -542.34,-311.21"/>
                 <g class="nad-edge-infos" transform="translate(-498.22,-284.27)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-17.44)">
@@ -348,13 +346,13 @@
                         <text transform="rotate(-287.44)" x="-19.00" style="text-anchor:end">4</text>
                     </g>
                 </g>
-                <circle cx="-555.87" cy="-296.48" r="20.00"/>
+                <circle class="nad-winding" cx="-555.87" cy="-296.48" r="20.00"/>
             </g>
         </g>
         <g id="27">
             <desc>BBE2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-543.38,254.41 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-543.38,254.41 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-529.78,283.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.26)">
@@ -373,7 +371,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-382.79,602.89 -463.08,428.65"/>
+                <polyline class="nad-edge-path" points="-382.79,602.89 -463.08,428.65"/>
                 <g class="nad-edge-infos" transform="translate(-396.39,573.37)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.74)">
@@ -395,7 +393,7 @@
         <g id="28">
             <desc>DDE1AA1  DDE2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="688.22,255.53 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="688.22,255.53 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(666.04,231.77)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-43.04)">
@@ -414,7 +412,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="467.55,19.25 577.89,137.39"/>
+                <polyline class="nad-edge-path" points="467.55,19.25 577.89,137.39"/>
                 <g class="nad-edge-infos" transform="translate(489.74,43.00)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(136.96)">
@@ -436,7 +434,7 @@
         <g id="29">
             <desc>DDE1AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="682.74,285.42 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="682.74,285.42 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(653.58,299.76)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-116.19)">
@@ -455,7 +453,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="397.79,425.55 540.26,355.48"/>
+                <polyline class="nad-edge-path" points="397.79,425.55 540.26,355.48"/>
                 <g class="nad-edge-infos" transform="translate(426.95,411.21)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(63.81)">
@@ -477,7 +475,7 @@
         <g id="30">
             <desc>DDE2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="445.81,25.75 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="445.81,25.75 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(440.29,57.77)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-170.21)">
@@ -496,7 +494,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="379.24,411.67 412.53,218.71"/>
+                <polyline class="nad-edge-path" points="379.24,411.67 412.53,218.71"/>
                 <g class="nad-edge-infos" transform="translate(384.77,379.65)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(9.79)">
@@ -518,7 +516,7 @@
         <g id="31">
             <desc>DDE2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="439.74,-22.66 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="439.74,-22.66 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(426.46,-52.33)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-24.10)">
@@ -537,7 +535,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="262.40,-419.00 351.07,-220.83"/>
+                <polyline class="nad-edge-path" points="262.40,-419.00 351.07,-220.83"/>
                 <g class="nad-edge-infos" transform="translate(275.68,-389.34)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(155.90)">
@@ -559,7 +557,7 @@
         <g id="32">
             <desc>FFR2AA1  DDE3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="78.24,695.20 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="78.24,695.20 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(102.75,673.85)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(48.94)">
@@ -578,7 +576,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="355.68,453.55 216.96,574.38"/>
+                <polyline class="nad-edge-path" points="355.68,453.55 216.96,574.38"/>
                 <g class="nad-edge-infos" transform="translate(331.17,474.90)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-131.06)">
@@ -600,7 +598,7 @@
         <g id="33">
             <desc>FFR1AA1  FFR2AA1  1</desc>
             <g class="nad-vl300to500">
-                <path d="M24.31,709.20 L-1.51,661.20 C-20.46,625.98 0.01,610.51 39.99,611.71"/>
+                <path class="nad-edge-path" d="M24.31,709.20 L-1.51,661.20 C-20.46,625.98 0.01,610.51 39.99,611.71"/>
                 <g class="nad-edge-infos" transform="translate(-1.51,661.20)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-28.28)">
@@ -619,7 +617,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <path d="M65.57,684.44 L78.45,663.60 C99.48,629.58 79.97,612.91 39.99,611.71"/>
+                <path class="nad-edge-path" d="M65.57,684.44 L78.45,663.60 C99.48,629.58 79.97,612.91 39.99,611.71"/>
                 <g class="nad-edge-infos" transform="translate(78.45,663.60)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(31.72)">
@@ -641,7 +639,7 @@
         <g id="34">
             <desc>FFR1AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="18.20,713.78 -20.67,675.58 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-49.72,668.08)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
@@ -660,7 +658,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
+                <polyline class="nad-edge-path" points="-347.54,619.23 -295.03,604.66 -157.85,640.12"/>
                 <g class="nad-edge-infos" transform="translate(-265.98,612.17)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -682,7 +680,7 @@
         <g id="35">
             <desc>FFR2AA1  FFR3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-17.09,746.49 -40.70,753.04 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-69.74,745.53)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-75.51)">
@@ -701,7 +699,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
+                <polyline class="nad-edge-path" points="-353.93,643.92 -315.05,682.11 -177.87,717.58"/>
                 <g class="nad-edge-infos" transform="translate(-286.01,689.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(104.49)">
@@ -723,7 +721,7 @@
         <g id="36">
             <desc>FFR1AA1  FFR2AA1  2</desc>
             <g class="nad-vl300to500">
-                <path d="M83.60,760.83 L104.44,773.71 C138.47,794.74 128.47,818.38 119.67,823.11"/>
+                <path class="nad-edge-path" d="M83.60,760.83 L104.44,773.71 C138.47,794.74 128.47,818.38 119.67,823.11"/>
                 <g class="nad-edge-infos" transform="translate(104.44,773.71)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(121.72)">
@@ -740,10 +738,10 @@
                         <text transform="rotate(31.72)" x="19.00">4</text>
                     </g>
                 </g>
-                <circle cx="102.05" cy="832.59" r="20.00"/>
+                <circle class="nad-winding" cx="102.05" cy="832.59" r="20.00"/>
             </g>
             <g class="nad-vl300to500">
-                <path d="M35.63,757.14 L33.99,811.62 C32.79,851.60 58.02,856.28 66.83,851.54"/>
+                <path class="nad-edge-path" d="M35.63,757.14 L33.99,811.62 C32.79,851.60 58.02,856.28 66.83,851.54"/>
                 <g class="nad-edge-infos" transform="translate(33.99,811.62)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-178.28)">
@@ -760,13 +758,13 @@
                         <text transform="rotate(-88.28)" x="-19.00" style="text-anchor:end">9</text>
                     </g>
                 </g>
-                <circle cx="84.44" cy="842.07" r="20.00"/>
+                <circle class="nad-winding" cx="84.44" cy="842.07" r="20.00"/>
             </g>
         </g>
         <g id="37">
             <desc>NNL1AA1  NNL2AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="104.91,-785.55 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="104.91,-785.55 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(81.76,-762.74)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-134.58)">
@@ -785,7 +783,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-131.48,-552.60 -13.29,-669.08"/>
+                <polyline class="nad-edge-path" points="-131.48,-552.60 -13.29,-669.08"/>
                 <g class="nad-edge-infos" transform="translate(-108.33,-575.41)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(45.42)">
@@ -807,7 +805,7 @@
         <g id="38">
             <desc>NNL1AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="131.64,-779.44 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="131.64,-779.44 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(142.57,-748.83)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(160.36)">
@@ -826,7 +824,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="243.42,-466.29 187.53,-622.87"/>
+                <polyline class="nad-edge-path" points="243.42,-466.29 187.53,-622.87"/>
                 <g class="nad-edge-infos" transform="translate(232.49,-496.90)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-19.64)">
@@ -848,7 +846,7 @@
         <g id="39">
             <desc>NNL2AA1  NNL3AA1  1</desc>
             <g class="nad-vl300to500">
-                <polyline points="-124.79,-528.98 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="-124.79,-528.98 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(-93.12,-521.69)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(102.96)">
@@ -867,7 +865,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="227.14,-448.00 51.17,-488.49"/>
+                <polyline class="nad-edge-path" points="227.14,-448.00 51.17,-488.49"/>
                 <g class="nad-edge-infos" transform="translate(195.47,-455.29)">
                     <g class="nad-active nad-state-in">
                         <g transform="rotate(-77.04)">

--- a/src/test/resources/simple-eu.svg
+++ b/src/test/resources/simple-eu.svg
@@ -100,45 +100,45 @@
     <g class="nad-vl-nodes">
         <g transform="translate(-474.24,-207.95)" id="0" class="nad-vl300to500">
             <desc>BBE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="1"/>
-            <path class="nad-busnode" d="M-9.957,-56.631 A57.500,57.500 75.053 0 1 52.147,-24.226 L27.955,-16.577 A32.500,32.500 -63.556 0 0 -2.393,-32.412 Z M56.631,-9.957 A57.500,57.500 132.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -121.300 0 0 32.412,-2.393 Z M-42.578,38.644 A57.500,57.500 107.309 0 1 -24.226,-52.147 L-16.577,-27.955 A32.500,32.500 -95.811 0 0 -26.133,19.322 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
+            <path d="M-9.957,-56.631 A57.500,57.500 75.053 0 1 52.147,-24.226 L27.955,-16.577 A32.500,32.500 -63.556 0 0 -2.393,-32.412 Z M56.631,-9.957 A57.500,57.500 132.798 0 1 -31.170,48.318 L-14.794,28.938 A32.500,32.500 -121.300 0 0 32.412,-2.393 Z M-42.578,38.644 A57.500,57.500 107.309 0 1 -24.226,-52.147 L-16.577,-27.955 A32.500,32.500 -95.811 0 0 -26.133,19.322 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-554.05,231.25)" id="3" class="nad-vl300to500">
             <desc>BBE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="4"/>
+            <circle r="27.50" id="4" class="nad-busnode"/>
         </g>
         <g transform="translate(705.62,274.16)" id="5" class="nad-vl300to500">
             <desc>DDE1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="6"/>
+            <circle r="27.50" id="6" class="nad-busnode"/>
         </g>
         <g transform="translate(450.15,0.62)" id="7" class="nad-vl300to500">
             <desc>DDE2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="8"/>
+            <circle r="27.50" id="8" class="nad-busnode"/>
         </g>
         <g transform="translate(374.91,436.80)" id="9" class="nad-vl300to500">
             <desc>DDE3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="10"/>
+            <circle r="27.50" id="10" class="nad-busnode"/>
         </g>
         <g transform="translate(36.39,731.65)" id="11" class="nad-vl300to500">
             <desc>FFR1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="12"/>
-            <path class="nad-busnode" d="M-20.426,-53.750 A57.500,57.500 195.053 1 1 5.765,57.210 L6.481,31.847 A32.500,32.500 -183.556 1 0 -8.444,-31.384 Z M-9.186,56.762 A57.500,57.500 117.829 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -106.331 0 0 -8.380,31.401 Z " id="13"/>
+            <circle r="27.50" id="12" class="nad-busnode"/>
+            <path d="M-20.426,-53.750 A57.500,57.500 195.053 1 1 5.765,57.210 L6.481,31.847 A32.500,32.500 -183.556 1 0 -8.444,-31.384 Z M-9.186,56.762 A57.500,57.500 117.829 0 1 -45.909,-34.621 L-27.778,-16.871 A32.500,32.500 -106.331 0 0 -8.380,31.401 Z " id="13" class="nad-busnode"/>
         </g>
         <g transform="translate(-372.12,626.05)" id="14" class="nad-vl300to500">
             <desc>FFR3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="15"/>
+            <circle r="27.50" id="15" class="nad-busnode"/>
         </g>
         <g transform="translate(123.07,-803.45)" id="16" class="nad-vl300to500">
             <desc>NNL1AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="17"/>
+            <circle r="27.50" id="17" class="nad-busnode"/>
         </g>
         <g transform="translate(-149.64,-534.70)" id="18" class="nad-vl300to500">
             <desc>NNL2AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="19"/>
+            <circle r="27.50" id="19" class="nad-busnode"/>
         </g>
         <g transform="translate(251.99,-442.28)" id="20" class="nad-vl300to500">
             <desc>NNL3AA1</desc>
-            <circle class="nad-busnode" r="27.50" id="21"/>
+            <circle r="27.50" id="21" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/vl_description_id.svg
+++ b/src/test/resources/vl_description_id.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(119.59,-46.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -94,7 +92,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-44.74,125.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/vl_description_id.svg
+++ b/src/test/resources/vl_description_id.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/vl_description_substation.svg
+++ b/src/test/resources/vl_description_substation.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(119.59,-46.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -94,7 +92,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-44.74,125.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/vl_description_substation.svg
+++ b/src/test/resources/vl_description_substation.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/vl_description_substation_id.svg
+++ b/src/test/resources/vl_description_substation_id.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -66,16 +64,16 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1"/>
+            <circle class="nad-busnode" r="27.50" id="1"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle r="27.50" id="3"/>
+            <circle class="nad-busnode" r="27.50" id="3"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="4">
             <g class="nad-vl300to500">
-                <polyline points="142.00,-70.46 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="142.00,-70.46 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(119.59,-46.93)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -94,7 +92,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-67.15,149.16 37.43,39.35"/>
+                <polyline class="nad-edge-path" points="-67.15,149.16 37.43,39.35"/>
                 <g class="nad-edge-infos" transform="translate(-44.74,125.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">

--- a/src/test/resources/vl_description_substation_id.svg
+++ b/src/test/resources/vl_description_substation_id.svg
@@ -64,10 +64,10 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1"/>
+            <circle r="27.50" id="1" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="2" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="3"/>
+            <circle r="27.50" id="3" class="nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/voltage_limits.svg
+++ b/src/test/resources/voltage_limits.svg
@@ -66,11 +66,11 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="1" class="nad-overvoltage"/>
-            <path class="nad-busnode" d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
+            <circle r="27.50" id="1" class="nad-overvoltage nad-busnode"/>
+            <path d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2" class="nad-busnode"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="3" class="nad-vl300to500">
-            <circle class="nad-busnode" r="27.50" id="4" class="nad-undervoltage"/>
+            <circle r="27.50" id="4" class="nad-undervoltage nad-busnode"/>
         </g>
     </g>
     <g class="nad-branch-edges">

--- a/src/test/resources/voltage_limits.svg
+++ b/src/test/resources/voltage_limits.svg
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="800.00" height="721.78" viewBox="-284.74 -303.93 744.32 671.55" xmlns="http://www.w3.org/2000/svg">
     <style><![CDATA[
-.nad-branch-edges polyline, .nad-branch-edges path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-branch-edges circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
-.nad-3wt-edges polyline {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-edge-path, .nad-3wt-edges .nad-edge-path {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
+.nad-branch-edges .nad-winding, .nad-3wt-nodes .nad-winding {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-text-edges {stroke: black; stroke-width: 2; stroke-dasharray: 3,5}
-.nad-branch-edges .nad-disconnected polyline, .nad-3wt-edges .nad-disconnected polyline {stroke-dasharray: 10,10}
-.nad-vl-nodes circle, .nad-vl-nodes path {fill: var(--nad-vl-color, lightblue)}
+.nad-disconnected .nad-edge-path {stroke-dasharray: 10,10}
+.nad-vl-nodes .nad-busnode {fill: var(--nad-vl-color, lightblue)}
 .nad-vl-nodes circle.nad-unknown-busnode {stroke: lightgrey; stroke-width: 5; stroke-dasharray: 5,5; fill: none}
 .nad-hvdc-edge polyline.nad-hvdc {stroke: grey; stroke-width: 20}
-.nad-3wt-nodes circle {stroke: var(--nad-vl-color, lightgrey); stroke-width: 5; fill: none}
 .nad-state-out .nad-arrow-in {visibility: hidden}
 .nad-state-in .nad-arrow-out {visibility: hidden}
 .nad-active path {stroke: none; fill: #546e7a}
@@ -28,7 +26,7 @@
 .nad-vl120to180 {--nad-vl-color: #00ACC1}
 .nad-vl180to300 {--nad-vl-color: #2E7D32}
 .nad-vl300to500 {--nad-vl-color: #D32F2F}
-.nad-branch-edges .nad-overload polyline, .nad-branch-edges .nad-overload path {animation: line-blink 3s infinite}
+.nad-branch-edges .nad-overload .nad-edge-path {animation: line-blink 3s infinite}
 .nad-vl-nodes .nad-overvoltage {animation: node-over-blink 3s infinite}
 .nad-vl-nodes .nad-undervoltage {animation: node-under-blink 3s infinite}
 
@@ -68,17 +66,17 @@
     </defs>
     <g class="nad-vl-nodes">
         <g transform="translate(159.59,-88.93)" id="0" class="nad-vl300to500">
-            <circle r="27.50" id="1" class="nad-overvoltage"/>
-            <path d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
+            <circle class="nad-busnode" r="27.50" id="1" class="nad-overvoltage"/>
+            <path class="nad-busnode" d="M-56.804,8.921 A57.500,57.500 345.053 1 1 -52.581,23.270 L-28.253,16.063 A32.500,32.500 -333.556 1 0 -32.450,1.801 Z " id="2"/>
         </g>
         <g transform="translate(-84.74,167.62)" id="3" class="nad-vl300to500">
-            <circle r="27.50" id="4" class="nad-undervoltage"/>
+            <circle class="nad-busnode" r="27.50" id="4" class="nad-undervoltage"/>
         </g>
     </g>
     <g class="nad-branch-edges">
         <g id="5">
             <g class="nad-vl300to500">
-                <polyline points="135.12,-81.73 82.84,-66.34 8.46,11.76"/>
+                <polyline class="nad-edge-path" points="135.12,-81.73 82.84,-66.34 8.46,11.76"/>
                 <g class="nad-edge-infos" transform="translate(62.15,-44.62)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -97,7 +95,7 @@
                 </g>
             </g>
             <g class="nad-vl300to500">
-                <polyline points="-78.74,142.84 -65.92,89.87 8.46,11.76"/>
+                <polyline class="nad-edge-path" points="-78.74,142.84 -65.92,89.87 8.46,11.76"/>
                 <g class="nad-edge-infos" transform="translate(-45.23,68.14)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">
@@ -118,7 +116,7 @@
         </g>
         <g id="6">
             <g class="nad-vl300to500">
-                <polyline points="146.53,-34.99 140.77,-11.17 66.39,66.93"/>
+                <polyline class="nad-edge-path" points="146.53,-34.99 140.77,-11.17 66.39,66.93"/>
                 <g class="nad-edge-infos" transform="translate(120.08,10.55)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(-136.40)">
@@ -137,7 +135,7 @@
                 </g>
             </g>
             <g class="nad-disconnected nad-vl300to500">
-                <polyline points="-60.27,160.42 -7.99,145.04 66.39,66.93"/>
+                <polyline class="nad-edge-path" points="-60.27,160.42 -7.99,145.04 66.39,66.93"/>
                 <g class="nad-edge-infos" transform="translate(12.70,123.31)">
                     <g class="nad-active nad-state-out">
                         <g transform="rotate(43.60)">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?** 
Bug fix



**What is the current behavior?**
Some classes are missing in the SVG to discriminate properly the elements, leading to clumsy CSS selector and some display bugs: arrows inherit the style of the edge path.


**What is the new behavior (if this is a feature change)?**
Adding `nad-busnode`, `nad-edge-path` and `nad-winding` classes to properly discriminate those.


**Does this PR introduce a breaking change or deprecate an API?** 
No
